### PR TITLE
Lopatin Ilya. Lab 1: Clang AST. Option 1.

### DIFF
--- a/clang/compiler-course/lopatin_i_user_data_type/CMakeLists.txt
+++ b/clang/compiler-course/lopatin_i_user_data_type/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "UserDataTypePlugin")
+set(Student "LopatinIlya")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/lopatin_i_user_data_type/lopatin_i_user_data_type_plugin.cpp
+++ b/clang/compiler-course/lopatin_i_user_data_type/lopatin_i_user_data_type_plugin.cpp
@@ -1,10 +1,13 @@
+#include <string>
+#include <sstream>
+
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
 #include "llvm/Support/raw_ostream.h"
 
-namespace lopatin_i_user_data_type {
+namespace {
 
 std::string getAccessSpelling(clang::AccessSpecifier access) {
   switch (access) {
@@ -16,66 +19,66 @@ std::string getAccessSpelling(clang::AccessSpecifier access) {
 }
 
 class UserDataTypeVisitor final : public clang::RecursiveASTVisitor<UserDataTypeVisitor> {
-  llvm::raw_ostream &m_os;
 public:
-  explicit UserDataTypeVisitor(clang::ASTContext *context, llvm::raw_ostream &os) : m_os(os) {}
+  explicit UserDataTypeVisitor(clang::ASTContext *context) {}
   bool VisitCXXRecordDecl(clang::CXXRecordDecl *D) {
     if (!D->isThisDeclarationADefinition() || D->isImplicit())
       return true;
 
-    // classes
-    m_os << D->getName();
+    auto& os = llvm::outs();
+    os << D->getName();
+	
+	// classes
     if (D->getNumBases()) {
-      m_os << " -> ";
+      os << " -> ";
       bool first = true;
       for (const clang::CXXBaseSpecifier &B : D->bases()) {
-        if (!first) m_os << ", ";
+        if (!first) os << ", ";
         first = false;
-        m_os << B.getType()->getAsCXXRecordDecl()->getName();
+        os << B.getType()->getAsCXXRecordDecl()->getName();
       }
     }
-    m_os << "\n";
+    os << "\n";
 
     // fields
-    m_os << "|_Fields\n";
+    os << "|_Fields\n";
+    bool hasFields = false;
     for (clang::FieldDecl *F : D->fields()) {
-      m_os << "| |_ " << F->getName() << " ("
-           << F->getType().getAsString() << "|"
-           << lopatin_i_user_data_type::getAccessSpelling(F->getAccess()) << ")\n";
+      hasFields = true;
+      os << "| |_ " << F->getName() << " ("
+         << F->getType().getAsString() << "|"
+         << ::getAccessSpelling(F->getAccess()) << ")\n";
     }
+    if (!hasFields) os << "| |_ (no fields)\n";
 
     // methods
-    m_os << "|_Methods\n";
-    for (clang::CXXMethodDecl *M : D->methods()) {
-      if (M->isImplicit()) continue;
+    if (D->method_begin() != D->method_end()) {
+      os << "|_Methods\n";
+      for (clang::CXXMethodDecl *M : D->methods()) {
+        if (M->isImplicit()) continue;
 
-      // method type
-      std::string TypeStr;
-      clang::QualType ReturnType = M->getReturnType();
-      TypeStr += ReturnType.getAsString() + "(";
+        std::stringstream TypeStr;
+        TypeStr << M->getReturnType().getAsString() << "(";
+        for (unsigned i = 0; i < M->getNumParams(); ++i) {
+          if (i > 0) TypeStr << ", ";
+          TypeStr << M->getParamDecl(i)->getType().getAsString();
+        }
+        TypeStr << ")";
 
-      for (unsigned i = 0; i < M->getNumParams(); ++i) {
-        if (i > 0) TypeStr += ", ";
-        TypeStr += M->getParamDecl(i)->getType().getAsString();
+		// specs
+        llvm::SmallVector<std::string, 4> Specs;
+        if (M->isVirtual() && !M->hasAttr<clang::OverrideAttr>())
+          Specs.push_back("virtual");
+        if (M->isPureVirtual()) Specs.push_back("pure");
+        if (M->hasAttr<clang::OverrideAttr>()) Specs.push_back("override");
+        if (M->isConst()) Specs.push_back("const");
+
+        os << "| |_ " << M->getNameAsString() << " (" << TypeStr.str() << "|"
+           << ::getAccessSpelling(M->getAccess());
+        for (const auto &S : Specs)
+          os << "|" << S;
+        os << ")\n";
       }
-      TypeStr += ")";
-
-      // specifiers
-      std::vector<std::string> Specs;
-      if (M->isVirtual() && !M->hasAttr<clang::OverrideAttr>()) {
-        Specs.push_back("virtual");
-      }
-      if (M->isPureVirtual()) Specs.push_back("pure");
-      if (M->hasAttr<clang::OverrideAttr>()) Specs.push_back("override");
-      if (M->isConst()) Specs.push_back("const");
-
-      m_os << "| |_ " << M->getNameAsString() << " (" << TypeStr << "|"
-           << lopatin_i_user_data_type::getAccessSpelling(M->getAccess());
-
-      for (const auto &S : Specs) {
-        m_os << "|" << S;
-      }
-      m_os << ")\n";
     }
     return true;
   }
@@ -83,7 +86,7 @@ public:
 
 class UserDataTypeConsumer final : public clang::ASTConsumer {
 public:
-  explicit UserDataTypeConsumer(clang::ASTContext *context) : m_visitor(context, llvm::outs()) {}
+  explicit UserDataTypeConsumer(clang::ASTContext *context) : m_visitor(context) {}
 
   void HandleTranslationUnit(clang::ASTContext &context) override {
     m_visitor.TraverseDecl(context.getTranslationUnitDecl());
@@ -106,7 +109,7 @@ public:
   }
 };
 
-} // namespace lopatin_i_user_data_type
+} // namespace
 
-static clang::FrontendPluginRegistry::Add<lopatin_i_user_data_type::UserDataTypeAction>
+static clang::FrontendPluginRegistry::Add<UserDataTypeAction>
     X("UserDataTypePlugin_LopatinIlya_FIIT3_ClangAST", "Prints info about user defined data types");

--- a/clang/compiler-course/lopatin_i_user_data_type/lopatin_i_user_data_type_plugin.cpp
+++ b/clang/compiler-course/lopatin_i_user_data_type/lopatin_i_user_data_type_plugin.cpp
@@ -1,0 +1,117 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace lopatin_i_user_data_type {
+
+std::string getAccessSpelling(clang::AccessSpecifier access) {
+  switch (access) {
+    case clang::AS_public: return "public";
+    case clang::AS_protected: return "protected";
+    case clang::AS_private: return "private";
+    default: return "";
+  }
+}
+
+class UserDataTypeVisitor final : public clang::RecursiveASTVisitor<UserDataTypeVisitor> {
+  llvm::raw_ostream &m_os;
+public:
+  explicit UserDataTypeVisitor(clang::ASTContext *context, llvm::raw_ostream &os) : m_os(os) {}
+  bool VisitCXXRecordDecl(clang::CXXRecordDecl *D) {
+    if (!D->isThisDeclarationADefinition() || D->isImplicit())
+      return true;
+
+    // classes
+    m_os << D->getName();
+    if (D->getNumBases()) {
+      m_os << " -> ";
+      bool first = true;
+      for (const clang::CXXBaseSpecifier &B : D->bases()) {
+        if (!first) m_os << ", ";
+        first = false;
+        m_os << B.getType()->getAsCXXRecordDecl()->getName();
+      }
+    }
+    m_os << "\n";
+
+    // fields
+    m_os << "|_Fields\n";
+    for (clang::FieldDecl *F : D->fields()) {
+      m_os << "| |_ " << F->getName() << " ("
+           << F->getType().getAsString() << "|"
+           << lopatin_i_user_data_type::getAccessSpelling(F->getAccess()) << ")\n";
+    }
+
+    // methods
+    m_os << "|_Methods\n";
+    for (clang::CXXMethodDecl *M : D->methods()) {
+      if (M->isImplicit()) continue;
+
+      // method type
+      std::string TypeStr;
+      clang::QualType ReturnType = M->getReturnType();
+      TypeStr += ReturnType.getAsString() + "(";
+
+      for (unsigned i = 0; i < M->getNumParams(); ++i) {
+        if (i > 0) TypeStr += ", ";
+        TypeStr += M->getParamDecl(i)->getType().getAsString();
+      }
+      TypeStr += ")";
+
+      // specifiers
+      std::vector<std::string> Specs;
+      if (M->isVirtual() && !M->hasAttr<clang::OverrideAttr>()) {
+        Specs.push_back("virtual");
+      }
+      if (M->isPureVirtual()) Specs.push_back("pure");
+      if (M->hasAttr<clang::OverrideAttr>()) Specs.push_back("override");
+      if (M->isConst()) Specs.push_back("const");
+      if (const auto *FPT = M->getType()->getAs<clang::FunctionProtoType>()) {
+      if (FPT->getExceptionSpecType() == clang::EST_NoexceptTrue) {
+          Specs.push_back("noexcept");
+        }
+      }
+
+      m_os << "| |_ " << M->getNameAsString() << " (" << TypeStr << "|"
+           << lopatin_i_user_data_type::getAccessSpelling(M->getAccess());
+
+      for (const auto &S : Specs) {
+        m_os << "|" << S;
+      }
+      m_os << ")\n";
+    }
+    return true;
+  }
+};
+
+class UserDataTypeConsumer final : public clang::ASTConsumer {
+public:
+  explicit UserDataTypeConsumer(clang::ASTContext *context) : m_visitor(context, llvm::outs()) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+  }
+
+private:
+  UserDataTypeVisitor m_visitor;
+};
+
+class UserDataTypeAction final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    return std::make_unique<UserDataTypeConsumer>(&ci.getASTContext());
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+};
+
+} // namespace lopatin_i_user_data_type
+
+static clang::FrontendPluginRegistry::Add<lopatin_i_user_data_type::UserDataTypeAction>
+    X("UserDataTypePlugin_LopatinIlya_FIIT3_ClangAST", "Prints info about user defined data types");

--- a/clang/compiler-course/lopatin_i_user_data_type/lopatin_i_user_data_type_plugin.cpp
+++ b/clang/compiler-course/lopatin_i_user_data_type/lopatin_i_user_data_type_plugin.cpp
@@ -68,11 +68,6 @@ public:
       if (M->isPureVirtual()) Specs.push_back("pure");
       if (M->hasAttr<clang::OverrideAttr>()) Specs.push_back("override");
       if (M->isConst()) Specs.push_back("const");
-      if (const auto *FPT = M->getType()->getAs<clang::FunctionProtoType>()) {
-      if (FPT->getExceptionSpecType() == clang::EST_NoexceptTrue) {
-          Specs.push_back("noexcept");
-        }
-      }
 
       m_os << "| |_ " << M->getNameAsString() << " (" << TypeStr << "|"
            << lopatin_i_user_data_type::getAccessSpelling(M->getAccess());

--- a/clang/compiler-course/source.cpp
+++ b/clang/compiler-course/source.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main(){
+	std::cout << "i hate stupid labs" << std::endl;
+	return 0;
+}

--- a/clang/compiler-course/source.cpp
+++ b/clang/compiler-course/source.cpp
@@ -1,6 +1,0 @@
-#include <iostream>
-
-int main(){
-	std::cout << "i hate stupid labs" << std::endl;
-	return 0;
-}

--- a/clang/test/compiler-course/lopatin_i_user_data_type/lopatin_i_user_data_type_test.cpp
+++ b/clang/test/compiler-course/lopatin_i_user_data_type/lopatin_i_user_data_type_test.cpp
@@ -1,31 +1,47 @@
 // RUN: %clang_cc1 -load %llvmshlibdir/UserDataTypePlugin_LopatinIlya_FIIT3_ClangAST%pluginext -plugin UserDataTypePlugin_LopatinIlya_FIIT3_ClangAST %s -fsyntax-only 2>&1 | FileCheck %s
 
-// CHECK: Human
+// CHECK: Base1
 // CHECK: |_Fields
-// CHECK: | |_ age (unsigned int|public)
-// CHECK: | |_ height (unsigned int|public)
 // CHECK: |_Methods
-// CHECK: | |_ sleep (void()|public|virtual|pure)
-// CHECK: | |_ eat (void()|public|virtual|pure)
-
-// CHECK: Engineer -> Human
+// CHECK: | |_ virtualMethod (void()|public|virtual|pure)
+// CHECK: Base2
 // CHECK: |_Fields
-// CHECK: | |_ salary (unsigned int|public)
 // CHECK: |_Methods
-// CHECK: | |_ sleep (void()|public|override)
-// CHECK: | |_ eat (void()|public|override)
-// CHECK: | |_ work (void()|public)
+// CHECK: | |_ baseMethod (void()|public|virtual)
+// CHECK: Derived -> Base1, Base2
+// CHECK: |_Fields
+// CHECK: | |_ publicField (int|public)
+// CHECK: | |_ protectedField (float|protected)
+// CHECK: | |_ privateField (char|private)
+// CHECK: |_Methods
+// CHECK: | |_ virtualMethod (void()|public|override)
+// CHECK: | |_ baseMethod (void()|public|override)
+// CHECK: | |_ constMethod (int()|private|const)
+// CHECK: | |_ anotherMethod (void(int)|protected)
 
-struct Human {
-  unsigned age;
-  unsigned height;
-  virtual void sleep() = 0;
-  virtual void eat() = 0;
+struct Base1 {
+  virtual void virtualMethod() = 0;
 };
 
-struct Engineer : Human {
-  unsigned salary;
-  void sleep() override {}
-  void eat() override {}
-  void work() {}
+struct Base2 {
+  virtual void baseMethod() {}
+};
+
+struct Derived : Base1, Base2 {
+public:
+  int publicField;
+protected:
+  float protectedField;
+private:
+  char privateField;
+
+public:
+  void virtualMethod() override {}
+  void baseMethod() override {}
+  
+private:
+  int constMethod() const { return 0; }
+  
+protected:
+  void anotherMethod(int) {}
 };

--- a/clang/test/compiler-course/lopatin_i_user_data_type/lopatin_i_user_data_type_test.cpp
+++ b/clang/test/compiler-course/lopatin_i_user_data_type/lopatin_i_user_data_type_test.cpp
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/UserDataTypePlugin_LopatinIlya_FIIT3_ClangAST%pluginext -plugin UserDataTypePlugin_LopatinIlya_FIIT3_ClangAST %s -fsyntax-only 2>&1 | FileCheck %s
+
+// CHECK: Human
+// CHECK: |_Fields
+// CHECK: | |_ age (unsigned int|public)
+// CHECK: | |_ height (unsigned int|public)
+// CHECK: |_Methods
+// CHECK: | |_ sleep (void()|public|virtual|pure)
+// CHECK: | |_ eat (void()|public|virtual|pure)
+
+// CHECK: Engineer -> Human
+// CHECK: |_Fields
+// CHECK: | |_ salary (unsigned int|public)
+// CHECK: |_Methods
+// CHECK: | |_ sleep (void()|public|override)
+// CHECK: | |_ eat (void()|public|override)
+// CHECK: | |_ work (void()|public)
+
+struct Human {
+  unsigned age;
+  unsigned height;
+  virtual void sleep() = 0;
+  virtual void eat() = 0;
+};
+
+struct Engineer : Human {
+  unsigned salary;
+  void sleep() override {}
+  void eat() override {}
+  void work() {}
+};

--- a/clang/test/compiler-course/lopatin_i_user_data_type/lopatin_i_user_data_type_test.cpp
+++ b/clang/test/compiler-course/lopatin_i_user_data_type/lopatin_i_user_data_type_test.cpp
@@ -1,23 +1,32 @@
 // RUN: %clang_cc1 -load %llvmshlibdir/UserDataTypePlugin_LopatinIlya_FIIT3_ClangAST%pluginext -plugin UserDataTypePlugin_LopatinIlya_FIIT3_ClangAST %s -fsyntax-only 2>&1 | FileCheck %s
 
 // CHECK: Base1
-// CHECK: |_Fields
-// CHECK: |_Methods
-// CHECK: | |_ virtualMethod (void()|public|virtual|pure)
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ (no fields)
+// CHECK-NEXT: |_Methods
+// CHECK-NEXT: | |_ virtualMethod (void()|public|virtual|pure)
+
 // CHECK: Base2
-// CHECK: |_Fields
-// CHECK: |_Methods
-// CHECK: | |_ baseMethod (void()|public|virtual)
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ (no fields)
+// CHECK-NEXT: |_Methods
+// CHECK-NEXT: | |_ baseMethod (void()|public|virtual)
+
 // CHECK: Derived -> Base1, Base2
-// CHECK: |_Fields
-// CHECK: | |_ publicField (int|public)
-// CHECK: | |_ protectedField (float|protected)
-// CHECK: | |_ privateField (char|private)
-// CHECK: |_Methods
-// CHECK: | |_ virtualMethod (void()|public|override)
-// CHECK: | |_ baseMethod (void()|public|override)
-// CHECK: | |_ constMethod (int()|private|const)
-// CHECK: | |_ anotherMethod (void(int)|protected)
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ publicField (int|public)
+// CHECK-NEXT: | |_ protectedField (float|protected)
+// CHECK-NEXT: | |_ privateField (char|private)
+// CHECK-NEXT: |_Methods
+// CHECK-NEXT: | |_ virtualMethod (void()|public|override)
+// CHECK-NEXT: | |_ baseMethod (void()|public|override)
+// CHECK-NEXT: | |_ constMethod (int()|private|const)
+// CHECK-NEXT: | |_ anotherMethod (void(int)|protected)
+
+// CHECK: Array
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ ptr (T[SZ]|public)
+
 
 struct Base1 {
   virtual void virtualMethod() = 0;
@@ -45,3 +54,9 @@ private:
 protected:
   void anotherMethod(int) {}
 };
+
+template <typename T, unsigned SZ>
+struct Array {
+  T ptr[SZ]{};
+};
+


### PR DESCRIPTION
This Clang plugin analyzes C++ user-defined types (classes/structs) using LLVM/Clang's AST traversal capabilities.

### Functionality:
- Extracts class inheritance chains
- Lists fields with types/access modifiers
- Identifies methods with signatures, qualifiers (const/noexcept), and special properties (virtual/override/pure)

### LLVM/Clang APIs Used:
- `RecursiveASTVisitor` for deep AST traversal
- `CXXRecordDecl` for class declarations
- `CXXBaseSpecifier` for inheritance info
- `FieldDecl`/`CXXMethodDecl` for member analysis

### Workflow:
- Registers as FrontendPlugin
- Traverses Translation Unit AST
- Filters implicit/compiler-generated elements
- Outputs structured type info via LLVM's raw_ostream