### PR TITLE
Дрождинов Дмитрий. Лабораторная работа 1. Clang AST. Вариант 3.

### DIFF
--- a/clang/compiler-course/drozhdinov_d_clangast_var3/CMakeLists.txt
+++ b/clang/compiler-course/drozhdinov_d_clangast_var3/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "CastCounter")
+set(Student "DrozhdinovD")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
+++ b/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
@@ -27,7 +27,8 @@ public:
       return true;
     }
 
-    clang::QualType SourceType = Expr->getArg(0)->getType();
+    clang::QualType SourceType =
+        Expr->getArg(0)->getType();
     clang::QualType DestType = Expr->getType();
 
     if (SourceType == DestType) {

--- a/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
+++ b/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
@@ -93,7 +93,7 @@ public:
 
   bool ParseArgs(const clang::CompilerInstance &CI,
                  const vector<string> &Args) override {
-  	return true;
+    return true;
   }
 };
 

--- a/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
+++ b/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
@@ -34,15 +34,15 @@ public:
       return true;
     }
     CastMap[CurrentFunction]
-    			 [std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
+    [std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
     return true;
   }
 
   bool VisitImplicitCastExpr(clang::ImplicitCastExpr *Expr) {
     clang::CastKind Kind = Expr->getCastKind();
 
-    if (Kind == clang::CK_LValueToRValue || 
-    		Kind == clang::CK_FunctionToPointerDecay) {
+    if (Kind == clang::CK_LValueToRValue ||
+    Kind == clang::CK_FunctionToPointerDecay) {
       return true;
     }
 
@@ -53,7 +53,7 @@ public:
       return true;
     }
     CastMap[CurrentFunction]
-    			 [std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
+    [std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
     return true;
   }
 
@@ -86,20 +86,20 @@ public:
 
 class CastCounterAction final : public clang::PluginASTAction {
 public:
-  std::unique_ptr<clang::ASTConsumer> 
+  std::unique_ptr<clang::ASTConsumer>
   CreateASTConsumer(clang::CompilerInstance &CI, llvm::StringRef) override {
     return std::make_unique<CastCounterConsumer>();
   }
 
   bool ParseArgs(const clang::CompilerInstance &CI, 
-  							 const vector<string> &Args) override { 
+  const vector<string> &Args) override { 
   	return true;
   }
 };
 
 } // namespace
 
-static clang::FrontendPluginRegistry::Add<CastCounterAction> 
-	X("CastCounter_DrozhdinovD_FIIT1_ClangAST",
-    "Detects and counts implicit casts in function bodies and constructor "
-    "conversions");
+static clang::FrontendPluginRegistry::Add<CastCounterAction>
+X("CastCounter_DrozhdinovD_FIIT1_ClangAST",
+"Detects and counts implicit casts in function bodies and constructor "
+"conversions");

--- a/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
+++ b/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
@@ -15,14 +15,14 @@ using std::vector;
 
 namespace {
 class CastCounter final : public clang::RecursiveASTVisitor<CastCounter> {
- public:
+public:
   CastCounter() = default;
-  bool VisitFunctionDecl(clang::FunctionDecl* Expr) {
+  bool VisitFunctionDecl(clang::FunctionDecl *Expr) {
     CurrentFunction = Expr->getNameAsString();
     return true;
   }
 
-  bool VisitCXXConstructExpr(clang::CXXConstructExpr* Expr) {
+  bool VisitCXXConstructExpr(clang::CXXConstructExpr *Expr) {
     if (Expr->getNumArgs() < 1) {
       return true;
     }
@@ -33,14 +33,16 @@ class CastCounter final : public clang::RecursiveASTVisitor<CastCounter> {
     if (SourceType == DestType) {
       return true;
     }
-    CastMap[CurrentFunction][std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
+    CastMap[CurrentFunction]
+    			 [std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
     return true;
   }
 
-  bool VisitImplicitCastExpr(clang::ImplicitCastExpr* Expr) {
+  bool VisitImplicitCastExpr(clang::ImplicitCastExpr *Expr) {
     clang::CastKind Kind = Expr->getCastKind();
 
-    if (Kind == clang::CK_LValueToRValue || Kind == clang::CK_FunctionToPointerDecay) {
+    if (Kind == clang::CK_LValueToRValue || 
+    		Kind == clang::CK_FunctionToPointerDecay) {
       return true;
     }
 
@@ -50,7 +52,8 @@ class CastCounter final : public clang::RecursiveASTVisitor<CastCounter> {
     if (SourceType == DestType) {
       return true;
     }
-    CastMap[CurrentFunction][std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
+    CastMap[CurrentFunction]
+    			[std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
     return true;
   }
 
@@ -63,35 +66,40 @@ class CastCounter final : public clang::RecursiveASTVisitor<CastCounter> {
     }
   }
 
- private:
+private:
   map<string, map<std::pair<string, string>, int>> CastMap;
   string CurrentFunction;
 };
 
 class CastCounterConsumer final : public clang::ASTConsumer {
- private:
+private:
   CastCounter cc;
 
- public:
+public:
   CastCounterConsumer() = default;
 
-  void HandleTranslationUnit(clang::ASTContext& Context) override {
+  void HandleTranslationUnit(clang::ASTContext &Context) override {
     cc.TraverseDecl(Context.getTranslationUnitDecl());
     cc.getResult();
   }
 };
 
 class CastCounterAction final : public clang::PluginASTAction {
- public:
-  std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance& CI, llvm::StringRef) override {
+public:
+  std::unique_ptr<clang::ASTConsumer> 
+  CreateASTConsumer(clang::CompilerInstance &CI, llvm::StringRef) override {
     return std::make_unique<CastCounterConsumer>();
   }
 
-  bool ParseArgs(const clang::CompilerInstance& CI, const vector<string>& Args) override { return true; }
+  bool ParseArgs(const clang::CompilerInstance &CI, 
+  							 const vector<string> &Args) override { 
+  	return true;
+  }
 };
 
-}  // namespace
+} // namespace
 
-static clang::FrontendPluginRegistry::Add<CastCounterAction> X(
-    "CastCounter_DrozhdinovD_FIIT1_ClangAST",
-    "Detects and counts implicit casts in function bodies and constructor conversions");
+static clang::FrontendPluginRegistry::Add<CastCounterAction> 
+	X("CastCounter_DrozhdinovD_FIIT1_ClangAST",
+    "Detects and counts implicit casts in function bodies and constructor "
+    "conversions");

--- a/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
+++ b/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
@@ -34,7 +34,7 @@ public:
       return true;
     }
     CastMap[CurrentFunction]
-    [std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
+           [std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
     return true;
   }
 
@@ -42,7 +42,7 @@ public:
     clang::CastKind Kind = Expr->getCastKind();
 
     if (Kind == clang::CK_LValueToRValue ||
-    Kind == clang::CK_FunctionToPointerDecay) {
+        Kind == clang::CK_FunctionToPointerDecay) {
       return true;
     }
 
@@ -53,7 +53,7 @@ public:
       return true;
     }
     CastMap[CurrentFunction]
-    [std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
+           [std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
     return true;
   }
 
@@ -92,7 +92,7 @@ public:
   }
 
   bool ParseArgs(const clang::CompilerInstance &CI, 
-  const vector<string> &Args) override { 
+                 const vector<string> &Args) override { 
   	return true;
   }
 };
@@ -100,6 +100,6 @@ public:
 } // namespace
 
 static clang::FrontendPluginRegistry::Add<CastCounterAction>
-X("CastCounter_DrozhdinovD_FIIT1_ClangAST",
-"Detects and counts implicit casts in function bodies and constructor "
-"conversions");
+    X("CastCounter_DrozhdinovD_FIIT1_ClangAST",
+      "Detects and counts implicit casts in function bodies and constructor "
+      "conversions");

--- a/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
+++ b/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
@@ -34,7 +34,7 @@ public:
       return true;
     }
     CastMap[CurrentFunction]
-    [std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
+           [std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
     return true;
   }
 
@@ -42,18 +42,18 @@ public:
     clang::CastKind Kind = Expr->getCastKind();
 
     if (Kind == clang::CK_LValueToRValue ||
-    Kind == clang::CK_FunctionToPointerDecay) {
+        Kind == clang::CK_FunctionToPointerDecay) {
       return true;
     }
 
-    clang::QualType SourceType = Expr->getSubExpr()->getType();
-    clang::QualType DestType = Expr->getType();
+    clang::QualType SourceType = Expr->getSubExpr()->getType().getCanonicalType();
+    clang::QualType DestType = Expr->getType().getCanonicalType();
 
     if (SourceType == DestType) {
       return true;
     }
     CastMap[CurrentFunction]
-    [std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
+           [std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
     return true;
   }
 
@@ -91,15 +91,15 @@ public:
     return std::make_unique<CastCounterConsumer>();
   }
 
-  bool ParseArgs(const clang::CompilerInstance &CI, 
-  const vector<string> &Args) override { 
-  	return true;
+  bool ParseArgs(const clang::CompilerInstance &CI,
+                 const vector<string> &Args) override {
+    return true;
   }
 };
 
 } // namespace
 
 static clang::FrontendPluginRegistry::Add<CastCounterAction>
-X("CastCounter_DrozhdinovD_FIIT1_ClangAST",
-"Detects and counts implicit casts in function bodies and constructor "
-"conversions");
+    X("CastCounter_DrozhdinovD_FIIT1_ClangAST",
+      "Detects and counts implicit casts in function bodies and constructor "
+      "conversions");

--- a/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
+++ b/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
@@ -91,8 +91,8 @@ public:
     return std::make_unique<CastCounterConsumer>();
   }
 
-  bool ParseArgs(const clang::CompilerInstance &CI, 
-                 const vector<string> &Args) override { 
+  bool ParseArgs(const clang::CompilerInstance &CI,
+                 const vector<string> &Args) override {
   	return true;
   }
 };

--- a/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
+++ b/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
@@ -53,7 +53,7 @@ public:
       return true;
     }
     CastMap[CurrentFunction]
-    			[std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
+    			 [std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
     return true;
   }
 

--- a/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
+++ b/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
@@ -1,93 +1,98 @@
 #include "clang/AST/ASTConsumer.h"
-#include "clang/AST/ASTTypeTraits.h"
-#include "clang/AST/ParentMapContext.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
 #include "llvm/Support/raw_ostream.h"
 #include <map>
+#include <vector>
+#include <string>
 
+using namespace std;
 using namespace clang;
+using namespace llvm;
 
 namespace {
-class CastCounter : public clang::RecursiveASTVisitor<CastCounter> {
-private:
-  clang::ASTContext *m_context;
-  std::string CurrentFunc;
-  std::map<std::string, std::map<std::string, int>> transformations;
-  std::map<const clang::FunctionDecl*, std::map<std::pair<std::string, std::string>, int>> tr;
-public:
-  explicit CastCounter(clang::ASTContext *context) : m_context(context) {}
-  bool CheckImplicitCast(clang::ImplicitCastExpr *Expr) {
-  	auto CastType = Expr->getCastKind();
-  	/*
-  	if (CastType == clang::CK_LValueToRValue ||
-  		CastType == clang::CK_NoOp ||
-  		CastType == clang::CK_FunctionToPointerDecay ||
-  		CastType == clang::CK_ArrayToPointerDecay ||
-  		CastType == clang::CK_NullToPointer) {
-  		return true;
-  	}*/
-    clang::QualType SourceType = Expr->getSubExpr()->getType();
-    clang::QualType DestType = Expr->getType();
-    
-    if (SourceType.getAsString() == DestType.getAsString()){
-    	return true;
-    }
-    
-    auto CurrentScope = clang::DynTypedNode::create<clang::ImplicitCastExpr>(*Expr);
-    auto PrevScope = m_context->getParents(CurrentScope);
-    
-    while (!PrevScope.empty()) {
-    	if (const clang::FunctionDecl *Decl = PrevScope[0].get<clang::FunctionDecl>()) {
-    		std::string source = SourceType.getAsString();
-    		std::string dest = DestType.getAsString();
-    		tr[Decl][std::make_pair(source, dest)]++;
-    		break;
-    	}
-    	CurrentScope = PrevScope[0];
-    	PrevScope = m_context->getParents(CurrentScope);
-    }
-    return true;
-  }
-  
-  void GetResult(){
-  	for (const auto &t : tr) {
-  		llvm::errs() << "Function `" << t.first->getName() << "`\n";
-  		for (const auto &c : t.second) {
-  			llvm::errs() << c.first.first << " -> " << c.first.second << ": " << c.second << "\n";
-  		}
-  	}
-  }
+	class CastCounter final : public RecursiveASTVisitor<CastCounter> {
+	public:
+		explicit CastCounter() = default;
+		bool VisitFunctionDecl(FunctionDecl* Expr) {
+			CurrentFunction = Expr->getNameAsString();
+			return true;
+		}
 
-};
+		bool VisitCXXConstructExpr(CXXConstructExpr* Expr) {
+			if (Expr->getNumArgs() < 1) {
+				return true;
+			}
 
-class CastConsumer : public clang::ASTConsumer {
-public:
-  explicit CastConsumer(clang::ASTContext *context) : Counter(context) {}
+			QualType SourceType = Expr->getArg(0)->getType();
+			QualType DestType = Expr->getType();
 
-  void HandleTranslationUnit(clang::ASTContext &context) override {
-    Counter.TraverseDecl(context.getTranslationUnitDecl());
-    Counter.GetResult();
-  }
+			if (SourceType == DestType) {
+				return true;
+			}
+			CastMap[CurrentFunction][make_pair(SourceType.getAsString(), DestType.getAsString())]++;
+			return true;
+		}
 
-private:
-	CastCounter Counter;
-};
+		bool VisitImplicitCastExpr(ImplicitCastExpr* Expr) {
+			CastKind Kind = Expr->getCastKind();
+			
+			if (Kind == CK_LValueToRValue || Kind == CK_FunctionToPointerDecay){
+				return true;
+			}
+			
+			QualType SourceType = Expr->getSubExpr()->getType();
+			QualType DestType = Expr->getType();
 
-class CastCounterAction final : public clang::PluginASTAction {
-public:
-  std::unique_ptr<clang::ASTConsumer>
-  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
-    return std::make_unique<CastConsumer>(&ci.getASTContext());
-  }
+			if (SourceType == DestType) {
+				return true;
+			}
+			CastMap[CurrentFunction][make_pair(SourceType.getAsString(), DestType.getAsString())]++;
+			return true;
+		}
 
-  bool ParseArgs(const clang::CompilerInstance &ci,
-                 const std::vector<std::string> &args) override {
-    return true;
-  }
-};
+		bool getResult() {
+			for (auto iter = CastMap.rbegin(); iter != CastMap.rend(); iter++){
+				outs() << "Function " << (*iter).first << "\n";
+				for (auto [cast, val] : (*iter).second){
+					outs() << cast.first << " -> " << cast.second << ": " << val << "\n";
+				}
+			}
+			return true;
+		}
+
+	private:
+		map<string, map<pair<string, string>, int>> CastMap;
+		string CurrentFunction;
+	};
+
+	class CastCounterConsumer final : public ASTConsumer {
+	private:
+		CastCounter cc;
+	public:
+		explicit CastCounterConsumer() = default;
+
+		void HandleTranslationUnit(ASTContext& Context) override {
+			cc.TraverseDecl(Context.getTranslationUnitDecl());
+			cc.getResult();
+		}
+
+	
+	};
+
+	class CastCounterAction final : public PluginASTAction {
+	public:
+		unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance& CI, StringRef) override {
+			return make_unique<CastCounterConsumer>();
+		}
+
+		bool ParseArgs(const CompilerInstance& CI, const vector<string>& Args) override {
+			return true;
+		}
+	};
+
 } // namespace
 
-static clang::FrontendPluginRegistry::Add<CastCounterAction>
-	X("CastCounter", "This plugin counts number of implicit casts");
+static FrontendPluginRegistry::Add<CastCounterAction>
+X("CastCounter", "Counts implicit casts");

--- a/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
+++ b/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
@@ -1,0 +1,93 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/ASTTypeTraits.h"
+#include "clang/AST/ParentMapContext.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+#include <map>
+
+using namespace clang;
+
+namespace {
+class CastCounter : public clang::RecursiveASTVisitor<CastCounter> {
+private:
+  clang::ASTContext *m_context;
+  std::string CurrentFunc;
+  std::map<std::string, std::map<std::string, int>> transformations;
+  std::map<const clang::FunctionDecl*, std::map<std::pair<std::string, std::string>, int>> tr;
+public:
+  explicit CastCounter(clang::ASTContext *context) : m_context(context) {}
+  bool CheckImplicitCast(clang::ImplicitCastExpr *Expr) {
+  	auto CastType = Expr->getCastKind();
+  	/*
+  	if (CastType == clang::CK_LValueToRValue ||
+  		CastType == clang::CK_NoOp ||
+  		CastType == clang::CK_FunctionToPointerDecay ||
+  		CastType == clang::CK_ArrayToPointerDecay ||
+  		CastType == clang::CK_NullToPointer) {
+  		return true;
+  	}*/
+    clang::QualType SourceType = Expr->getSubExpr()->getType();
+    clang::QualType DestType = Expr->getType();
+    
+    if (SourceType.getAsString() == DestType.getAsString()){
+    	return true;
+    }
+    
+    auto CurrentScope = clang::DynTypedNode::create<clang::ImplicitCastExpr>(*Expr);
+    auto PrevScope = m_context->getParents(CurrentScope);
+    
+    while (!PrevScope.empty()) {
+    	if (const clang::FunctionDecl *Decl = PrevScope[0].get<clang::FunctionDecl>()) {
+    		std::string source = SourceType.getAsString();
+    		std::string dest = DestType.getAsString();
+    		tr[Decl][std::make_pair(source, dest)]++;
+    		break;
+    	}
+    	CurrentScope = PrevScope[0];
+    	PrevScope = m_context->getParents(CurrentScope);
+    }
+    return true;
+  }
+  
+  void GetResult(){
+  	for (const auto &t : tr) {
+  		llvm::errs() << "Function `" << t.first->getName() << "`\n";
+  		for (const auto &c : t.second) {
+  			llvm::errs() << c.first.first << " -> " << c.first.second << ": " << c.second << "\n";
+  		}
+  	}
+  }
+
+};
+
+class CastConsumer : public clang::ASTConsumer {
+public:
+  explicit CastConsumer(clang::ASTContext *context) : Counter(context) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    Counter.TraverseDecl(context.getTranslationUnitDecl());
+    Counter.GetResult();
+  }
+
+private:
+	CastCounter Counter;
+};
+
+class CastCounterAction final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    return std::make_unique<CastConsumer>(&ci.getASTContext());
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+};
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<CastCounterAction>
+	X("CastCounter", "This plugin counts number of implicit casts");

--- a/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
+++ b/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
@@ -27,8 +27,7 @@ public:
       return true;
     }
 
-    clang::QualType SourceType =
-        Expr->getArg(0)->getType();
+    clang::QualType SourceType = Expr->getArg(0)->getType();
     clang::QualType DestType = Expr->getType();
 
     if (SourceType == DestType) {
@@ -47,7 +46,8 @@ public:
       return true;
     }
 
-    clang::QualType SourceType = Expr->getSubExpr()->getType().getCanonicalType();
+    clang::QualType SourceType =
+        Expr->getSubExpr()->getType().getCanonicalType();
     clang::QualType DestType = Expr->getType().getCanonicalType();
 
     if (SourceType == DestType) {

--- a/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
+++ b/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
@@ -1,97 +1,97 @@
+#include <map>
+#include <string>
+#include <vector>
+
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
 #include "llvm/Support/raw_ostream.h"
-#include <map>
-#include <vector>
-#include <string>
 
-using std::vector;
+using llvm::outs;
 using std::map;
 using std::string;
-using llvm::outs;
+using std::vector;
 
 namespace {
-	class CastCounter final : public clang::RecursiveASTVisitor<CastCounter> {
-	public:
-		CastCounter() = default;
-		bool VisitFunctionDecl(clang::FunctionDecl* Expr) {
-			CurrentFunction = Expr->getNameAsString();
-			return true;
-		}
+class CastCounter final : public clang::RecursiveASTVisitor<CastCounter> {
+ public:
+  CastCounter() = default;
+  bool VisitFunctionDecl(clang::FunctionDecl* Expr) {
+    CurrentFunction = Expr->getNameAsString();
+    return true;
+  }
 
-		bool VisitCXXConstructExpr(clang::CXXConstructExpr* Expr) {
-			if (Expr->getNumArgs() < 1) {
-				return true;
-			}
+  bool VisitCXXConstructExpr(clang::CXXConstructExpr* Expr) {
+    if (Expr->getNumArgs() < 1) {
+      return true;
+    }
 
-			clang::QualType SourceType = Expr->getArg(0)->getType();
-			clang::QualType DestType = Expr->getType();
+    clang::QualType SourceType = Expr->getArg(0)->getType();
+    clang::QualType DestType = Expr->getType();
 
-			if (SourceType == DestType) {
-				return true;
-			}
-			CastMap[CurrentFunction][std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
-			return true;
-		}
+    if (SourceType == DestType) {
+      return true;
+    }
+    CastMap[CurrentFunction][std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
+    return true;
+  }
 
-		bool VisitImplicitCastExpr(clang::ImplicitCastExpr* Expr) {
-			clang::CastKind Kind = Expr->getCastKind();
-			
-			if (Kind == clang::CK_LValueToRValue || Kind == clang::CK_FunctionToPointerDecay){
-				return true;
-			}
-			
-			clang::QualType SourceType = Expr->getSubExpr()->getType();
-			clang::QualType DestType = Expr->getType();
+  bool VisitImplicitCastExpr(clang::ImplicitCastExpr* Expr) {
+    clang::CastKind Kind = Expr->getCastKind();
 
-			if (SourceType == DestType) {
-				return true;
-			}
-			CastMap[CurrentFunction][std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
-			return true;
-		}
+    if (Kind == clang::CK_LValueToRValue || Kind == clang::CK_FunctionToPointerDecay) {
+      return true;
+    }
 
-		void getResult() {
-			for (auto iter = CastMap.rbegin(); iter != CastMap.rend(); iter++){
-				outs() << "Function " << iter->first << "\n";
-				for (auto [cast, val] : iter->second){
-					outs() << cast.first << " -> " << cast.second << ": " << val << "\n";
-				}
-			}
-		}
+    clang::QualType SourceType = Expr->getSubExpr()->getType();
+    clang::QualType DestType = Expr->getType();
 
-	private:
-		map<string, map<std::pair<string, string>, int>> CastMap;
-		string CurrentFunction;
-	};
+    if (SourceType == DestType) {
+      return true;
+    }
+    CastMap[CurrentFunction][std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
+    return true;
+  }
 
-	class CastCounterConsumer final : public clang::ASTConsumer {
-	private:
-		CastCounter cc;
-	public:
-		CastCounterConsumer() = default;
+  void getResult() {
+    for (auto iter = CastMap.rbegin(); iter != CastMap.rend(); iter++) {
+      outs() << "Function " << iter->first << "\n";
+      for (auto [cast, val] : iter->second) {
+        outs() << cast.first << " -> " << cast.second << ": " << val << "\n";
+      }
+    }
+  }
 
-		void HandleTranslationUnit(clang::ASTContext& Context) override {
-			cc.TraverseDecl(Context.getTranslationUnitDecl());
-			cc.getResult();
-		}
+ private:
+  map<string, map<std::pair<string, string>, int>> CastMap;
+  string CurrentFunction;
+};
 
-	};
+class CastCounterConsumer final : public clang::ASTConsumer {
+ private:
+  CastCounter cc;
 
-	class CastCounterAction final : public clang::PluginASTAction {
-	public:
-		std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance& CI, llvm::StringRef) override {
-			return std::make_unique<CastCounterConsumer>();
-		}
+ public:
+  CastCounterConsumer() = default;
 
-		bool ParseArgs(const clang::CompilerInstance& CI, const vector<string>& Args) override {
-			return true;
-		}
-	};
+  void HandleTranslationUnit(clang::ASTContext& Context) override {
+    cc.TraverseDecl(Context.getTranslationUnitDecl());
+    cc.getResult();
+  }
+};
 
-} // namespace
+class CastCounterAction final : public clang::PluginASTAction {
+ public:
+  std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance& CI, llvm::StringRef) override {
+    return std::make_unique<CastCounterConsumer>();
+  }
 
-static clang::FrontendPluginRegistry::Add<CastCounterAction>
-X("CastCounter_DrozhdinovD_FIIT1_ClangAST", "Detects and counts implicit casts in function bodies and constructor conversions");
+  bool ParseArgs(const clang::CompilerInstance& CI, const vector<string>& Args) override { return true; }
+};
+
+}  // namespace
+
+static clang::FrontendPluginRegistry::Add<CastCounterAction> X(
+    "CastCounter_DrozhdinovD_FIIT1_ClangAST",
+    "Detects and counts implicit casts in function bodies and constructor conversions");

--- a/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
+++ b/clang/compiler-course/drozhdinov_d_clangast_var3/drozhdinov_clang.cpp
@@ -7,92 +7,91 @@
 #include <vector>
 #include <string>
 
-using namespace std;
-using namespace clang;
-using namespace llvm;
+using std::vector;
+using std::map;
+using std::string;
+using llvm::outs;
 
 namespace {
-	class CastCounter final : public RecursiveASTVisitor<CastCounter> {
+	class CastCounter final : public clang::RecursiveASTVisitor<CastCounter> {
 	public:
-		explicit CastCounter() = default;
-		bool VisitFunctionDecl(FunctionDecl* Expr) {
+		CastCounter() = default;
+		bool VisitFunctionDecl(clang::FunctionDecl* Expr) {
 			CurrentFunction = Expr->getNameAsString();
 			return true;
 		}
 
-		bool VisitCXXConstructExpr(CXXConstructExpr* Expr) {
+		bool VisitCXXConstructExpr(clang::CXXConstructExpr* Expr) {
 			if (Expr->getNumArgs() < 1) {
 				return true;
 			}
 
-			QualType SourceType = Expr->getArg(0)->getType();
-			QualType DestType = Expr->getType();
+			clang::QualType SourceType = Expr->getArg(0)->getType();
+			clang::QualType DestType = Expr->getType();
 
 			if (SourceType == DestType) {
 				return true;
 			}
-			CastMap[CurrentFunction][make_pair(SourceType.getAsString(), DestType.getAsString())]++;
+			CastMap[CurrentFunction][std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
 			return true;
 		}
 
-		bool VisitImplicitCastExpr(ImplicitCastExpr* Expr) {
-			CastKind Kind = Expr->getCastKind();
+		bool VisitImplicitCastExpr(clang::ImplicitCastExpr* Expr) {
+			clang::CastKind Kind = Expr->getCastKind();
 			
-			if (Kind == CK_LValueToRValue || Kind == CK_FunctionToPointerDecay){
+			if (Kind == clang::CK_LValueToRValue || Kind == clang::CK_FunctionToPointerDecay){
 				return true;
 			}
 			
-			QualType SourceType = Expr->getSubExpr()->getType();
-			QualType DestType = Expr->getType();
+			clang::QualType SourceType = Expr->getSubExpr()->getType();
+			clang::QualType DestType = Expr->getType();
 
 			if (SourceType == DestType) {
 				return true;
 			}
-			CastMap[CurrentFunction][make_pair(SourceType.getAsString(), DestType.getAsString())]++;
+			CastMap[CurrentFunction][std::make_pair(SourceType.getAsString(), DestType.getAsString())]++;
 			return true;
 		}
 
-		bool getResult() {
+		void getResult() {
 			for (auto iter = CastMap.rbegin(); iter != CastMap.rend(); iter++){
-				outs() << "Function " << (*iter).first << "\n";
-				for (auto [cast, val] : (*iter).second){
+				outs() << "Function " << iter->first << "\n";
+				for (auto [cast, val] : iter->second){
 					outs() << cast.first << " -> " << cast.second << ": " << val << "\n";
 				}
 			}
-			return true;
 		}
 
 	private:
-		map<string, map<pair<string, string>, int>> CastMap;
+		map<string, map<std::pair<string, string>, int>> CastMap;
 		string CurrentFunction;
 	};
 
-	class CastCounterConsumer final : public ASTConsumer {
+	class CastCounterConsumer final : public clang::ASTConsumer {
 	private:
 		CastCounter cc;
 	public:
-		explicit CastCounterConsumer() = default;
+		CastCounterConsumer() = default;
 
-		void HandleTranslationUnit(ASTContext& Context) override {
+		void HandleTranslationUnit(clang::ASTContext& Context) override {
 			cc.TraverseDecl(Context.getTranslationUnitDecl());
 			cc.getResult();
 		}
 
-	
 	};
 
-	class CastCounterAction final : public PluginASTAction {
+	class CastCounterAction final : public clang::PluginASTAction {
 	public:
-		unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance& CI, StringRef) override {
-			return make_unique<CastCounterConsumer>();
+		std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance& CI, llvm::StringRef) override {
+			return std::make_unique<CastCounterConsumer>();
 		}
 
-		bool ParseArgs(const CompilerInstance& CI, const vector<string>& Args) override {
+		bool ParseArgs(const clang::CompilerInstance& CI, const vector<string>& Args) override {
 			return true;
 		}
 	};
 
 } // namespace
 
-static FrontendPluginRegistry::Add<CastCounterAction>
-X("CastCounter", "Counts implicit casts");
+static clang::FrontendPluginRegistry::Add<CastCounterAction>
+X("CastCounter_DrozhdinovD_FIIT1_ClangAST", "Detects and counts implicit casts in function bodies and constructor conversions");

--- a/clang/test/compiler-course/drozhdinov_d_clangast_var3_test/test.cpp
+++ b/clang/test/compiler-course/drozhdinov_d_clangast_var3_test/test.cpp
@@ -1,14 +1,15 @@
-// RUN: %clang_cc1 -load %llvmshlibdir/CastCounter_DrozhdinovD_FIIT1_ClangAST%pluginext -plugin CastCounter %s -fsyntax-only 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -load %llvmshlibdir/CastCounter_DrozhdinovD_FIIT1_ClangAST%pluginext -plugin CastCounter_DrozhdinovD_FIIT1_ClangAST %s -fsyntax-only 2>&1 | FileCheck %s
+using Abrakadabra = int;
+#define int Abrakadabra
 
 // CHECK: Function sum
+// CHECK-NEXT: Abrakadabra -> float: 1
 // CHECK-NEXT: float -> double: 1
-// CHECK-NEXT: int -> float: 1
 
 // CHECK: Function mul
-// CHECK-NEXT: double -> int: 1
+// CHECK-NEXT: double -> Abrakadabra: 1
+// CHECK-NEXT: float -> Abrakadabra: 1
 // CHECK-NEXT: float -> double: 1
-// CHECK-NEXT: float -> int: 1
-
 
 double sum(int a, float b) {
 	return a + b;
@@ -16,4 +17,39 @@ double sum(int a, float b) {
 
 int mul(float a, float b) {
 	return a + sum(a, b);
+}
+
+// CHECK: Function func
+// CHECK-NEXT: Abrakadabra -> double: 1
+// CHECK-NEXT: _Bool -> Abrakadabra: 1
+// CHECK-NEXT: double -> _Bool: 2
+
+void func() {
+	bool b = 3.14;
+	bool bb = 0.00;
+	int x = b;
+	double d = x;
+}
+
+// CHECK: Function foo
+// CHECK-NEXT: Abrakadabra * -> const Abrakadabra *: 1
+
+void bar(const int*);
+void foo() {
+	int x = 42;
+	bar(&x);
+}
+
+// CHECK: Function createX
+// CHECK-NEXT; Abrakadabra -> X: 1
+
+class X {
+	int x;
+public:
+	X(int val) : x(val) {}
+};
+
+
+X createX() {
+	return 10;
 }

--- a/clang/test/compiler-course/drozhdinov_d_clangast_var3_test/test.cpp
+++ b/clang/test/compiler-course/drozhdinov_d_clangast_var3_test/test.cpp
@@ -3,13 +3,13 @@ using Abrakadabra = int;
 #define int Abrakadabra
 
 // CHECK: Function sum
-// CHECK-NEXT: Abrakadabra -> float: 1
 // CHECK-NEXT: float -> double: 1
+// CHECK-NEXT: int -> float: 1
 
 // CHECK: Function mul
-// CHECK-NEXT: double -> Abrakadabra: 1
-// CHECK-NEXT: float -> Abrakadabra: 1
+// CHECK-NEXT: double -> int: 1
 // CHECK-NEXT: float -> double: 1
+// CHECK-NEXT: float -> int: 1
 
 double sum(int a, float b) {
 	return a + b;
@@ -20,9 +20,9 @@ int mul(float a, float b) {
 }
 
 // CHECK: Function func
-// CHECK-NEXT: Abrakadabra -> double: 1
-// CHECK-NEXT: _Bool -> Abrakadabra: 1
+// CHECK-NEXT: _Bool -> int: 1
 // CHECK-NEXT: double -> _Bool: 2
+// CHECK-NEXT: int -> double: 1
 
 void func() {
 	bool b = 3.14;
@@ -32,7 +32,7 @@ void func() {
 }
 
 // CHECK: Function foo
-// CHECK-NEXT: Abrakadabra * -> const Abrakadabra *: 1
+// CHECK-NEXT: int * -> const int *: 1
 
 void bar(const int*);
 void foo() {
@@ -41,7 +41,7 @@ void foo() {
 }
 
 // CHECK: Function createX
-// CHECK-NEXT; Abrakadabra -> X: 1
+// CHECK-NEXT: int -> X: 1
 
 class X {
 	int x;

--- a/clang/test/compiler-course/drozhdinov_d_clangast_var3_test/test.cpp
+++ b/clang/test/compiler-course/drozhdinov_d_clangast_var3_test/test.cpp
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/CastCounter_DrozhdinovD_FIIT1_ClangAST%pluginext -plugin CastCounter %s -fsyntax-only 2>&1 | FileCheck %s
+
+// CHECK: Function `sum`
+// CHECK-NEXT: float -> double: 1
+// CHECK-NEXT: int -> float: 1
+
+// CHECK-NEXT: Function `mul`
+// CHECK-NEXT: double -> int: 1
+// CHECK-NEXT: float -> double: 1
+// CHECK-NEXT: float -> int: 1
+
+double sum(int a, float b) {
+	return a + b;
+}
+
+int mul(float a, float b) {
+	return a + sum(a, b);
+}

--- a/clang/test/compiler-course/drozhdinov_d_clangast_var3_test/test.cpp
+++ b/clang/test/compiler-course/drozhdinov_d_clangast_var3_test/test.cpp
@@ -1,13 +1,14 @@
 // RUN: %clang_cc1 -load %llvmshlibdir/CastCounter_DrozhdinovD_FIIT1_ClangAST%pluginext -plugin CastCounter %s -fsyntax-only 2>&1 | FileCheck %s
 
-// CHECK: Function `sum`
+// CHECK: Function sum
 // CHECK-NEXT: float -> double: 1
 // CHECK-NEXT: int -> float: 1
 
-// CHECK-NEXT: Function `mul`
+// CHECK: Function mul
 // CHECK-NEXT: double -> int: 1
 // CHECK-NEXT: float -> double: 1
 // CHECK-NEXT: float -> int: 1
+
 
 double sum(int a, float b) {
 	return a + b;


### PR DESCRIPTION
Clang плагин `CastCounter` реализует одноимённый класс, наследованный от `RecursiveASTVisitor` и выполняющий обход AST, выявляя случаи неявного приведения типов. В классе `CastCounter` реализованы методы:

- `VisitFunctionDecl`, получающий имя функции, в которую попали при обходе;

- `VisitCXXConstructExpr`, проверяющий случаи, когда аргумент передаётся в конструктор и вызывает преобразование

- `VisitImplicitCastExpr`, анализирующий неявные преобразования (игнорирует LValueToRValue, FunctionToPointerDecay)

- `getResult` выводит информацию о найденных преобразованиях.

Информация о преобразованиях содержится в мапе `CastMap`. Класс `CastCounterConsumer` управляет запуском обхода AST и вызывает `getResult`. Класс `CastCounterAction` регистрирует плагин в компиляторе Clang.

Тест для плагина выполнен согласно образцам `example`.