### PR TITLE
Резанцева Анастасия. Лабораторная работа 1: Clang AST. Вариант 4.

### DIFF
--- a/clang/compiler-course/rezantseva_a_prefixes/CMakeLists.txt
+++ b/clang/compiler-course/rezantseva_a_prefixes/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "PrefixesPlugin")
+set(Student "RezantsevaAnastasia")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes.cpp
+++ b/clang/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes.cpp
@@ -1,0 +1,47 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+class ExampleVisitor final : public clang::RecursiveASTVisitor<ExampleVisitor> {
+public:
+  explicit ExampleVisitor(clang::ASTContext *context) : m_context(context) {}
+  bool VisitFunctionDecl(clang::FunctionDecl *func) {
+    func->dump();
+    return true;
+  }
+
+private:
+  clang::ASTContext *m_context;
+};
+
+class ExampleConsumer final : public clang::ASTConsumer {
+public:
+  explicit ExampleConsumer(clang::ASTContext *context) : m_visitor(context) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+  }
+
+private:
+  ExampleVisitor m_visitor;
+};
+
+class ExampleAction final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    return std::make_unique<ExampleConsumer>(&ci.getASTContext());
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+};
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<ExampleAction>
+    X("example_plugin", "Description plugin");

--- a/clang/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes.cpp
+++ b/clang/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes.cpp
@@ -16,7 +16,7 @@ public:
     if (!var) {
       return true;
     }
-    if (var.getName().empty()) {
+    if (var->getName().empty()) {
       return true;
     }
     std::string prefix;
@@ -40,7 +40,7 @@ public:
     if (!param) {
       return true;
     }
-    if (param.getName().empty()) {
+    if (param->getName().empty()) {
       return true;
     }
     std::string newName = "param_" + param->getName().str();
@@ -57,7 +57,7 @@ public:
     if (!decl) {
       return true;
     }
-    if (decl.getName().empty()) {
+    if (decl->getName().empty()) {
       return true;
     }
 

--- a/clang/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes.cpp
+++ b/clang/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes.cpp
@@ -13,6 +13,12 @@ public:
       : m_rewriter(rewriter) {}
 
   bool VisitVarDecl(clang::VarDecl *var) {
+    if (!var) {
+      return true;
+    }
+    if (var.getName().empty()) {
+      return true;
+    }
     std::string prefix;
     if (var->isStaticLocal()) {
       prefix = "static_";
@@ -31,6 +37,12 @@ public:
   }
 
   bool VisitParmVarDecl(clang::ParmVarDecl *param) {
+    if (!param) {
+      return true;
+    }
+    if (param.getName().empty()) {
+      return true;
+    }
     std::string newName = "param_" + param->getName().str();
     renameVar(param, newName);
     m_renamedVars[param] = newName;
@@ -38,7 +50,18 @@ public:
   }
 
   bool VisitDeclRefExpr(clang::DeclRefExpr *expr) {
-    if (auto *var = clang::dyn_cast<clang::VarDecl>(expr->getDecl())) {
+    if (!expr) {
+      return true;
+    }
+    auto *decl = expr->getDecl();
+    if (!decl) {
+      return true;
+    }
+    if (decl.getName().empty()) {
+      return true;
+    }
+
+    if (auto *var = clang::dyn_cast<clang::VarDecl>(decl)) {
       auto it = m_renamedVars.find(var);
       if (it != m_renamedVars.end()) {
         m_rewriter.ReplaceText(expr->getLocation(), var->getName().size(),

--- a/clang/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes.cpp
+++ b/clang/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes.cpp
@@ -4,6 +4,7 @@
 #include "clang/Frontend/FrontendPluginRegistry.h"
 #include "clang/Rewrite/Core/Rewriter.h"
 #include "llvm/Support/raw_ostream.h"
+#include <unordered_map>
 
 namespace {
     class PrefixVisitor : public clang::RecursiveASTVisitor<PrefixVisitor> {
@@ -12,29 +13,38 @@ namespace {
             : m_rewriter(rewriter) {}
 
         bool VisitVarDecl(clang::VarDecl* var) {
-            if (var->isLocalVarDecl()) {
-                renameVar(var, "local_");
+            std::string prefix;
+            if (var->isStaticLocal()) {
+                prefix = "static_";
             }
-            else if (var->isStaticLocal()) {
-                renameVar(var, "static_");
+            else if (var->isLocalVarDecl()) {
+                prefix = "local_";
             }
             else if (var->hasGlobalStorage()) {
-                renameVar(var, "global_");
+                prefix = "global_";
+            }
+
+            if (!prefix.empty()) {
+                std::string newName = prefix + var->getName().str();
+                renameVar(var, newName);
+                m_renamedVars[var] = newName;
             }
             return true;
         }
 
         bool VisitParmVarDecl(clang::ParmVarDecl* param) {
-            renameVar(param, "param_");
+            std::string newName = "param_" + param->getName().str();
+            renameVar(param, newName);
+            m_renamedVars[param] = newName;
             return true;
         }
 
-        bool VisitCallExpr(clang::CallExpr* call) {
-            for (auto* arg : call->arguments()) {
-                if (auto* declRef = clang::dyn_cast<clang::DeclRefExpr>(arg)) {
-                    if (auto* var = clang::dyn_cast<clang::VarDecl>(declRef->getDecl())) {
-                        renameVar(var, getPrefixForVar(var));
-                    }
+        bool VisitDeclRefExpr(clang::DeclRefExpr* expr) {
+            if (auto* var = clang::dyn_cast<clang::VarDecl>(expr->getDecl())) {
+                auto it = m_renamedVars.find(var);
+                if (it != m_renamedVars.end()) {
+
+                    m_rewriter.ReplaceText(expr->getLocation(), var->getName().size(), it->second);
                 }
             }
             return true;
@@ -42,23 +52,10 @@ namespace {
 
     private:
         clang::Rewriter& m_rewriter;
+        std::unordered_map<clang::VarDecl*, std::string> m_renamedVars;
 
-        void renameVar(clang::VarDecl* var, const std::string& prefix) {
-            std::string newName = prefix + var->getName().str();
+        void renameVar(clang::VarDecl* var, const std::string& newName) {
             m_rewriter.ReplaceText(var->getLocation(), var->getName().size(), newName);
-        }
-
-        std::string getPrefixForVar(clang::VarDecl* var) {
-            if (var->isLocalVarDecl()) {
-                return "local_";
-            }
-            else if (var->isStaticLocal()) {
-                return "static_";
-            }
-            else if (var->hasGlobalStorage()) {
-                return "global_";
-            }
-            return "";
         }
     };
 
@@ -81,19 +78,33 @@ namespace {
     public:
         std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(
             clang::CompilerInstance& ci, llvm::StringRef) override {
+
+            if (m_shouldExit) {
+                return nullptr;
+            }
+
             m_rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
             return std::make_unique<PrefixConsumer>(&ci.getASTContext(), m_rewriter);
         }
-
         bool ParseArgs(const clang::CompilerInstance& ci,
                        const std::vector<std::string>& args) override {
+            for (const auto& arg : args) {
+                if (arg == "--help") {
+                    llvm::outs() << "PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST:\n"
+                        << "This plugin adds appropriate prefixes to variables and parameters in the code.\n"
+                        << "Usage: -Xclang -plugin-arg-PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST --help\n";
+                    m_shouldExit = true;
+                    return true;
+                }
+            }
             return true;
         }
 
     private:
         clang::Rewriter m_rewriter;
+        bool m_shouldExit = false;
     };
-}// namespace
+} // namespace
 
 static clang::FrontendPluginRegistry::Add<PrefixAction>
 X("PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST", "Adds appropriate prefixes to objects and parameters");

--- a/clang/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes.cpp
+++ b/clang/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes.cpp
@@ -2,46 +2,98 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Rewrite/Core/Rewriter.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace {
-class ExampleVisitor final : public clang::RecursiveASTVisitor<ExampleVisitor> {
-public:
-  explicit ExampleVisitor(clang::ASTContext *context) : m_context(context) {}
-  bool VisitFunctionDecl(clang::FunctionDecl *func) {
-    func->dump();
-    return true;
-  }
+    class PrefixVisitor : public clang::RecursiveASTVisitor<PrefixVisitor> {
+    public:
+        explicit PrefixVisitor(clang::ASTContext* context, clang::Rewriter& rewriter)
+            : m_rewriter(rewriter) {}
 
-private:
-  clang::ASTContext *m_context;
-};
+        bool VisitVarDecl(clang::VarDecl* var) {
+            if (var->isLocalVarDecl()) {
+                renameVar(var, "local_");
+            }
+            else if (var->isStaticLocal()) {
+                renameVar(var, "static_");
+            }
+            else if (var->hasGlobalStorage()) {
+                renameVar(var, "global_");
+            }
+            return true;
+        }
 
-class ExampleConsumer final : public clang::ASTConsumer {
-public:
-  explicit ExampleConsumer(clang::ASTContext *context) : m_visitor(context) {}
+        bool VisitParmVarDecl(clang::ParmVarDecl* param) {
+            renameVar(param, "param_");
+            return true;
+        }
 
-  void HandleTranslationUnit(clang::ASTContext &context) override {
-    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
-  }
+        bool VisitCallExpr(clang::CallExpr* call) {
+            for (auto* arg : call->arguments()) {
+                if (auto* declRef = clang::dyn_cast<clang::DeclRefExpr>(arg)) {
+                    if (auto* var = clang::dyn_cast<clang::VarDecl>(declRef->getDecl())) {
+                        renameVar(var, getPrefixForVar(var));
+                    }
+                }
+            }
+            return true;
+        }
 
-private:
-  ExampleVisitor m_visitor;
-};
+    private:
+        clang::Rewriter& m_rewriter;
 
-class ExampleAction final : public clang::PluginASTAction {
-public:
-  std::unique_ptr<clang::ASTConsumer>
-  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
-    return std::make_unique<ExampleConsumer>(&ci.getASTContext());
-  }
+        void renameVar(clang::VarDecl* var, const std::string& prefix) {
+            std::string newName = prefix + var->getName().str();
+            m_rewriter.ReplaceText(var->getLocation(), var->getName().size(), newName);
+        }
 
-  bool ParseArgs(const clang::CompilerInstance &ci,
-                 const std::vector<std::string> &args) override {
-    return true;
-  }
-};
-} // namespace
+        std::string getPrefixForVar(clang::VarDecl* var) {
+            if (var->isLocalVarDecl()) {
+                return "local_";
+            }
+            else if (var->isStaticLocal()) {
+                return "static_";
+            }
+            else if (var->hasGlobalStorage()) {
+                return "global_";
+            }
+            return "";
+        }
+    };
 
-static clang::FrontendPluginRegistry::Add<ExampleAction>
-    X("example_plugin", "Description plugin");
+    class PrefixConsumer : public clang::ASTConsumer {
+    public:
+        explicit PrefixConsumer(clang::ASTContext* context, clang::Rewriter& rewriter)
+            : m_visitor(context, rewriter), m_rewriter(rewriter) {}
+
+        void HandleTranslationUnit(clang::ASTContext& context) override {
+            m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+            m_rewriter.getEditBuffer(context.getSourceManager().getMainFileID()).write(llvm::outs());
+        }
+
+    private:
+        PrefixVisitor m_visitor;
+        clang::Rewriter& m_rewriter;
+    };
+
+    class PrefixAction : public clang::PluginASTAction {
+    public:
+        std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(
+            clang::CompilerInstance& ci, llvm::StringRef) override {
+            m_rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
+            return std::make_unique<PrefixConsumer>(&ci.getASTContext(), m_rewriter);
+        }
+
+        bool ParseArgs(const clang::CompilerInstance& ci,
+                       const std::vector<std::string>& args) override {
+            return true;
+        }
+
+    private:
+        clang::Rewriter m_rewriter;
+    };
+}// namespace
+
+static clang::FrontendPluginRegistry::Add<PrefixAction>
+X("PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST", "Adds appropriate prefixes to objects and parameters");

--- a/clang/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes.cpp
+++ b/clang/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes.cpp
@@ -7,104 +7,104 @@
 #include <unordered_map>
 
 namespace {
-    class PrefixVisitor : public clang::RecursiveASTVisitor<PrefixVisitor> {
-    public:
-        explicit PrefixVisitor(clang::ASTContext* context, clang::Rewriter& rewriter)
-            : m_rewriter(rewriter) {}
+class PrefixVisitor : public clang::RecursiveASTVisitor<PrefixVisitor> {
+public:
+  explicit PrefixVisitor(clang::ASTContext *context, clang::Rewriter &rewriter)
+      : m_rewriter(rewriter) {}
 
-        bool VisitVarDecl(clang::VarDecl* var) {
-            std::string prefix;
-            if (var->isStaticLocal()) {
-                prefix = "static_";
-            }
-            else if (var->isLocalVarDecl()) {
-                prefix = "local_";
-            }
-            else if (var->hasGlobalStorage()) {
-                prefix = "global_";
-            }
+  bool VisitVarDecl(clang::VarDecl *var) {
+    std::string prefix;
+    if (var->isStaticLocal()) {
+      prefix = "static_";
+    } else if (var->isLocalVarDecl()) {
+      prefix = "local_";
+    } else if (var->hasGlobalStorage()) {
+      prefix = "global_";
+    }
 
-            if (!prefix.empty()) {
-                std::string newName = prefix + var->getName().str();
-                renameVar(var, newName);
-                m_renamedVars[var] = newName;
-            }
-            return true;
-        }
+    if (!prefix.empty()) {
+      std::string newName = prefix + var->getName().str();
+      renameVar(var, newName);
+      m_renamedVars[var] = newName;
+    }
+    return true;
+  }
 
-        bool VisitParmVarDecl(clang::ParmVarDecl* param) {
-            std::string newName = "param_" + param->getName().str();
-            renameVar(param, newName);
-            m_renamedVars[param] = newName;
-            return true;
-        }
+  bool VisitParmVarDecl(clang::ParmVarDecl *param) {
+    std::string newName = "param_" + param->getName().str();
+    renameVar(param, newName);
+    m_renamedVars[param] = newName;
+    return true;
+  }
 
-        bool VisitDeclRefExpr(clang::DeclRefExpr* expr) {
-            if (auto* var = clang::dyn_cast<clang::VarDecl>(expr->getDecl())) {
-                auto it = m_renamedVars.find(var);
-                if (it != m_renamedVars.end()) {
+  bool VisitDeclRefExpr(clang::DeclRefExpr *expr) {
+    if (auto *var = clang::dyn_cast<clang::VarDecl>(expr->getDecl())) {
+      auto it = m_renamedVars.find(var);
+      if (it != m_renamedVars.end()) {
+        m_rewriter.ReplaceText(expr->getLocation(), var->getName().size(),
+                               it->second);
+      }
+    }
+    return true;
+  }
 
-                    m_rewriter.ReplaceText(expr->getLocation(), var->getName().size(), it->second);
-                }
-            }
-            return true;
-        }
+private:
+  clang::Rewriter &m_rewriter;
+  std::unordered_map<clang::VarDecl *, std::string> m_renamedVars;
 
-    private:
-        clang::Rewriter& m_rewriter;
-        std::unordered_map<clang::VarDecl*, std::string> m_renamedVars;
+  void renameVar(clang::VarDecl *var, const std::string &newName) {
+    m_rewriter.ReplaceText(var->getLocation(), var->getName().size(), newName);
+  }
+};
 
-        void renameVar(clang::VarDecl* var, const std::string& newName) {
-            m_rewriter.ReplaceText(var->getLocation(), var->getName().size(), newName);
-        }
-    };
+class PrefixConsumer : public clang::ASTConsumer {
+public:
+  explicit PrefixConsumer(clang::ASTContext *context, clang::Rewriter &rewriter)
+      : m_visitor(context, rewriter), m_rewriter(rewriter) {}
 
-    class PrefixConsumer : public clang::ASTConsumer {
-    public:
-        explicit PrefixConsumer(clang::ASTContext* context, clang::Rewriter& rewriter)
-            : m_visitor(context, rewriter), m_rewriter(rewriter) {}
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+    m_rewriter.getEditBuffer(context.getSourceManager().getMainFileID())
+        .write(llvm::outs());
+  }
 
-        void HandleTranslationUnit(clang::ASTContext& context) override {
-            m_visitor.TraverseDecl(context.getTranslationUnitDecl());
-            m_rewriter.getEditBuffer(context.getSourceManager().getMainFileID()).write(llvm::outs());
-        }
+private:
+  PrefixVisitor m_visitor;
+  clang::Rewriter &m_rewriter;
+};
 
-    private:
-        PrefixVisitor m_visitor;
-        clang::Rewriter& m_rewriter;
-    };
+class PrefixAction : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    if (m_shouldExit) {
+      return nullptr;
+    }
 
-    class PrefixAction : public clang::PluginASTAction {
-    public:
-        std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(
-            clang::CompilerInstance& ci, llvm::StringRef) override {
+    m_rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
+    return std::make_unique<PrefixConsumer>(&ci.getASTContext(), m_rewriter);
+  }
 
-            if (m_shouldExit) {
-                return nullptr;
-            }
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    for (const auto &arg : args) {
+      if (arg == "--help") {
+        llvm::outs() << "PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST:\n";
+        llvm::outs() << "This plugin adds appropriate prefixes to variables "
+                        "and parameters in the code.\n";
+        m_shouldExit = true;
+        return true;
+      }
+    }
+    return true;
+  }
 
-            m_rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
-            return std::make_unique<PrefixConsumer>(&ci.getASTContext(), m_rewriter);
-        }
-        bool ParseArgs(const clang::CompilerInstance& ci,
-                       const std::vector<std::string>& args) override {
-            for (const auto& arg : args) {
-                if (arg == "--help") {
-                    llvm::outs() << "PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST:\n"
-                        << "This plugin adds appropriate prefixes to variables and parameters in the code.\n"
-                        << "Usage: -Xclang -plugin-arg-PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST --help\n";
-                    m_shouldExit = true;
-                    return true;
-                }
-            }
-            return true;
-        }
-
-    private:
-        clang::Rewriter m_rewriter;
-        bool m_shouldExit = false;
-    };
+private:
+  clang::Rewriter m_rewriter;
+  bool m_shouldExit = false;
+};
 } // namespace
 
 static clang::FrontendPluginRegistry::Add<PrefixAction>
-X("PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST", "Adds appropriate prefixes to objects and parameters");
+    X("PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST",
+      "Adds appropriate prefixes to objects and parameters");

--- a/clang/test/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes_test.cpp
+++ b/clang/test/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes_test.cpp
@@ -1,13 +1,16 @@
 // RUN: %clang_cc1 -load %llvmshlibdir/PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST%pluginext -plugin PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST -fsyntax-only %s 2>&1 | FileCheck %s
 
 // CHECK: int global_var1 = 0;
-// CHECK-NEXT: int static foo(int param_a, int param_b) {
+// CHECK-NEXT: int foo(int param_a, int param_b) {
 // CHECK-NEXT:   static int static_var2 = 0;
 // CHECK-NEXT:   int local_var3 = 123;
 // CHECK-NEXT:   ++static_var2;
 // CHECK-NEXT:   return param_a + param_b + global_var1 + static_var2 + local_var3;
 // CHECK-NEXT: }
-// CHECK-NEXT: int static global_check = foo(1, a(var3));
+// CHECK-NEXT: int static global_var4 = 3;
+//CHECK-NEXT:  int static glocbal_var5 = foo(1, global_var4);
+
+
 
 
 int var1 = 0;
@@ -19,4 +22,5 @@ int foo(int a, int b) {
     return a + b + var1 + var2 + var3;
 }
 
-int static check = foo(1, a(var3));
+int static var4 = 3;
+int static var5 = foo(1, var4);

--- a/clang/test/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes_test.cpp
+++ b/clang/test/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes_test.cpp
@@ -23,4 +23,3 @@ int static var5 = foo(1, var4);
 // RUN: %clang_cc1 -load %llvmshlibdir/PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST%pluginext -plugin PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST -plugin-arg-PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST --help -fsyntax-only %s 2>&1 | FileCheck --match-full-lines %s --check-prefix=CHECK-HELP
 // CHECK-HELP: PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST:
 // CHECK-HELP-NEXT: This plugin adds appropriate prefixes to variables and parameters in the code.
-// CHECK-HELP-NEXT: Usage: -Xclang -plugin-arg-PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST --help

--- a/clang/test/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes_test.cpp
+++ b/clang/test/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes_test.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -load %llvmshlibdir/PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST%pluginext -plugin PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST -fsyntax-only %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -load %llvmshlibdir/PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST%pluginext -plugin PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST -fsyntax-only %s 2>&1 | FileCheck --match-full-lines %s
 
 // CHECK: int global_var1 = 0;
 // CHECK-NEXT: int foo(int param_a, int param_b) {
@@ -8,19 +8,19 @@
 // CHECK-NEXT:   return param_a + param_b + global_var1 + static_var2 + local_var3;
 // CHECK-NEXT: }
 // CHECK-NEXT: int static global_var4 = 3;
-//CHECK-NEXT:  int static glocbal_var5 = foo(1, global_var4);
-
-
-
+//CHECK:  int static global_var5 = foo(1, global_var4);
 
 int var1 = 0;
-
 int foo(int a, int b) {
     static int var2 = 0;
     int var3 = 123;
     ++var2;
     return a + b + var1 + var2 + var3;
 }
-
 int static var4 = 3;
 int static var5 = foo(1, var4);
+
+// RUN: %clang_cc1 -load %llvmshlibdir/PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST%pluginext -plugin PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST -plugin-arg-PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST --help -fsyntax-only %s 2>&1 | FileCheck --match-full-lines %s --check-prefix=CHECK-HELP
+// CHECK-HELP: PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST:
+// CHECK-HELP-NEXT: This plugin adds appropriate prefixes to variables and parameters in the code.
+// CHECK-HELP-NEXT: Usage: -Xclang -plugin-arg-PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST --help

--- a/clang/test/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes_test.cpp
+++ b/clang/test/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes_test.cpp
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST%pluginext -plugin PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST -fsyntax-only %s 2>&1 | FileCheck %s
+
+// CHECK: int global_var1 = 0;
+// CHECK-NEXT: int static foo(int param_a, int param_b) {
+// CHECK-NEXT:   static int static_var2 = 0;
+// CHECK-NEXT:   int local_var3 = 123;
+// CHECK-NEXT:   ++static_var2;
+// CHECK-NEXT:   return param_a + param_b + global_var1 + static_var2 + local_var3;
+// CHECK-NEXT: }
+// CHECK-NEXT: int static global_check = foo(1, a(var3));
+
+
+int var1 = 0;
+
+int foo(int a, int b) {
+    static int var2 = 0;
+    int var3 = 123;
+    ++var2;
+    return a + b + var1 + var2 + var3;
+}
+
+int static check = foo(1, a(var3));

--- a/clang/test/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes_test.cpp
+++ b/clang/test/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes_test.cpp
@@ -8,7 +8,7 @@
 // CHECK-NEXT:   return param_a + param_b + global_var1 + static_var2 + local_var3;
 // CHECK-NEXT: }
 // CHECK-NEXT: int static global_var4 = 3;
-//CHECK:  int static global_var5 = foo(1, global_var4);
+// CHECK-NEXT:  int static global_var5 = foo(1, global_var4);
 
 int var1 = 0;
 int foo(int a, int b) {

--- a/clang/test/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes_test.cpp
+++ b/clang/test/compiler-course/rezantseva_a_prefixes/rezantseva_a_prefixes_test.cpp
@@ -23,3 +23,4 @@ int static var5 = foo(1, var4);
 // RUN: %clang_cc1 -load %llvmshlibdir/PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST%pluginext -plugin PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST -plugin-arg-PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST --help -fsyntax-only %s 2>&1 | FileCheck --match-full-lines %s --check-prefix=CHECK-HELP
 // CHECK-HELP: PrefixesPlugin_RezantsevaAnastasia_FIIT1_ClangAST:
 // CHECK-HELP-NEXT: This plugin adds appropriate prefixes to variables and parameters in the code.
+ 


### PR DESCRIPTION
Реализован Clang плагин, который добавляет к статическим, локальным, глобальным объектам и параметрам функции
соответствующие префиксы (static_, local_, global_, param_). 

Класс PrefixVisitor обходит AST (Abstract Syntax Tree) с помощью RecursiveASTVisitor и добавляет префиксы к переменным и параметрам в зависимости от их типа, а также обновляет имена переменных в вызовах функций, чтобы они соответствовали новым именам с префиксами. 

**Используемые API LLVM/Clang:**

- RecursiveASTVisitor для обхода AST
- VarDecl для работы с переменными
- ParmVarDecl для работы с параметрами функций
- CallExpr для анализа вызовов функций
- Rewriter для модификации исходного кода