### PR TITLE
Соловьев Данила. Лабораторная работа 1: Clang AST. Вариант 2.

### DIFF
--- a/clang/compiler-course/solovyev_d_unused_variable/CMakeLists.txt
+++ b/clang/compiler-course/solovyev_d_unused_variable/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "UnusedVariable")
+set(Student "Solovyev_Danila")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/solovyev_d_unused_variable/solovyev_d_unused_variable_plugin.cpp
+++ b/clang/compiler-course/solovyev_d_unused_variable/solovyev_d_unused_variable_plugin.cpp
@@ -3,67 +3,79 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Rewrite/Core/Rewriter.h"
 #include "llvm/Support/raw_ostream.h"
-
 namespace {
 class UnusedVisitor final : public clang::RecursiveASTVisitor<UnusedVisitor> {
 public:
-  explicit UnusedVisitor(clang::ASTContext *context) : m_context(context) {}
+  explicit UnusedVisitor(clang::ASTContext *context, clang::Rewriter &Rewriter)
+      : m_context(context), MRewriter(Rewriter) {}
   bool VisitVarDecl(clang::VarDecl *var) {
     if (!var->isUsed() && !var->hasAttr<clang::UnusedAttr>()) {
-        var->addAttr(clang::UnusedAttr::Create(*m_context));
+      MRewriter.InsertText(var->getSourceRange().getBegin(),
+                           "[[maybe_unused]] ", true, true);
+      var->addAttr(clang::UnusedAttr::Create(*m_context));
     }
     return true;
   }
 
   bool VisitParmVarDecl(clang::ParmVarDecl *param) {
     if (!param->isUsed() && !param->hasAttr<clang::UnusedAttr>()) {
-        param->addAttr(clang::UnusedAttr::Create(*m_context));
+      MRewriter.InsertText(param->getSourceRange().getBegin(),
+                           "[[maybe_unused]] ", true, true);
+      param->addAttr(clang::UnusedAttr::Create(*m_context));
     }
     return true;
   }
+
 private:
+  clang::Rewriter &MRewriter;
   clang::ASTContext *m_context;
 };
 
-class DumpVisitor final : public clang::RecursiveASTVisitor<DumpVisitor> {
-    public:
-      explicit DumpVisitor(clang::ASTContext *context) : m_context(context) {}
-      bool VisitFunctionDecl(clang::FunctionDecl *func) {
-        func->dump();
-        return true;
-      }
-    private:
-      clang::ASTContext *m_context;
-    };
-
-class ExampleConsumer final : public clang::ASTConsumer {
+class UnusedConsumer final : public clang::ASTConsumer {
 public:
-  explicit ExampleConsumer(clang::ASTContext *context) : um_visitor(context),dm_visitor(context) {}
+  explicit UnusedConsumer(clang::ASTContext *context, clang::Rewriter &Rewriter)
+      : um_visitor(context, Rewriter) {}
 
   void HandleTranslationUnit(clang::ASTContext &context) override {
     um_visitor.TraverseDecl(context.getTranslationUnitDecl());
-    dm_visitor.TraverseDecl(context.getTranslationUnitDecl());
   }
 
 private:
   UnusedVisitor um_visitor;
-  DumpVisitor dm_visitor;
 };
 
-class ExampleAction final : public clang::PluginASTAction {
+class UnusedAction final : public clang::PluginASTAction {
 public:
   std::unique_ptr<clang::ASTConsumer>
   CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
-    return std::make_unique<ExampleConsumer>(&ci.getASTContext());
+    MRewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
+    return std::make_unique<UnusedConsumer>(&ci.getASTContext(), MRewriter);
   }
 
   bool ParseArgs(const clang::CompilerInstance &ci,
                  const std::vector<std::string> &args) override {
+    for (const auto &arg : args) {
+      if (arg == "--help") {
+        llvm::outs() << "Marking unused variables and function parameters as "
+                        "[[maybe_unused]]\n";
+        return true;
+      }
+    }
     return true;
   }
+
+  void EndSourceFileAction() override {
+    MRewriter.getEditBuffer(MRewriter.getSourceMgr().getMainFileID())
+        .write(llvm::outs());
+  }
+
+private:
+  clang::Rewriter MRewriter;
 };
 } // namespace
 
-static clang::FrontendPluginRegistry::Add<ExampleAction>
-    X("unused_variable_plugin", "Description plugin");
+static clang::FrontendPluginRegistry::Add<UnusedAction>
+    X("unused_variable_plugin",
+      "Marking unused variables and function parameters as [[maybe_unused]]");

--- a/clang/compiler-course/solovyev_d_unused_variable/solovyev_d_unused_variable_plugin.cpp
+++ b/clang/compiler-course/solovyev_d_unused_variable/solovyev_d_unused_variable_plugin.cpp
@@ -1,0 +1,69 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/Attr.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+class UnusedVisitor final : public clang::RecursiveASTVisitor<UnusedVisitor> {
+public:
+  explicit UnusedVisitor(clang::ASTContext *context) : m_context(context) {}
+  bool VisitVarDecl(clang::VarDecl *var) {
+    if (!var->isUsed() && !var->hasAttr<clang::UnusedAttr>()) {
+        var->addAttr(clang::UnusedAttr::Create(*m_context));
+    }
+    return true;
+  }
+
+  bool VisitParmVarDecl(clang::ParmVarDecl *param) {
+    if (!param->isUsed() && !param->hasAttr<clang::UnusedAttr>()) {
+        param->addAttr(clang::UnusedAttr::Create(*m_context));
+    }
+    return true;
+  }
+private:
+  clang::ASTContext *m_context;
+};
+
+class DumpVisitor final : public clang::RecursiveASTVisitor<DumpVisitor> {
+    public:
+      explicit DumpVisitor(clang::ASTContext *context) : m_context(context) {}
+      bool VisitFunctionDecl(clang::FunctionDecl *func) {
+        func->dump();
+        return true;
+      }
+    private:
+      clang::ASTContext *m_context;
+    };
+
+class ExampleConsumer final : public clang::ASTConsumer {
+public:
+  explicit ExampleConsumer(clang::ASTContext *context) : um_visitor(context),dm_visitor(context) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    um_visitor.TraverseDecl(context.getTranslationUnitDecl());
+    dm_visitor.TraverseDecl(context.getTranslationUnitDecl());
+  }
+
+private:
+  UnusedVisitor um_visitor;
+  DumpVisitor dm_visitor;
+};
+
+class ExampleAction final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    return std::make_unique<ExampleConsumer>(&ci.getASTContext());
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+};
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<ExampleAction>
+    X("unused_variable_plugin", "Description plugin");

--- a/clang/test/compiler-course/solovyev_d_unused_variable/solovyev_d_unused_variable_test.cpp
+++ b/clang/test/compiler-course/solovyev_d_unused_variable/solovyev_d_unused_variable_test.cpp
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/UnusedVariable_Solovyev_Danila_FIIT3_ClangAST%pluginext -plugin unused_variable_plugin -fsyntax-only %s 2>&1 | FileCheck %s
+
+//CHECK: |-ParmVarDecl {{0x[0-9a-fA-F]+}} <col:23, col:27> col:27 c 'int'
+//CHECK-NEXT: | `-UnusedAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> maybe_unused
+
+//CHECK: `-VarDecl {{0x[0-9a-fA-F]+}} <col:5, col:20> col:12 value 'double' cinit
+//CHECK-NEXT:  |   |-FloatingLiteral {{0x[0-9a-fA-F]+}} <col:20> 'double' 0.000000e+00
+//CHECK-NEXT:  |   `-UnusedAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> maybe_unused
+
+int foo(int a, int b, int c) {
+    double value = 0.0;
+    return a + b;
+}
+
+//CHECK: |-ParmVarDecl {{0x[0-9a-fA-F]+}} <col:25, col:34> col:32 c 'double' cinit
+//CHECK-NEXT: | |-FloatingLiteral {{0x[0-9a-fA-F]+}} <col:34> 'double' 3.000000e+00
+//CHECK-NEXT: | `-UnusedAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> maybe_unused
+
+bool bar(int a, bool b, double c=3.0){
+    b=a++;
+    return true;
+}

--- a/clang/test/compiler-course/solovyev_d_unused_variable/solovyev_d_unused_variable_test.cpp
+++ b/clang/test/compiler-course/solovyev_d_unused_variable/solovyev_d_unused_variable_test.cpp
@@ -1,22 +1,31 @@
 // RUN: %clang_cc1 -load %llvmshlibdir/UnusedVariable_Solovyev_Danila_FIIT3_ClangAST%pluginext -plugin unused_variable_plugin -fsyntax-only %s 2>&1 | FileCheck %s
 
-//CHECK: |-ParmVarDecl {{0x[0-9a-fA-F]+}} <col:23, col:27> col:27 c 'int'
-//CHECK-NEXT: | `-UnusedAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> maybe_unused
-
-//CHECK: `-VarDecl {{0x[0-9a-fA-F]+}} <col:5, col:20> col:12 value 'double' cinit
-//CHECK-NEXT:  |   |-FloatingLiteral {{0x[0-9a-fA-F]+}} <col:20> 'double' 0.000000e+00
-//CHECK-NEXT:  |   `-UnusedAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> maybe_unused
+//CHECK: int foo(int a, int b, \[\[maybe_unused\]\] int c) {
+//CHECK:      \[\[maybe_unused\]\] double value = 0.0;
 
 int foo(int a, int b, int c) {
     double value = 0.0;
     return a + b;
 }
 
-//CHECK: |-ParmVarDecl {{0x[0-9a-fA-F]+}} <col:25, col:34> col:32 c 'double' cinit
-//CHECK-NEXT: | |-FloatingLiteral {{0x[0-9a-fA-F]+}} <col:34> 'double' 3.000000e+00
-//CHECK-NEXT: | `-UnusedAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> maybe_unused
+//CHECK: bool bar(int a, bool b, \[\[maybe_unused\]\] double c=3.0){
 
 bool bar(int a, bool b, double c=3.0){
     b=a++;
     return true;
 }
+
+//CHECK: \[\[maybe_unused\]\] int test;
+//CHECK: \[\[maybe_unused\]\] bool c=b;
+
+int test;
+int b=1;
+bool c=b;
+
+//CHECK: A(int a,\[\[maybe_unused\]\] int b){
+
+class A{
+    A(int a,int b){
+        a=1;
+    }
+};

--- a/clang/test/compiler-course/solovyev_d_unused_variable/solovyev_d_unused_variable_test.cpp
+++ b/clang/test/compiler-course/solovyev_d_unused_variable/solovyev_d_unused_variable_test.cpp
@@ -1,4 +1,7 @@
 // RUN: %clang_cc1 -load %llvmshlibdir/UnusedVariable_Solovyev_Danila_FIIT3_ClangAST%pluginext -plugin unused_variable_plugin -fsyntax-only %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -load %llvmshlibdir/UnusedVariable_Solovyev_Danila_FIIT3_ClangAST%pluginext -plugin unused_variable_plugin -plugin-arg-unused_variable_plugin --help 2>&1 | FileCheck --check-prefix=HELP %s
+
+//HELP:Marking unused variables and function parameters as {{\[\[maybe_unused\]\]}}
 
 //CHECK: int foo(int a, int b, \[\[maybe_unused\]\] int c) {
 //CHECK:      \[\[maybe_unused\]\] double value = 0.0;

--- a/clang/test/compiler-course/solovyev_d_unused_variable/solovyev_d_unused_variable_test_help.cpp
+++ b/clang/test/compiler-course/solovyev_d_unused_variable/solovyev_d_unused_variable_test_help.cpp
@@ -1,3 +1,0 @@
-// RUN: %clang_cc1 -load %llvmshlibdir/UnusedVariable_Solovyev_Danila_FIIT3_ClangAST%pluginext -plugin unused_variable_plugin -plugin-arg-unused_variable_plugin --help 2>&1 | FileCheck %s
-
-// CHECK:Marking unused variables and function parameters as {{\[\[maybe_unused\]\]}}

--- a/clang/test/compiler-course/solovyev_d_unused_variable/solovyev_d_unused_variable_test_help.cpp
+++ b/clang/test/compiler-course/solovyev_d_unused_variable/solovyev_d_unused_variable_test_help.cpp
@@ -1,0 +1,3 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/UnusedVariable_Solovyev_Danila_FIIT3_ClangAST%pluginext -plugin unused_variable_plugin -plugin-arg-unused_variable_plugin --help 2>&1 | FileCheck %s
+
+// CHECK:Marking unused variables and function parameters as {{\[\[maybe_unused\]\]}}


### PR DESCRIPTION
Плагин обходит все переменные и параметры функций и если данная переменная не используется, то помечает ее аттрибутом `maybe_unused`. После этого, плагин обходит все функции, делая `dump` их AST.
Обход реализован двумя обходчиками: `UnusedVisitor` и `DumpVisitor`.
Сначала вызывается `UnusedVisitor`, который помечает переменные и параметры функций, а затем вызывается `DumpVisitor` выводящий `dump` AST для всех функций, для проверки наличия аттрибута `maybe_unused` при помощи тестов.