### PR TITLE
Шкуринская Елена. Лабораторная работа 1. Clang AST. Вариант 4.

### DIFF
--- a/clang/compiler-course/shkurinskaya_e_var_renaming/CMakeLists.txt
+++ b/clang/compiler-course/shkurinskaya_e_var_renaming/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "ClangAST_4")
+set(Student "Shkurinskaya_Elena")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/shkurinskaya_e_var_renaming/shkurinskaya_e_var_renaming.cpp
+++ b/clang/compiler-course/shkurinskaya_e_var_renaming/shkurinskaya_e_var_renaming.cpp
@@ -26,7 +26,7 @@ public:
 
     if (newName != VD->getNameAsString()) {
       m_rewriter.ReplaceText(VD->getLocation(), VD->getNameAsString().size(),
-                        	 newName);
+                             newName);
     }
     return true;
   }
@@ -37,7 +37,7 @@ public:
 
     std::string newName = "param_" + PVD->getNameAsString();
     m_rewriter.ReplaceText(PVD->getLocation(), PVD->getNameAsString().size(),
-	                       newName);
+	                   newName);
     return true;
   }
 
@@ -73,7 +73,7 @@ public:
 
   void EndSourceFileAction() override {
     m_rewriter.getEditBuffer(m_rewriter.getSourceMgr().getMainFileID())
-	    .write(llvm::outs());
+        .write(llvm::outs());
   }
 
 private:

--- a/clang/compiler-course/shkurinskaya_e_var_renaming/shkurinskaya_e_var_renaming.cpp
+++ b/clang/compiler-course/shkurinskaya_e_var_renaming/shkurinskaya_e_var_renaming.cpp
@@ -16,7 +16,6 @@ public:
       return true;
 
     std::string newName = VD->getNameAsString();
-	   llvm::outs() << "Checking variable: " << oldName << "\n";
     if (VD->isStaticLocal()) {
       newName = "static_" + newName;
     } else if (VD->hasGlobalStorage() && !VD->isStaticLocal()) {
@@ -26,8 +25,8 @@ public:
     }
 
     if (newName != VD->getNameAsString()) {
-      llvm::outs() << "Renaming " << VD->getNameAsString() << " to " << newName << "\n";
-      m_rewriter.ReplaceText(VD->getLocation(), VD->getNameAsString().size(), newName);
+      m_rewriter.ReplaceText(VD->getLocation(), VD->getNameAsString().size(),
+                        	 newName);
     }
     return true;
   }
@@ -37,8 +36,8 @@ public:
       return true;
 
     std::string newName = "param_" + PVD->getNameAsString();
-    llvm::outs() << "Renaming " << PVD->getNameAsString() << " to " << newName << "\n";
-    m_rewriter.ReplaceText(PVD->getLocation(), PVD->getNameAsString().size(), newName);
+    m_rewriter.ReplaceText(PVD->getLocation(), PVD->getNameAsString().size(),
+	                       newName);
     return true;
   }
 
@@ -73,7 +72,8 @@ public:
   }
 
   void EndSourceFileAction() override {
-    m_rewriter.getEditBuffer(m_rewriter.getSourceMgr().getMainFileID()).write(llvm::outs());
+    m_rewriter.getEditBuffer(m_rewriter.getSourceMgr().getMainFileID())
+	    .write(llvm::outs());
   }
 
 private:

--- a/clang/compiler-course/shkurinskaya_e_var_renaming/shkurinskaya_e_var_renaming.cpp
+++ b/clang/compiler-course/shkurinskaya_e_var_renaming/shkurinskaya_e_var_renaming.cpp
@@ -37,7 +37,7 @@ public:
 
     std::string newName = "param_" + PVD->getNameAsString();
     m_rewriter.ReplaceText(PVD->getLocation(), PVD->getNameAsString().size(),
-	                   newName);
+	                    newName);
     return true;
   }
 

--- a/clang/compiler-course/shkurinskaya_e_var_renaming/shkurinskaya_e_var_renaming.cpp
+++ b/clang/compiler-course/shkurinskaya_e_var_renaming/shkurinskaya_e_var_renaming.cpp
@@ -37,7 +37,7 @@ public:
 
     std::string newName = "param_" + PVD->getNameAsString();
     m_rewriter.ReplaceText(PVD->getLocation(), PVD->getNameAsString().size(),
-	                    newName);
+                           newName);
     return true;
   }
 

--- a/clang/compiler-course/shkurinskaya_e_var_renaming/shkurinskaya_e_var_renaming.cpp
+++ b/clang/compiler-course/shkurinskaya_e_var_renaming/shkurinskaya_e_var_renaming.cpp
@@ -1,0 +1,85 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+class PrefixVisitor final : public clang::RecursiveASTVisitor<PrefixVisitor> {
+public:
+  explicit PrefixVisitor(clang::ASTContext *context, clang::Rewriter &rewriter)
+      : m_rewriter(rewriter) {}
+
+  bool VisitVarDecl(clang::VarDecl *VD) {
+    if (VD->getLocation().isInvalid() || !VD->getIdentifier())
+      return true;
+
+    std::string newName = VD->getNameAsString();
+	   llvm::outs() << "Checking variable: " << oldName << "\n";
+    if (VD->isStaticLocal()) {
+      newName = "static_" + newName;
+    } else if (VD->hasGlobalStorage() && !VD->isStaticLocal()) {
+      newName = "global_" + newName;
+    } else if (VD->isLocalVarDecl() && !VD->isStaticLocal()) {
+      newName = "local_" + newName;
+    }
+
+    if (newName != VD->getNameAsString()) {
+      llvm::outs() << "Renaming " << VD->getNameAsString() << " to " << newName << "\n";
+      m_rewriter.ReplaceText(VD->getLocation(), VD->getNameAsString().size(), newName);
+    }
+    return true;
+  }
+
+  bool VisitParmVarDecl(clang::ParmVarDecl *PVD) {
+    if (PVD->getLocation().isInvalid() || !PVD->getIdentifier())
+      return true;
+
+    std::string newName = "param_" + PVD->getNameAsString();
+    llvm::outs() << "Renaming " << PVD->getNameAsString() << " to " << newName << "\n";
+    m_rewriter.ReplaceText(PVD->getLocation(), PVD->getNameAsString().size(), newName);
+    return true;
+  }
+
+private:
+  clang::Rewriter &m_rewriter;
+};
+
+class PrefixConsumer final : public clang::ASTConsumer {
+public:
+  explicit PrefixConsumer(clang::ASTContext *context, clang::Rewriter &rewriter)
+      : m_visitor(context, rewriter) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+  }
+
+private:
+  PrefixVisitor m_visitor;
+};
+
+class PrefixAction final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    m_rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
+    return std::make_unique<PrefixConsumer>(&ci.getASTContext(), m_rewriter);
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+
+  void EndSourceFileAction() override {
+    m_rewriter.getEditBuffer(m_rewriter.getSourceMgr().getMainFileID()).write(llvm::outs());
+  }
+
+private:
+  clang::Rewriter m_rewriter;
+};
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<PrefixAction>
+    X("ClangAST_4", "Adding prefixes to variables");

--- a/clang/test/compiler-course/shkurinskaya_e_var_renaming/shkurinskaya_e_var_renaming_test.cpp
+++ b/clang/test/compiler-course/shkurinskaya_e_var_renaming/shkurinskaya_e_var_renaming_test.cpp
@@ -1,0 +1,40 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/ClangAST_4_Shkurinskaya_Elena_FIIT2_ClangAST%pluginext -plugin ClangAST_4 -fsyntax-only %s 2>&1 | FileCheck %s
+
+// Проверка глобальных переменных
+// CHECK: int global_var = 42;
+// CHECK: float global_pi = 3.1415;
+// CHECK: static double global_static_value = 2.71828;
+
+// Проверка параметров функций
+// CHECK: void process(param_int a, param_float b, param_char c)
+
+// Проверка локальных и статических переменных внутри функций
+// CHECK: int local_sum = a + b;
+// CHECK: static int static_counter = 0;
+// CHECK: for (int local_i = 0; local_i < 5; ++local_i)
+// CHECK: char local_buf[10];
+
+int var = 42;
+float pi = 3.1415;
+static double static_value = 2.71828;
+
+void process(int a, float b, char c) {
+    int sum = a + b;
+    static int counter = 0;
+
+    for (int i = 0; i < 5; ++i) {
+        char buf[10];
+        buf[0] = c;
+    }
+}
+
+void anotherFunction() {
+    static int flag = 1;
+    int value = flag + 10;
+}
+
+void testLoop() {
+    for (int j = 0; j < 3; ++j) {
+        int temp = j * 2;
+    }
+}

--- a/clang/test/compiler-course/shkurinskaya_e_var_renaming/shkurinskaya_e_var_renaming_test.cpp
+++ b/clang/test/compiler-course/shkurinskaya_e_var_renaming/shkurinskaya_e_var_renaming_test.cpp
@@ -3,7 +3,7 @@
 // CHECK: int global_var = 42;
 // CHECK-NEXT: float global_pi = 3.1415;
 // CHECK-NEXT: static double global_static_value = 2.71828;
-// CHECK-NEXT: void process(param_int param_a, param_float param_b, param_char param_c) {
+// CHECK-NEXT: void process(int param_a, float param_b, char param_c) {
 // CHECK-NEXT:   int local_sum = param_a + param_b;
 // CHECK-NEXT:   static int static_counter = 0;
 // CHECK-NEXT:   for (int local_i = 0; local_i < 5; ++local_i) {

--- a/clang/test/compiler-course/shkurinskaya_e_var_renaming/shkurinskaya_e_var_renaming_test.cpp
+++ b/clang/test/compiler-course/shkurinskaya_e_var_renaming/shkurinskaya_e_var_renaming_test.cpp
@@ -1,18 +1,24 @@
 // RUN: %clang_cc1 -load %llvmshlibdir/ClangAST_4_Shkurinskaya_Elena_FIIT2_ClangAST%pluginext -plugin ClangAST_4 -fsyntax-only %s 2>&1 | FileCheck %s
 
-// Проверка глобальных переменных
 // CHECK: int global_var = 42;
-// CHECK: float global_pi = 3.1415;
-// CHECK: static double global_static_value = 2.71828;
-
-// Проверка параметров функций
-// CHECK: void process(param_int a, param_float b, param_char c)
-
-// Проверка локальных и статических переменных внутри функций
-// CHECK: int local_sum = a + b;
-// CHECK: static int static_counter = 0;
-// CHECK: for (int local_i = 0; local_i < 5; ++local_i)
-// CHECK: char local_buf[10];
+// CHECK-NEXT: float global_pi = 3.1415;
+// CHECK-NEXT: static double global_static_value = 2.71828;
+// CHECK-NEXT: void process(param_int param_a, param_float param_b, param_char param_c) {
+// CHECK-NEXT:   int local_sum = param_a + param_b;
+// CHECK-NEXT:   static int static_counter = 0;
+// CHECK-NEXT:   for (int local_i = 0; local_i < 5; ++local_i) {
+// CHECK-NEXT:     char local_buf[10];
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK-NEXT: void anotherFunction() {
+// CHECK-NEXT:   static int static_flag = 1;
+// CHECK-NEXT:   int local_value = static_flag + 10;
+// CHECK-NEXT: }
+// CHECK-NEXT: void testLoop() {
+// CHECK-NEXT:   for (int local_j = 0; local_j < 3; ++local_j) {
+// CHECK-NEXT:     int local_temp = local_j * 2;
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
 
 int var = 42;
 float pi = 3.1415;


### PR DESCRIPTION
Плагин ClangAST_4 для Clang автоматически добавляет префиксы (static_, global_, local_, param_) к именам переменных и параметров функций, чтобы обозначить их область видимости. Он использует RecursiveASTVisitor для обхода AST и Rewriter для изменения кода. PrefixVisitor выполняет анализ и переименование, PrefixConsumer запускает обработку, а PrefixAction управляет работой плагина и выводит измененный код.