### PR TITLE
Фролова Елизавета. Лабораторная работа 1. Clang AST. Вариант 3.

### DIFF
--- a/clang/compiler-course/frolova_e_implicit_conversions/CMakeLists.txt
+++ b/clang/compiler-course/frolova_e_implicit_conversions/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "ImplicitConvPlugin")
+set(Student "Frolova_Elizaveta")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
+++ b/clang/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
@@ -5,30 +5,16 @@
 #include "llvm/Support/raw_ostream.h"
 #include <map>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace {
 class ImplicitConvVisitor final : public clang::RecursiveASTVisitor<ImplicitConvVisitor> {
-public:
-  explicit ImplicitConvVisitor(clang::ASTContext *context) : Context(context) {}
-
-  bool VisitFunctionDecl(clang::FunctionDecl *func) {
-
-    currentFunction = func->getNameInfo().getName().getAsString();
-    return true;
-  } 
-
-  bool VisitImplicitCastExpr(clang::ImplicitCastExpr *cast) {
-    if (!cast || !cast->getSubExpr()) {
-        return true;
-    }
-
-    clang::QualType fromType = cast->getSubExpr()->getType();
-    clang::QualType toType = cast->getType();
-
+  void handleTypeConversion(const clang::QualType &fromType, const clang::QualType &toType) {
     std::string fromTypeStr = fromType.getAsString();
     std::string toTypeStr = toType.getAsString();
+
+    fromTypeStr = (fromTypeStr == "_Bool") ? "bool" : fromTypeStr;
+    toTypeStr = (toTypeStr == "_Bool") ? "bool" : toTypeStr;
 
     if (fromTypeStr != toTypeStr) {
         std::string conversion = fromTypeStr + " -> " + toTypeStr;
@@ -37,7 +23,7 @@ public:
         bool found = false;
         for (auto &entry : convList) {
             if (entry.first == conversion) {
-                entry.second++; 
+                entry.second++;
                 found = true;
                 break;
             }
@@ -47,39 +33,61 @@ public:
             convList.push_back({conversion, 1});
         }
     }
+  }
 
-    return true;
-}
+public:
+  explicit ImplicitConvVisitor(clang::ASTContext *context) : Context(context) {}
 
-  bool VisitCallExpr(clang::CallExpr *call) {
-    if (auto *callee = call->getDirectCallee()) {
-        llvm::outs() << "Function call detected: " << callee->getNameAsString() << "\n";
+  bool VisitFunctionDecl(clang::FunctionDecl *func) {
+    currentFunction = func->getNameInfo().getName().getAsString();
+    if (conversions.find(currentFunction) == conversions.end()) {
+      functionOrder.push_back(currentFunction);
     }
     return true;
   }
 
-  void printResults() {
-    for (const auto &func : conversions) {
-        llvm::outs() << "Function: " << func.first << "\n";
-        
-        for (const auto &conv : func.second) {
-            llvm::outs() << "  " << conv.first << ": " << conv.second << "\n";
-        }
-
-        llvm::outs() << "\n";
+  bool VisitCXXConstructExpr(clang::CXXConstructExpr *expr) {
+    if (expr->getNumArgs() == 1) {
+        clang::QualType fromType = expr->getArg(0)->getType();
+        clang::QualType toType = expr->getType();
+        handleTypeConversion(fromType, toType);
     }
-}
+    return true;
+  }
+
+  bool VisitImplicitCastExpr(clang::ImplicitCastExpr *cast) {
+    if (!cast || !cast->getSubExpr() || 
+        cast->getCastKind() == clang::CK_FunctionToPointerDecay) {
+        return true;
+    }
+
+    clang::QualType fromType = cast->getSubExpr()->getType();
+    clang::QualType toType = cast->getType();
+    handleTypeConversion(fromType, toType);
+    return true;
+  }
+
+  void printResults() {
+    auto &os = llvm::outs();
+    for (const auto &funcName : functionOrder) {
+        os << "Function: " << funcName << "\n";
+        for (const auto &conversion : conversions[funcName]) {
+            os << "  " << conversion.first << ": " << conversion.second << "\n";
+        }
+        os << "\n";
+    }
+  }
 
 private:
   clang::ASTContext *Context;
   std::string currentFunction;
+  std::vector<std::string> functionOrder;
   std::map<std::string, std::vector<std::pair<std::string, int>>> conversions;
-
 };
 
-class ExampleConsumer final : public clang::ASTConsumer {
+class ConversionConsumer final : public clang::ASTConsumer {
 public:
-  explicit ExampleConsumer(clang::ASTContext *context) : Visitor(context) {}
+  explicit ConversionConsumer(clang::ASTContext *context) : Visitor(context) {}
 
   void HandleTranslationUnit(clang::ASTContext &context) override {
     Visitor.TraverseDecl(context.getTranslationUnitDecl());
@@ -87,14 +95,14 @@ public:
   }
 
 private:
-ImplicitConvVisitor Visitor;
+  ImplicitConvVisitor Visitor;
 };
 
-class ExampleAction final : public clang::PluginASTAction {
+class ConversionAction final : public clang::PluginASTAction {
 public:
   std::unique_ptr<clang::ASTConsumer>
   CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
-    return std::make_unique<ExampleConsumer>(&ci.getASTContext());
+    return std::make_unique<ConversionConsumer>(&ci.getASTContext());
   }
 
   bool ParseArgs(const clang::CompilerInstance &ci,
@@ -104,5 +112,5 @@ public:
 };
 } // namespace
 
-static clang::FrontendPluginRegistry::Add<ExampleAction>
+static clang::FrontendPluginRegistry::Add<ConversionAction>
     X("ImplicitConvPlugin", "Output the number of implicit conversions in the entire file");

--- a/clang/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
+++ b/clang/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
@@ -8,7 +8,8 @@
 #include <vector>
 
 namespace {
-class ImplicitConvVisitor final : public clang::RecursiveASTVisitor<ImplicitConvVisitor> {
+class ImplicitConvVisitor final 
+    : public clang::RecursiveASTVisitor<ImplicitConvVisitor> {
   void handleTypeConversion(const clang::QualType &fromType, const clang::QualType &toType) {
     std::string fromTypeStr = fromType.getAsString();
     std::string toTypeStr = toType.getAsString();
@@ -17,21 +18,21 @@ class ImplicitConvVisitor final : public clang::RecursiveASTVisitor<ImplicitConv
     toTypeStr = (toTypeStr == "_Bool") ? "bool" : toTypeStr;
 
     if (fromTypeStr != toTypeStr) {
-        std::string conversion = fromTypeStr + " -> " + toTypeStr;
-        auto &convList = conversions[currentFunction];
+      std::string conversion = fromTypeStr + " -> " + toTypeStr;
+      auto &convList = conversions[currentFunction];
 
-        bool found = false;
-        for (auto &entry : convList) {
-            if (entry.first == conversion) {
-                entry.second++;
-                found = true;
-                break;
-            }
+      bool found = false;
+      for (auto &entry : convList) {
+        if (entry.first == conversion) {
+            entry.second++;
+            found = true;
+            break;
         }
+      }
 
-        if (!found) {
-            convList.push_back({conversion, 1});
-        }
+      if (!found) {
+        convList.push_back({conversion, 1});
+      }
     }
   }
 
@@ -48,17 +49,17 @@ public:
 
   bool VisitCXXConstructExpr(clang::CXXConstructExpr *expr) {
     if (expr->getNumArgs() == 1) {
-        clang::QualType fromType = expr->getArg(0)->getType();
-        clang::QualType toType = expr->getType();
-        handleTypeConversion(fromType, toType);
+      clang::QualType fromType = expr->getArg(0)->getType();
+      clang::QualType toType = expr->getType();
+      handleTypeConversion(fromType, toType);
     }
     return true;
   }
 
   bool VisitImplicitCastExpr(clang::ImplicitCastExpr *cast) {
-    if (!cast || !cast->getSubExpr() || 
+    if (!cast || !cast->getSubExpr() ||
         cast->getCastKind() == clang::CK_FunctionToPointerDecay) {
-        return true;
+      return true;
     }
 
     clang::QualType fromType = cast->getSubExpr()->getType();
@@ -70,11 +71,11 @@ public:
   void printResults() {
     auto &os = llvm::outs();
     for (const auto &funcName : functionOrder) {
-        os << "Function: " << funcName << "\n";
-        for (const auto &conversion : conversions[funcName]) {
-            os << "  " << conversion.first << ": " << conversion.second << "\n";
-        }
-        os << "\n";
+      os << "Function: " << funcName << "\n";
+      for (const auto &conversion : conversions[funcName]) {
+        os << "  " << conversion.first << ": " << conversion.second << "\n";
+      }
+      os << "\n";
     }
   }
 
@@ -113,4 +114,5 @@ public:
 } // namespace
 
 static clang::FrontendPluginRegistry::Add<ConversionAction>
-    X("ImplicitConvPlugin", "Output the number of implicit conversions in the entire file");
+    X("ImplicitConvPlugin",
+       "Output the number of implicit conversions in the entire file");

--- a/clang/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
+++ b/clang/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
@@ -18,23 +18,20 @@ class ImplicitConvVisitor final
     fromTypeStr = (fromTypeStr == "_Bool") ? "bool" : fromTypeStr;
     toTypeStr = (toTypeStr == "_Bool") ? "bool" : toTypeStr;
 
-    if (fromTypeStr != toTypeStr) {
-      std::string conversion = fromTypeStr + " -> " + toTypeStr;
-      auto &convList = conversions[currentFunction];
+    if(fromTypeStr == toTypeStr)
+      return;
 
-      bool found = false;
-      for (auto &entry : convList) {
-        if (entry.first == conversion) {
-          entry.second++;
-          found = true;
-          break;
-        }
-      }
+    std::string conversion = fromTypeStr + " -> " + toTypeStr;
+    auto &convList = conversions[currentFunction];
 
-      if (!found) {
-        convList.push_back({conversion, 1});
+    for (auto &entry : convList) {
+      if (entry.first == conversion) {
+        entry.second++;        
+        break;
       }
     }
+
+    convList.push_back({conversion, 1});  
   }
 
 public:
@@ -73,8 +70,8 @@ public:
     auto &os = llvm::outs();
     for (const auto &funcName : functionOrder) {
       os << "Function: " << funcName << "\n";
-      for (const auto &conversion : conversions[funcName]) {
-        os << "  " << conversion.first << ": " << conversion.second << "\n";
+      for (const auto &[c1,c2] : conversions[funcName]) {
+        os << "  " << c1 << ": " << c2 << "\n";
       }
       os << "\n";
     }

--- a/clang/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
+++ b/clang/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
@@ -8,9 +8,10 @@
 #include <vector>
 
 namespace {
-class ImplicitConvVisitor final 
+class ImplicitConvVisitor final
     : public clang::RecursiveASTVisitor<ImplicitConvVisitor> {
-  void handleTypeConversion(const clang::QualType &fromType, const clang::QualType &toType) {
+  void handleTypeConversion(const clang::QualType &fromType,
+                            const clang::QualType &toType) {
     std::string fromTypeStr = fromType.getAsString();
     std::string toTypeStr = toType.getAsString();
 
@@ -24,9 +25,9 @@ class ImplicitConvVisitor final
       bool found = false;
       for (auto &entry : convList) {
         if (entry.first == conversion) {
-            entry.second++;
-            found = true;
-            break;
+          entry.second++;
+          found = true;
+          break;
         }
       }
 
@@ -115,4 +116,4 @@ public:
 
 static clang::FrontendPluginRegistry::Add<ConversionAction>
     X("ImplicitConvPlugin",
-       "Output the number of implicit conversions in the entire file");
+      "Output the number of implicit conversions in the entire file");

--- a/clang/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
+++ b/clang/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
@@ -1,0 +1,108 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+class ImplicitConvVisitor final : public clang::RecursiveASTVisitor<ImplicitConvVisitor> {
+public:
+  explicit ImplicitConvVisitor(clang::ASTContext *context) : Context(context) {}
+
+  bool VisitFunctionDecl(clang::FunctionDecl *func) {
+
+    currentFunction = func->getNameInfo().getName().getAsString();
+    return true;
+  } 
+
+  bool VisitImplicitCastExpr(clang::ImplicitCastExpr *cast) {
+    if (!cast || !cast->getSubExpr()) {
+        return true;
+    }
+
+    clang::QualType fromType = cast->getSubExpr()->getType();
+    clang::QualType toType = cast->getType();
+
+    std::string fromTypeStr = fromType.getAsString();
+    std::string toTypeStr = toType.getAsString();
+
+    if (fromTypeStr != toTypeStr) {
+        std::string conversion = fromTypeStr + " -> " + toTypeStr;
+        auto &convList = conversions[currentFunction];
+
+        bool found = false;
+        for (auto &entry : convList) {
+            if (entry.first == conversion) {
+                entry.second++; 
+                found = true;
+                break;
+            }
+        }
+
+        if (!found) {
+            convList.push_back({conversion, 1});
+        }
+    }
+
+    return true;
+}
+
+  bool VisitCallExpr(clang::CallExpr *call) {
+    if (auto *callee = call->getDirectCallee()) {
+        llvm::outs() << "Function call detected: " << callee->getNameAsString() << "\n";
+    }
+    return true;
+  }
+
+  void printResults() {
+    for (const auto &func : conversions) {
+        llvm::outs() << "Function: " << func.first << "\n";
+        
+        for (const auto &conv : func.second) {
+            llvm::outs() << "  " << conv.first << ": " << conv.second << "\n";
+        }
+
+        llvm::outs() << "\n";
+    }
+}
+
+private:
+  clang::ASTContext *Context;
+  std::string currentFunction;
+  std::map<std::string, std::vector<std::pair<std::string, int>>> conversions;
+
+};
+
+class ExampleConsumer final : public clang::ASTConsumer {
+public:
+  explicit ExampleConsumer(clang::ASTContext *context) : Visitor(context) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    Visitor.TraverseDecl(context.getTranslationUnitDecl());
+    Visitor.printResults();
+  }
+
+private:
+ImplicitConvVisitor Visitor;
+};
+
+class ExampleAction final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    return std::make_unique<ExampleConsumer>(&ci.getASTContext());
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+};
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<ExampleAction>
+    X("ImplicitConvPlugin", "Output the number of implicit conversions in the entire file");

--- a/clang/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
+++ b/clang/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
@@ -18,7 +18,7 @@ class ImplicitConvVisitor final
     fromTypeStr = (fromTypeStr == "_Bool") ? "bool" : fromTypeStr;
     toTypeStr = (toTypeStr == "_Bool") ? "bool" : toTypeStr;
 
-    if(fromTypeStr == toTypeStr)
+    if (fromTypeStr == toTypeStr)
       return;
 
     std::string conversion = fromTypeStr + " -> " + toTypeStr;
@@ -26,12 +26,12 @@ class ImplicitConvVisitor final
 
     for (auto &entry : convList) {
       if (entry.first == conversion) {
-        entry.second++;        
+        entry.second++;
         break;
       }
     }
 
-    convList.push_back({conversion, 1});  
+    convList.push_back({conversion, 1});
   }
 
 public:
@@ -70,7 +70,7 @@ public:
     auto &os = llvm::outs();
     for (const auto &funcName : functionOrder) {
       os << "Function: " << funcName << "\n";
-      for (const auto &[c1,c2] : conversions[funcName]) {
+      for (const auto &[c1, c2] : conversions[funcName]) {
         os << "  " << c1 << ": " << c2 << "\n";
       }
       os << "\n";

--- a/clang/test/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
+++ b/clang/test/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -load %llvmshlibdir/ImplicitConvPlugin_Frolova_Elizaveta_FIIT3_ClangAST%pluginext -plugin ImplicitConvPlugin -fsyntax-only %s 2>&1 | FileCheck %s
-
 using ll = long long;
 #define long long ll
 
@@ -64,7 +63,6 @@ void callProcessPointer() {
 
 // CHECK: Function: createAndReturnObject
 // CHECK-NEXT: int -> MyClass: 1
-
 class MyClass {
     int x;
  public:

--- a/clang/test/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
+++ b/clang/test/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
@@ -1,10 +1,76 @@
 // RUN: %clang_cc1 -load %llvmshlibdir/ImplicitConvPlugin_Frolova_Elizaveta_FIIT3_ClangAST%pluginext -plugin ImplicitConvPlugin -fsyntax-only %s 2>&1 | FileCheck %s
 
+using ll = long long;
+#define long long ll
+
 // CHECK: Function: sum
 // CHECK-NEXT: float -> double: 1
 // CHECK-NEXT: int -> float: 1
-
 double sum(int a, float b) {
     return a + b; // 'a' (int) -> 'b' (float) -> 'double'
 }
 
+// CHECK: Function: mul
+// CHECK-NEXT: double -> int: 1
+// CHECK-NEXT: float -> double: 1
+// CHECK-NEXT: float -> int: 1
+int mul(float a, float b) {
+    return a + sum(a, b);
+}
+
+// CHECK: Function: checkCondition
+// CHECK-NEXT: int -> bool: 1
+// CHECK-NEXT: int -> double: 1
+double checkCondition() {
+    int x = 1;
+    if (x) { x++; }
+    return x;
+}
+
+// CHECK: Function: convertAndReturn
+// CHECK-NEXT: double -> float: 1
+// CHECK-NEXT: float -> int: 1
+int convertAndReturn() {
+    double x = 1.2;
+    float y = x;
+    return y;
+}
+
+// CHECK: Function: convertLongLongToInt
+// CHECK-NEXT: ll -> int: 1
+int convertLongLongToInt() {
+    ll x = 10000000000LL;
+    int y = x;
+    return y;
+}
+
+// CHECK: Function: charToIntAndDouble
+// CHECK-NEXT: char -> int: 1
+// CHECK-NEXT: int -> double: 1
+double charToIntAndDouble() {
+    char c = 'A';
+    int i = c;
+    double d = i;
+    return d;
+}
+
+// CHECK: Function: callProcessPointer
+// CHECK-NEXT: int * -> const int *: 1
+void processPointer(const int*);
+void callProcessPointer() {
+    int x = 42;
+    processPointer(&x);
+}
+
+// CHECK: Function: createAndReturnObject
+// CHECK-NEXT: int -> MyClass: 1
+
+class MyClass {
+    int x;
+ public:
+    MyClass(int);
+};
+
+MyClass createAndReturnObject() {
+    return 10;
+}

--- a/clang/test/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
+++ b/clang/test/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/ImplicitConvPlugin_Frolova_Elizaveta_FIIT3_ClangAST%pluginext -plugin ImplicitConvPlugin -fsyntax-only %s 2>&1 | FileCheck %s
+
+// CHECK: Function: sum
+// CHECK-NEXT: float -> double: 1
+// CHECK-NEXT: int -> float: 1
+
+double sum(int a, float b) {
+    return a + b; // 'a' (int) -> 'b' (float) -> 'double'
+}
+

--- a/clang/test/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
+++ b/clang/test/compiler-course/frolova_e_implicit_conversions/frolova_e_implicit_conversions.cpp
@@ -72,3 +72,10 @@ class MyClass {
 MyClass createAndReturnObject() {
     return 10;
 }
+
+// CHECK:Function: foo
+// CHECK-NEXT:int[3] -> int *: 1
+int foo(int a) {
+    static int aa[] = {1, 2, 3};
+    return aa[a];
+}


### PR DESCRIPTION
Плагин использует возможности Clang для обхода абстрактного синтаксического дерева (AST) и регистрирует все случаи неявных преобразований, происходящих в коде. При каждом неявном преобразовании плагин фиксирует типы, участвующие в преобразовании, и подсчитывает их количество для каждой функции. Результаты анализа выводятся для каждой функции, отображается имя и список неявных преобразований с соответствующими количествами.