### PR TITLE
Козлова Екатерина. Лабораторная работа 1. Clang AST. Вариант 4.

### DIFF
--- a/clang/compiler-course/kozlova_e_variant_4/CMakeLists.txt
+++ b/clang/compiler-course/kozlova_e_variant_4/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "FirstPlugin")
+set(Student "KozlovaEkaterina")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/kozlova_e_variant_4/kozlova_e_var_4.cpp
+++ b/clang/compiler-course/kozlova_e_variant_4/kozlova_e_var_4.cpp
@@ -39,7 +39,7 @@ public:
     if (param->hasDefaultArg()) {
       clang::Expr *defaultArg = param->getDefaultArg();
       llvm::raw_string_ostream stream(defaultValueStr);
-      defaultArg->printPretty(stream, nullptr, 
+      defaultArg->printPretty(stream, nullptr,
                               clang::PrintingPolicy(clang::LangOptions()));
       stream.flush();
       newName += "_default_" + defaultValueStr;

--- a/clang/compiler-course/kozlova_e_variant_4/kozlova_e_var_4.cpp
+++ b/clang/compiler-course/kozlova_e_variant_4/kozlova_e_var_4.cpp
@@ -21,7 +21,7 @@ public:
       }
     } else if (var->isFileVarDecl()) {
       if (var->getStorageClass() == clang::SC_Static) {
-        renameVar(var, "global_");
+        renameVar(var, "static_global_");
       } else {
         renameVar(var, "global_");
       }
@@ -30,7 +30,30 @@ public:
   }
 
   bool VisitParmVarDecl(clang::ParmVarDecl *param) {
-    renameVar(param, "param_");
+    llvm::StringRef oldName = param->getName();
+    if (oldName.empty()) 
+      return true;
+    
+    std::string newName = "param_" + oldName.str();
+    std::string defaultValueStr;
+    if (param->hasDefaultArg()) {
+      clang::Expr *defaultArg = param->getDefaultArg();
+      llvm::raw_string_ostream stream(defaultValueStr);
+      defaultArg->printPretty(stream, nullptr, clang::PrintingPolicy(clang::LangOptions()));
+      stream.flush();
+      newName += "_default_" + defaultValueStr;
+      clang::SourceLocation loc = param->getLocation();
+      if (loc.isValid() && m_rewriter.getSourceMgr().isWrittenInMainFile(loc)) {
+          m_rewriter.ReplaceText(loc, oldName.size() + defaultValueStr.size() + 3, newName);
+      }
+    }
+    else {
+      clang::SourceLocation loc = param->getLocation();
+      if (loc.isValid() && m_rewriter.getSourceMgr().isWrittenInMainFile(loc)) {
+          m_rewriter.ReplaceText(loc, oldName.size(), newName);
+      }
+    }
+    renamedVars[param] = newName;
     return true;
   }
 

--- a/clang/compiler-course/kozlova_e_variant_4/kozlova_e_var_4.cpp
+++ b/clang/compiler-course/kozlova_e_variant_4/kozlova_e_var_4.cpp
@@ -31,26 +31,27 @@ public:
 
   bool VisitParmVarDecl(clang::ParmVarDecl *param) {
     llvm::StringRef oldName = param->getName();
-    if (oldName.empty()) 
+    if (oldName.empty())
       return true;
-    
+
     std::string newName = "param_" + oldName.str();
     std::string defaultValueStr;
     if (param->hasDefaultArg()) {
       clang::Expr *defaultArg = param->getDefaultArg();
       llvm::raw_string_ostream stream(defaultValueStr);
-      defaultArg->printPretty(stream, nullptr, clang::PrintingPolicy(clang::LangOptions()));
+      defaultArg->printPretty(stream, nullptr, 
+                              clang::PrintingPolicy(clang::LangOptions()));
       stream.flush();
       newName += "_default_" + defaultValueStr;
       clang::SourceLocation loc = param->getLocation();
       if (loc.isValid() && m_rewriter.getSourceMgr().isWrittenInMainFile(loc)) {
-          m_rewriter.ReplaceText(loc, oldName.size() + defaultValueStr.size() + 3, newName);
+        m_rewriter.ReplaceText(loc, oldName.size() + defaultValueStr.size() + 3,
+                               newName);
       }
-    }
-    else {
+    } else {
       clang::SourceLocation loc = param->getLocation();
       if (loc.isValid() && m_rewriter.getSourceMgr().isWrittenInMainFile(loc)) {
-          m_rewriter.ReplaceText(loc, oldName.size(), newName);
+        m_rewriter.ReplaceText(loc, oldName.size(), newName);
       }
     }
     renamedVars[param] = newName;

--- a/clang/compiler-course/kozlova_e_variant_4/kozlova_e_var_4.cpp
+++ b/clang/compiler-course/kozlova_e_variant_4/kozlova_e_var_4.cpp
@@ -116,4 +116,4 @@ private:
 
 static clang::FrontendPluginRegistry::Add<ExampleAction>
     X("FirstPlugin_KozlovaEkaterina_FIIT3_ClangAST",
-        "Adds prefixes to variables");
+      "Adds prefixes to variables");

--- a/clang/compiler-course/kozlova_e_variant_4/kozlova_e_var_4.cpp
+++ b/clang/compiler-course/kozlova_e_variant_4/kozlova_e_var_4.cpp
@@ -1,0 +1,119 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+
+    class ExampleVisitor : public clang::RecursiveASTVisitor<ExampleVisitor> {
+    public:
+        explicit ExampleVisitor(clang::ASTContext* context, clang::Rewriter& rewriter)
+            : m_rewriter(rewriter) {}
+
+        bool VisitVarDecl(clang::VarDecl* var) {
+            if (var->isLocalVarDecl()) {
+                if (var->isStaticLocal()) {
+                    renameVar(var, "static_");
+                } else {
+                    renameVar(var, "local_");
+                }
+            } else if (var->isFileVarDecl()) {
+                if (var->getStorageClass() == clang::SC_Static) {
+                    renameVar(var, "global_");
+                } else {
+                    renameVar(var, "global_");
+                }
+            }
+            return true;
+        }
+
+        bool VisitParmVarDecl(clang::ParmVarDecl* param) {
+            renameVar(param, "param_");
+            return true;
+        }
+
+        bool VisitDeclRefExpr(clang::DeclRefExpr* expr) {
+            if (auto* var = llvm::dyn_cast<clang::VarDecl>(expr->getDecl())) {
+                llvm::StringRef oldName = var->getName();
+
+                if (!shouldRename(var)) return true;
+
+                clang::SourceLocation loc = expr->getLocation();
+                if (loc.isValid() && m_rewriter.getSourceMgr().isWrittenInMainFile(loc)) {
+                    std::string newName = getPrefixedName(var);
+                    m_rewriter.ReplaceText(loc, oldName.size(), newName);
+                }
+            }
+            return true;
+        }
+
+    private:
+        clang::Rewriter& m_rewriter;
+        llvm::DenseMap<clang::VarDecl*, std::string> renamedVars;
+
+        bool shouldRename(clang::VarDecl* var) {
+            return renamedVars.count(var) > 0;
+        }
+
+        std::string getPrefixedName(clang::VarDecl* var) {
+            return renamedVars[var];
+        }
+
+        void renameVar(clang::VarDecl* var, llvm::StringRef prefix) {
+            llvm::StringRef oldName = var->getName();
+            if (oldName.empty()) return;
+
+            std::string newName = (prefix + oldName).str();
+
+            clang::SourceLocation loc = var->getLocation();
+            if (loc.isValid() && m_rewriter.getSourceMgr().isWrittenInMainFile(loc)) {
+                m_rewriter.ReplaceText(loc, oldName.size(), newName);
+            }
+
+            renamedVars[var] = newName;
+        }
+    };
+
+    class ExampleConsumer : public clang::ASTConsumer {
+    public:
+        explicit ExampleConsumer(clang::ASTContext* context, clang::Rewriter& rewriter)
+            : m_visitor(context, rewriter), m_rewriter(rewriter) {
+        }
+
+        void HandleTranslationUnit(clang::ASTContext& context) override {
+            m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+
+            auto& buffer = m_rewriter.getEditBuffer(m_rewriter.getSourceMgr().getMainFileID());
+            if (buffer.size() > 0) {
+                buffer.write(llvm::outs());
+            }
+        }
+
+    private:
+        ExampleVisitor m_visitor;
+        clang::Rewriter& m_rewriter;
+    };
+
+    class ExampleAction : public clang::PluginASTAction {
+    public:
+        bool ParseArgs(const clang::CompilerInstance& ci,
+            const std::vector<std::string>& args) override {
+            return true;
+        }
+
+        std::unique_ptr<clang::ASTConsumer>
+        CreateASTConsumer(clang::CompilerInstance& ci, llvm::StringRef) override {
+            m_rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
+            return std::make_unique<ExampleConsumer>(&ci.getASTContext(), m_rewriter);
+        }
+
+    private:
+        clang::Rewriter m_rewriter;
+    };
+
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<ExampleAction>
+X("FirstPlugin_KozlovaEkaterina_FIIT3_ClangAST", "Adds prefixes to variables");

--- a/clang/compiler-course/kozlova_e_variant_4/kozlova_e_var_4.cpp
+++ b/clang/compiler-course/kozlova_e_variant_4/kozlova_e_var_4.cpp
@@ -7,113 +7,113 @@
 
 namespace {
 
-    class ExampleVisitor : public clang::RecursiveASTVisitor<ExampleVisitor> {
-    public:
-        explicit ExampleVisitor(clang::ASTContext* context, clang::Rewriter& rewriter)
-            : m_rewriter(rewriter) {}
+class ExampleVisitor : public clang::RecursiveASTVisitor<ExampleVisitor> {
+public:
+  explicit ExampleVisitor(clang::ASTContext *context, clang::Rewriter &rewriter)
+      : m_rewriter(rewriter) {}
 
-        bool VisitVarDecl(clang::VarDecl* var) {
-            if (var->isLocalVarDecl()) {
-                if (var->isStaticLocal()) {
-                    renameVar(var, "static_");
-                } else {
-                    renameVar(var, "local_");
-                }
-            } else if (var->isFileVarDecl()) {
-                if (var->getStorageClass() == clang::SC_Static) {
-                    renameVar(var, "global_");
-                } else {
-                    renameVar(var, "global_");
-                }
-            }
-            return true;
-        }
+  bool VisitVarDecl(clang::VarDecl *var) {
+    if (var->isLocalVarDecl()) {
+      if (var->isStaticLocal()) {
+        renameVar(var, "static_");
+      } else {
+        renameVar(var, "local_");
+      }
+    } else if (var->isFileVarDecl()) {
+      if (var->getStorageClass() == clang::SC_Static) {
+        renameVar(var, "global_");
+      } else {
+        renameVar(var, "global_");
+      }
+    }
+    return true;
+  }
 
-        bool VisitParmVarDecl(clang::ParmVarDecl* param) {
-            renameVar(param, "param_");
-            return true;
-        }
+  bool VisitParmVarDecl(clang::ParmVarDecl *param) {
+    renameVar(param, "param_");
+    return true;
+  }
 
-        bool VisitDeclRefExpr(clang::DeclRefExpr* expr) {
-            if (auto* var = llvm::dyn_cast<clang::VarDecl>(expr->getDecl())) {
-                llvm::StringRef oldName = var->getName();
+  bool VisitDeclRefExpr(clang::DeclRefExpr *expr) {
+    if (auto *var = llvm::dyn_cast<clang::VarDecl>(expr->getDecl())) {
+      llvm::StringRef oldName = var->getName();
 
-                if (!shouldRename(var)) return true;
+      if (!shouldRename(var))
+        return true;
 
-                clang::SourceLocation loc = expr->getLocation();
-                if (loc.isValid() && m_rewriter.getSourceMgr().isWrittenInMainFile(loc)) {
-                    std::string newName = getPrefixedName(var);
-                    m_rewriter.ReplaceText(loc, oldName.size(), newName);
-                }
-            }
-            return true;
-        }
+      clang::SourceLocation loc = expr->getLocation();
+      if (loc.isValid() && m_rewriter.getSourceMgr().isWrittenInMainFile(loc)) {
+        std::string newName = getPrefixedName(var);
+        m_rewriter.ReplaceText(loc, oldName.size(), newName);
+      }
+    }
+    return true;
+  }
 
-    private:
-        clang::Rewriter& m_rewriter;
-        llvm::DenseMap<clang::VarDecl*, std::string> renamedVars;
+private:
+  clang::Rewriter &m_rewriter;
+  llvm::DenseMap<clang::VarDecl *, std::string> renamedVars;
 
-        bool shouldRename(clang::VarDecl* var) {
-            return renamedVars.count(var) > 0;
-        }
+  bool shouldRename(clang::VarDecl *var) { return renamedVars.count(var) > 0; }
 
-        std::string getPrefixedName(clang::VarDecl* var) {
-            return renamedVars[var];
-        }
+  std::string getPrefixedName(clang::VarDecl *var) { return renamedVars[var]; }
 
-        void renameVar(clang::VarDecl* var, llvm::StringRef prefix) {
-            llvm::StringRef oldName = var->getName();
-            if (oldName.empty()) return;
+  void renameVar(clang::VarDecl *var, llvm::StringRef prefix) {
+    llvm::StringRef oldName = var->getName();
+    if (oldName.empty())
+      return;
 
-            std::string newName = (prefix + oldName).str();
+    std::string newName = (prefix + oldName).str();
 
-            clang::SourceLocation loc = var->getLocation();
-            if (loc.isValid() && m_rewriter.getSourceMgr().isWrittenInMainFile(loc)) {
-                m_rewriter.ReplaceText(loc, oldName.size(), newName);
-            }
+    clang::SourceLocation loc = var->getLocation();
+    if (loc.isValid() && m_rewriter.getSourceMgr().isWrittenInMainFile(loc)) {
+      m_rewriter.ReplaceText(loc, oldName.size(), newName);
+    }
 
-            renamedVars[var] = newName;
-        }
-    };
+    renamedVars[var] = newName;
+  }
+};
 
-    class ExampleConsumer : public clang::ASTConsumer {
-    public:
-        explicit ExampleConsumer(clang::ASTContext* context, clang::Rewriter& rewriter)
-            : m_visitor(context, rewriter), m_rewriter(rewriter) {
-        }
+class ExampleConsumer : public clang::ASTConsumer {
+public:
+  explicit ExampleConsumer(clang::ASTContext *context,
+                           clang::Rewriter &rewriter)
+      : m_visitor(context, rewriter), m_rewriter(rewriter) {}
 
-        void HandleTranslationUnit(clang::ASTContext& context) override {
-            m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
 
-            auto& buffer = m_rewriter.getEditBuffer(m_rewriter.getSourceMgr().getMainFileID());
-            if (buffer.size() > 0) {
-                buffer.write(llvm::outs());
-            }
-        }
+    auto &buffer =
+        m_rewriter.getEditBuffer(m_rewriter.getSourceMgr().getMainFileID());
+    if (buffer.size() > 0) {
+      buffer.write(llvm::outs());
+    }
+  }
 
-    private:
-        ExampleVisitor m_visitor;
-        clang::Rewriter& m_rewriter;
-    };
+private:
+  ExampleVisitor m_visitor;
+  clang::Rewriter &m_rewriter;
+};
 
-    class ExampleAction : public clang::PluginASTAction {
-    public:
-        bool ParseArgs(const clang::CompilerInstance& ci,
-            const std::vector<std::string>& args) override {
-            return true;
-        }
+class ExampleAction : public clang::PluginASTAction {
+public:
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
 
-        std::unique_ptr<clang::ASTConsumer>
-        CreateASTConsumer(clang::CompilerInstance& ci, llvm::StringRef) override {
-            m_rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
-            return std::make_unique<ExampleConsumer>(&ci.getASTContext(), m_rewriter);
-        }
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    m_rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
+    return std::make_unique<ExampleConsumer>(&ci.getASTContext(), m_rewriter);
+  }
 
-    private:
-        clang::Rewriter m_rewriter;
-    };
+private:
+  clang::Rewriter m_rewriter;
+};
 
 } // namespace
 
 static clang::FrontendPluginRegistry::Add<ExampleAction>
-X("FirstPlugin_KozlovaEkaterina_FIIT3_ClangAST", "Adds prefixes to variables");
+    X("FirstPlugin_KozlovaEkaterina_FIIT3_ClangAST",
+        "Adds prefixes to variables");

--- a/clang/test/compiler-course/kozlova_e_var_4_test/test.cpp
+++ b/clang/test/compiler-course/kozlova_e_var_4_test/test.cpp
@@ -8,8 +8,13 @@
 // CHECK-NEXT:   ++static_var2;
 // CHECK-NEXT:   return param_a + param_b + global_var1 + static_var2 + local_var3;
 // CHECK-NEXT: }
-// CHECK-NEXT: int static global_var4 = 1;
-//CHECK: int static global_var5 = foo(1, global_var4);
+// CHECK-NEXT: int static static_global_var4 = 1;
+// CHECK-NEXT: int static static_global_var5 = foo(1, static_global_var4);
+// CHECK-NEXT: int foo2(int param_a, int param_b_default_10) {
+// CHECK-NEXT: return param_a * param_b_default_10;
+// CHECK-NEXT: }
+// CHECK-NEXT: int global_var6 = foo2(1);
+// CHECK-NEXT: int global_var7 = foo2(1, 2);
 
 
 int var1 = 0;
@@ -21,3 +26,8 @@ int foo(int a, int b) {
 }
 int static var4 = 1;
 int static var5 = foo(1, var4);
+int foo2(int a, int b = 10) {
+    return a * b;
+}
+int var6 = foo2(1);
+int var7 = foo2(1, 2);

--- a/clang/test/compiler-course/kozlova_e_var_4_test/test.cpp
+++ b/clang/test/compiler-course/kozlova_e_var_4_test/test.cpp
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/FirstPlugin_KozlovaEkaterina_FIIT3_ClangAST%pluginext -plugin FirstPlugin_KozlovaEkaterina_FIIT3_ClangAST -fsyntax-only %s 2>&1 | FileCheck --match-full-lines %s
+
+
+// CHECK: int global_var1 = 0;
+// CHECK-NEXT: int foo(int param_a, int param_b) {
+// CHECK-NEXT:   static int static_var2 = 0;
+// CHECK-NEXT:   int local_var3 = 123;
+// CHECK-NEXT:   ++static_var2;
+// CHECK-NEXT:   return param_a + param_b + global_var1 + static_var2 + local_var3;
+// CHECK-NEXT: }
+// CHECK-NEXT: int static global_var4 = 1;
+//CHECK: int static global_var5 = foo(1, global_var4);
+
+
+int var1 = 0;
+int foo(int a, int b) {
+    static int var2 = 0;
+    int var3 = 123;
+    ++var2;
+    return a + b + var1 + var2 + var3;
+}
+int static var4 = 1;
+int static var5 = foo(1, var4);


### PR DESCRIPTION
Плагин использует возможности Clang для обхода абстрактного синтаксического дерева (AST) и автоматического изменения исходного кода на основе анализа структуры программы. Префиксы добавляются в процессе обхода AST с помощью класса ExampleVisitor, который проверяет тип и область видимости переменной. В зависимости от того, является ли переменная локальной, статической, глобальной или параметром функции, к её имени добавляется соответствующий префикс (local_, static_, global_, param_). Изменения выполняются через clang::Rewriter, который заменяет старые имена на новые в исходном коде.