### PR TITLE
Лысов Иван. Лабораторная работа 1. Clang AST. Вариант 2

### DIFF
--- a/clang/compiler-course/lysov_ivan_1stLabs/CMakeLists.txt
+++ b/clang/compiler-course/lysov_ivan_1stLabs/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "unUsedVarPlugin")
+set(Student "LysovIvan")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/lysov_ivan_1stLabs/lysov_ivan_1stLabs.cpp
+++ b/clang/compiler-course/lysov_ivan_1stLabs/lysov_ivan_1stLabs.cpp
@@ -29,9 +29,9 @@ public:
   }
 
   bool VisitParmVarDecl(clang::ParmVarDecl *param) {
-    if (!param->isUsed() && !param->isImplicit() && 
+    if (!param->isUsed() && !param->isImplicit() &&
         !param->hasAttr<clang::UnusedAttr>()) {
-      outs() << "Marking parameter as maybe_unused: " 
+      outs() << "Marking parameter as maybe_unused: "
              << param->getNameAsString() << "\n";
       auto *attr = clang::UnusedAttr::CreateImplicit(*context);
       param->addAttr(attr);

--- a/clang/compiler-course/lysov_ivan_1stLabs/lysov_ivan_1stLabs.cpp
+++ b/clang/compiler-course/lysov_ivan_1stLabs/lysov_ivan_1stLabs.cpp
@@ -9,70 +9,75 @@
 using llvm::outs;
 
 namespace {
-						   
+
 class UnusedVarLabel final : public clang::RecursiveASTVisitor<UnusedVarLabel> {
 public:
-  explicit UnusedVarLabel(clang::ASTContext *ctx, clang::Rewriter &rwrt) : context(ctx), rewriter(rwrt) {}
-											 
-  bool VisitVarDecl(clang::VarDecl *var) {
-    if (!var->isUsed() && !var->isImplicit() && !var->hasAttr<clang::UnusedAttr>()) {
-        outs() << "Marking variable as maybe_unused: " << var->getNameAsString() << "\n";
-        auto *attr = clang::UnusedAttr::CreateImplicit(*context);
-        var->addAttr(attr);
-        clang::SourceLocation loc = var->getSourceRange().getBegin();
-        rewriter.InsertText(loc, "[[maybe_unused]] ", true, true);
-    }
-    return true;
-  }
+    explicit UnusedVarLabel(clang::ASTContext *ctx, clang::Rewriter &rwrt)
+        : context(ctx), rewriter(rwrt) {}
 
-  bool VisitParmVarDecl(clang::ParmVarDecl *param) {
-    if (!param->isUsed() && !param->isImplicit() && !param->hasAttr<clang::UnusedAttr>()) {
-        outs() << "Marking parameter as maybe_unused: " << param->getNameAsString() << "\n";
-        auto *attr = clang::UnusedAttr::CreateImplicit(*context);
-        param->addAttr(attr);
-        clang::SourceLocation loc = param->getSourceRange().getBegin();
-        rewriter.InsertText(loc, "[[maybe_unused]] ", true, true);
+    bool VisitVarDecl(clang::VarDecl *var) {
+        if (!var->isUsed() && !var->isImplicit() && !var->hasAttr<clang::UnusedAttr>()) {
+            outs() << "Marking variable as maybe_unused: " << var->getNameAsString() << "\n";
+            auto *attr = clang::UnusedAttr::CreateImplicit(*context);
+            var->addAttr(attr);
+            clang::SourceLocation loc = var->getSourceRange().getBegin();
+            rewriter.InsertText(loc, "[[maybe_unused]] ", true, true);
+        }
+        return true;
     }
-    return true;
-  }
+
+    bool VisitParmVarDecl(clang::ParmVarDecl *param) {
+        if (!param->isUsed() && !param->isImplicit() && !param->hasAttr<clang::UnusedAttr>()) {
+            outs() << "Marking parameter as maybe_unused: " << param->getNameAsString() << "\n";
+            auto *attr = clang::UnusedAttr::CreateImplicit(*context);
+            param->addAttr(attr);
+            clang::SourceLocation loc = param->getSourceRange().getBegin();
+            rewriter.InsertText(loc, "[[maybe_unused]] ", true, true);
+        }
+        return true;
+    }
 
 private:
-  clang::ASTContext *context;
-  clang::Rewriter &rewriter;
+    clang::ASTContext *context;
+    clang::Rewriter &rewriter;
 };
 
 class ASTProcessor final : public clang::ASTConsumer {
 public:
-  explicit ASTProcessor(clang::ASTContext *ctx, clang::Rewriter &rwrt) : Label(ctx, rwrt) {}							  
-  void HandleTranslationUnit(clang::ASTContext &ctx) override {
-    Label.TraverseDecl(ctx.getTranslationUnitDecl());
-  }
+    explicit ASTProcessor(clang::ASTContext *ctx, clang::Rewriter &rwrt)
+        : Label(ctx, rwrt) {}
+
+    void HandleTranslationUnit(clang::ASTContext &ctx) override {
+        Label.TraverseDecl(ctx.getTranslationUnitDecl());
+    }
 
 private:
-  UnusedVarLabel Label;
+    UnusedVarLabel Label;
 };
 
 class PluginEntry final : public clang::PluginASTAction {
 public:
-  std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
-    rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
-    return std::make_unique<ASTProcessor>(&ci.getASTContext(), rewriter);
-  }
-									 
-  bool ParseArgs(const clang::CompilerInstance &ci, const std::vector<std::string> &args) override {
-																	  
-    return true;
-  }
+    std::unique_ptr<clang::ASTConsumer>
+    CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+        rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
+        return std::make_unique<ASTProcessor>(&ci.getASTContext(), rewriter);
+    }
 
-  void EndSourceFileAction() override {
-    rewriter.getEditBuffer(rewriter.getSourceMgr().getMainFileID()).write(llvm::outs());					 
-  }
+    bool ParseArgs(const clang::CompilerInstance &ci, const std::vector<std::string> &args) override {
+        return true;
+    }
+
+    void EndSourceFileAction() override {
+        rewriter.getEditBuffer(rewriter.getSourceMgr().getMainFileID()).write(llvm::outs());
+    }
 
 private:
-  clang::Rewriter rewriter;			
-   
+    clang::Rewriter rewriter;
 };
 
 } // namespace
+
 static clang::FrontendPluginRegistry::Add<PluginEntry>
-    X("unUsedVarPlugin_LysovIvan_FIIT3_ClangAST", "The plugin detects unused variables and function parameters in code and adds the [[maybe_unused]] attribute.");
+    X("unUsedVarPlugin_LysovIvan_FIIT3_ClangAST",
+      "The plugin detects unused variables and function parameters in code and "
+      "adds the [[maybe_unused]] attribute.");

--- a/clang/compiler-course/lysov_ivan_1stLabs/lysov_ivan_1stLabs.cpp
+++ b/clang/compiler-course/lysov_ivan_1stLabs/lysov_ivan_1stLabs.cpp
@@ -10,7 +10,7 @@ namespace {
 class UnusedVarMyVisitor final
     : public clang::RecursiveASTVisitor<UnusedVarMyVisitor> {
 public:
-  explicit UnusedVarMyVisitor(clang::ASTContext *ctx, clang::Rewriter &rwrt)
+  UnusedVarMyVisitor(clang::ASTContext *ctx, clang::Rewriter &rwrt)
       : context(ctx), rewriter(rwrt) {}
   bool VisitVarDecl(clang::VarDecl *var) {
     if (!var->isUsed() && !var->hasAttr<clang::UnusedAttr>()) {
@@ -35,7 +35,7 @@ private:
 
 class UnusedVarConsumer final : public clang::ASTConsumer {
 public:
-  explicit UnusedVarConsumer(clang::ASTContext *ctx, clang::Rewriter &rwrt)
+  UnusedVarConsumer(clang::ASTContext *ctx, clang::Rewriter &rwrt)
       : Label(ctx, rwrt) {}
 
   void HandleTranslationUnit(clang::ASTContext &ctx) override {

--- a/clang/compiler-course/lysov_ivan_1stLabs/lysov_ivan_1stLabs.cpp
+++ b/clang/compiler-course/lysov_ivan_1stLabs/lysov_ivan_1stLabs.cpp
@@ -6,37 +6,24 @@
 #include "clang/Rewrite/Core/Rewriter.h"
 #include "llvm/Support/raw_ostream.h"
 
-using llvm::outs;
-
 namespace {
-
-class UnusedVarLabel final : public clang::RecursiveASTVisitor<UnusedVarLabel> {
+class UnusedVarMyVisitor final
+    : public clang::RecursiveASTVisitor<UnusedVarMyVisitor> {
 public:
-  explicit UnusedVarLabel(clang::ASTContext *ctx, clang::Rewriter &rwrt)
+  explicit UnusedVarMyVisitor(clang::ASTContext *ctx, clang::Rewriter &rwrt)
       : context(ctx), rewriter(rwrt) {}
-
   bool VisitVarDecl(clang::VarDecl *var) {
-    if (!var->isUsed() && !var->isImplicit() &&
-        !var->hasAttr<clang::UnusedAttr>()) {
-      outs() << "Marking variable as maybe_unused: " << var->getNameAsString()
-             << "\n";
-      auto *attr = clang::UnusedAttr::CreateImplicit(*context);
-      var->addAttr(attr);
+    if (!var->isUsed() && !var->hasAttr<clang::UnusedAttr>()) {
       clang::SourceLocation loc = var->getSourceRange().getBegin();
-      rewriter.InsertText(loc, "[[maybe_unused]] ", true, true);
+      rewriter.InsertText(loc, "[[maybe_unused]]");
     }
     return true;
   }
 
   bool VisitParmVarDecl(clang::ParmVarDecl *param) {
-    if (!param->isUsed() && !param->isImplicit() &&
-        !param->hasAttr<clang::UnusedAttr>()) {
-      outs() << "Marking parameter as maybe_unused: "
-             << param->getNameAsString() << "\n";
-      auto *attr = clang::UnusedAttr::CreateImplicit(*context);
-      param->addAttr(attr);
+    if (!param->isUsed() && !param->hasAttr<clang::UnusedAttr>()) {
       clang::SourceLocation loc = param->getSourceRange().getBegin();
-      rewriter.InsertText(loc, "[[maybe_unused]] ", true, true);
+      rewriter.InsertText(loc, "[[maybe_unused]]");
     }
     return true;
   }
@@ -46,9 +33,9 @@ private:
   clang::Rewriter &rewriter;
 };
 
-class ASTProcessor final : public clang::ASTConsumer {
+class UnusedVarConsumer final : public clang::ASTConsumer {
 public:
-  explicit ASTProcessor(clang::ASTContext *ctx, clang::Rewriter &rwrt)
+  explicit UnusedVarConsumer(clang::ASTContext *ctx, clang::Rewriter &rwrt)
       : Label(ctx, rwrt) {}
 
   void HandleTranslationUnit(clang::ASTContext &ctx) override {
@@ -56,15 +43,15 @@ public:
   }
 
 private:
-  UnusedVarLabel Label;
+  UnusedVarMyVisitor Label;
 };
 
-class PluginEntry final : public clang::PluginASTAction {
+class UnusedVarAction final : public clang::PluginASTAction {
 public:
   std::unique_ptr<clang::ASTConsumer>
   CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
     rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
-    return std::make_unique<ASTProcessor>(&ci.getASTContext(), rewriter);
+    return std::make_unique<UnusedVarConsumer>(&ci.getASTContext(), rewriter);
   }
 
   bool ParseArgs(const clang::CompilerInstance &ci,
@@ -83,7 +70,7 @@ private:
 
 } // namespace
 
-static clang::FrontendPluginRegistry::Add<PluginEntry>
+static clang::FrontendPluginRegistry::Add<UnusedVarAction>
     X("unUsedVarPlugin_LysovIvan_FIIT3_ClangAST",
       "The plugin detects unused variables and function parameters in code and "
       "adds the [[maybe_unused]] attribute.");

--- a/clang/compiler-course/lysov_ivan_1stLabs/lysov_ivan_1stLabs.cpp
+++ b/clang/compiler-course/lysov_ivan_1stLabs/lysov_ivan_1stLabs.cpp
@@ -12,67 +12,67 @@ namespace {
 
 class UnusedVarLabel final : public clang::RecursiveASTVisitor<UnusedVarLabel> {
 public:
-    explicit UnusedVarLabel(clang::ASTContext *ctx, clang::Rewriter &rwrt)
-        : context(ctx), rewriter(rwrt) {}
+  explicit UnusedVarLabel(clang::ASTContext *ctx, clang::Rewriter &rwrt)
+      : context(ctx), rewriter(rwrt) {}
 
-    bool VisitVarDecl(clang::VarDecl *var) {
-        if (!var->isUsed() && !var->isImplicit() && !var->hasAttr<clang::UnusedAttr>()) {
-            outs() << "Marking variable as maybe_unused: " << var->getNameAsString() << "\n";
-            auto *attr = clang::UnusedAttr::CreateImplicit(*context);
-            var->addAttr(attr);
-            clang::SourceLocation loc = var->getSourceRange().getBegin();
-            rewriter.InsertText(loc, "[[maybe_unused]] ", true, true);
-        }
-        return true;
+  bool VisitVarDecl(clang::VarDecl *var) {
+      if (!var->isUsed() && !var->isImplicit() && !var->hasAttr<clang::UnusedAttr>()) {
+          outs() << "Marking variable as maybe_unused: " << var->getNameAsString() << "\n";
+          auto *attr = clang::UnusedAttr::CreateImplicit(*context);
+          var->addAttr(attr);
+          clang::SourceLocation loc = var->getSourceRange().getBegin();
+          rewriter.InsertText(loc, "[[maybe_unused]] ", true, true);
+      }
+      return true;
     }
 
-    bool VisitParmVarDecl(clang::ParmVarDecl *param) {
-        if (!param->isUsed() && !param->isImplicit() && !param->hasAttr<clang::UnusedAttr>()) {
-            outs() << "Marking parameter as maybe_unused: " << param->getNameAsString() << "\n";
-            auto *attr = clang::UnusedAttr::CreateImplicit(*context);
-            param->addAttr(attr);
-            clang::SourceLocation loc = param->getSourceRange().getBegin();
-            rewriter.InsertText(loc, "[[maybe_unused]] ", true, true);
-        }
-        return true;
+  bool VisitParmVarDecl(clang::ParmVarDecl *param) {
+      if (!param->isUsed() && !param->isImplicit() && !param->hasAttr<clang::UnusedAttr>()) {
+          outs() << "Marking parameter as maybe_unused: " << param->getNameAsString() << "\n";
+          auto *attr = clang::UnusedAttr::CreateImplicit(*context);
+          param->addAttr(attr);
+          clang::SourceLocation loc = param->getSourceRange().getBegin();
+          rewriter.InsertText(loc, "[[maybe_unused]] ", true, true);
+      }
+      return true;
     }
 
 private:
-    clang::ASTContext *context;
-    clang::Rewriter &rewriter;
+  clang::ASTContext *context;
+  clang::Rewriter &rewriter;
 };
 
 class ASTProcessor final : public clang::ASTConsumer {
 public:
-    explicit ASTProcessor(clang::ASTContext *ctx, clang::Rewriter &rwrt)
-        : Label(ctx, rwrt) {}
+  explicit ASTProcessor(clang::ASTContext *ctx, clang::Rewriter &rwrt)
+      : Label(ctx, rwrt) {}
 
-    void HandleTranslationUnit(clang::ASTContext &ctx) override {
-        Label.TraverseDecl(ctx.getTranslationUnitDecl());
+  void HandleTranslationUnit(clang::ASTContext &ctx) override {
+      Label.TraverseDecl(ctx.getTranslationUnitDecl());
     }
 
 private:
-    UnusedVarLabel Label;
+  UnusedVarLabel Label;
 };
 
 class PluginEntry final : public clang::PluginASTAction {
 public:
-    std::unique_ptr<clang::ASTConsumer>
-    CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
-        rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
-        return std::make_unique<ASTProcessor>(&ci.getASTContext(), rewriter);
-    }
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+      rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
+      return std::make_unique<ASTProcessor>(&ci.getASTContext(), rewriter);
+  }
 
-    bool ParseArgs(const clang::CompilerInstance &ci, const std::vector<std::string> &args) override {
-        return true;
-    }
+  bool ParseArgs(const clang::CompilerInstance &ci, const std::vector<std::string> &args) override {
+      return true;
+  }
 
-    void EndSourceFileAction() override {
-        rewriter.getEditBuffer(rewriter.getSourceMgr().getMainFileID()).write(llvm::outs());
-    }
+  void EndSourceFileAction() override {
+      rewriter.getEditBuffer(rewriter.getSourceMgr().getMainFileID()).write(llvm::outs());
+  }
 
 private:
-    clang::Rewriter rewriter;
+  clang::Rewriter rewriter;
 };
 
 } // namespace

--- a/clang/compiler-course/lysov_ivan_1stLabs/lysov_ivan_1stLabs.cpp
+++ b/clang/compiler-course/lysov_ivan_1stLabs/lysov_ivan_1stLabs.cpp
@@ -82,5 +82,3 @@ private:
 } // namespace
 static clang::FrontendPluginRegistry::Add<PluginEntry>
     X("unUsedVarPlugin_LysovIvan_FIIT3_ClangAST", "The plugin detects unused variables and function parameters in code and adds the [[maybe_unused]] attribute.");
-																		  
-						

--- a/clang/compiler-course/lysov_ivan_1stLabs/lysov_ivan_1stLabs.cpp
+++ b/clang/compiler-course/lysov_ivan_1stLabs/lysov_ivan_1stLabs.cpp
@@ -14,7 +14,6 @@ class UnusedVarLabel final : public clang::RecursiveASTVisitor<UnusedVarLabel> {
 public:
   explicit UnusedVarLabel(clang::ASTContext *ctx, clang::Rewriter &rwrt) : context(ctx), rewriter(rwrt) {}
 											 
-
   bool VisitVarDecl(clang::VarDecl *var) {
     if (!var->isUsed() && !var->isImplicit() && !var->hasAttr<clang::UnusedAttr>()) {
         outs() << "Marking variable as maybe_unused: " << var->getNameAsString() << "\n";
@@ -44,9 +43,7 @@ private:
 
 class ASTProcessor final : public clang::ASTConsumer {
 public:
-  explicit ASTProcessor(clang::ASTContext *ctx, clang::Rewriter &rwrt) : Label(ctx, rwrt) {}
-							  
-
+  explicit ASTProcessor(clang::ASTContext *ctx, clang::Rewriter &rwrt) : Label(ctx, rwrt) {}							  
   void HandleTranslationUnit(clang::ASTContext &ctx) override {
     Label.TraverseDecl(ctx.getTranslationUnitDecl());
   }
@@ -61,8 +58,6 @@ public:
     rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
     return std::make_unique<ASTProcessor>(&ci.getASTContext(), rewriter);
   }
-
-	   
 									 
   bool ParseArgs(const clang::CompilerInstance &ci, const std::vector<std::string> &args) override {
 																	  
@@ -70,8 +65,7 @@ public:
   }
 
   void EndSourceFileAction() override {
-    rewriter.getEditBuffer(rewriter.getSourceMgr().getMainFileID()).write(llvm::outs());
-							 
+    rewriter.getEditBuffer(rewriter.getSourceMgr().getMainFileID()).write(llvm::outs());					 
   }
 
 private:

--- a/clang/compiler-course/lysov_ivan_1stLabs/lysov_ivan_1stLabs.cpp
+++ b/clang/compiler-course/lysov_ivan_1stLabs/lysov_ivan_1stLabs.cpp
@@ -1,0 +1,86 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/Attr.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "llvm/Support/raw_ostream.h"
+
+using llvm::outs;
+
+namespace {
+						   
+class UnusedVarLabel final : public clang::RecursiveASTVisitor<UnusedVarLabel> {
+public:
+  explicit UnusedVarLabel(clang::ASTContext *ctx, clang::Rewriter &rwrt) : context(ctx), rewriter(rwrt) {}
+											 
+
+  bool VisitVarDecl(clang::VarDecl *var) {
+    if (!var->isUsed() && !var->isImplicit() && !var->hasAttr<clang::UnusedAttr>()) {
+        outs() << "Marking variable as maybe_unused: " << var->getNameAsString() << "\n";
+        auto *attr = clang::UnusedAttr::CreateImplicit(*context);
+        var->addAttr(attr);
+        clang::SourceLocation loc = var->getSourceRange().getBegin();
+        rewriter.InsertText(loc, "[[maybe_unused]] ", true, true);
+    }
+    return true;
+  }
+
+  bool VisitParmVarDecl(clang::ParmVarDecl *param) {
+    if (!param->isUsed() && !param->isImplicit() && !param->hasAttr<clang::UnusedAttr>()) {
+        outs() << "Marking parameter as maybe_unused: " << param->getNameAsString() << "\n";
+        auto *attr = clang::UnusedAttr::CreateImplicit(*context);
+        param->addAttr(attr);
+        clang::SourceLocation loc = param->getSourceRange().getBegin();
+        rewriter.InsertText(loc, "[[maybe_unused]] ", true, true);
+    }
+    return true;
+  }
+
+private:
+  clang::ASTContext *context;
+  clang::Rewriter &rewriter;
+};
+
+class ASTProcessor final : public clang::ASTConsumer {
+public:
+  explicit ASTProcessor(clang::ASTContext *ctx, clang::Rewriter &rwrt) : Label(ctx, rwrt) {}
+							  
+
+  void HandleTranslationUnit(clang::ASTContext &ctx) override {
+    Label.TraverseDecl(ctx.getTranslationUnitDecl());
+  }
+
+private:
+  UnusedVarLabel Label;
+};
+
+class PluginEntry final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
+    return std::make_unique<ASTProcessor>(&ci.getASTContext(), rewriter);
+  }
+
+	   
+									 
+  bool ParseArgs(const clang::CompilerInstance &ci, const std::vector<std::string> &args) override {
+																	  
+    return true;
+  }
+
+  void EndSourceFileAction() override {
+    rewriter.getEditBuffer(rewriter.getSourceMgr().getMainFileID()).write(llvm::outs());
+							 
+  }
+
+private:
+  clang::Rewriter rewriter;			
+   
+};
+
+} // namespace
+static clang::FrontendPluginRegistry::Add<PluginEntry>
+    X("unUsedVarPlugin_LysovIvan_FIIT3_ClangAST", "The plugin detects unused variables and function parameters in code and adds the [[maybe_unused]] attribute.");
+																		  
+						

--- a/clang/compiler-course/lysov_ivan_1stLabs/lysov_ivan_1stLabs.cpp
+++ b/clang/compiler-course/lysov_ivan_1stLabs/lysov_ivan_1stLabs.cpp
@@ -16,26 +16,30 @@ public:
       : context(ctx), rewriter(rwrt) {}
 
   bool VisitVarDecl(clang::VarDecl *var) {
-      if (!var->isUsed() && !var->isImplicit() && !var->hasAttr<clang::UnusedAttr>()) {
-          outs() << "Marking variable as maybe_unused: " << var->getNameAsString() << "\n";
-          auto *attr = clang::UnusedAttr::CreateImplicit(*context);
-          var->addAttr(attr);
-          clang::SourceLocation loc = var->getSourceRange().getBegin();
-          rewriter.InsertText(loc, "[[maybe_unused]] ", true, true);
-      }
-      return true;
+    if (!var->isUsed() && !var->isImplicit() &&
+        !var->hasAttr<clang::UnusedAttr>()) {
+      outs() << "Marking variable as maybe_unused: " << var->getNameAsString()
+             << "\n";
+      auto *attr = clang::UnusedAttr::CreateImplicit(*context);
+      var->addAttr(attr);
+      clang::SourceLocation loc = var->getSourceRange().getBegin();
+      rewriter.InsertText(loc, "[[maybe_unused]] ", true, true);
     }
+    return true;
+  }
 
   bool VisitParmVarDecl(clang::ParmVarDecl *param) {
-      if (!param->isUsed() && !param->isImplicit() && !param->hasAttr<clang::UnusedAttr>()) {
-          outs() << "Marking parameter as maybe_unused: " << param->getNameAsString() << "\n";
-          auto *attr = clang::UnusedAttr::CreateImplicit(*context);
-          param->addAttr(attr);
-          clang::SourceLocation loc = param->getSourceRange().getBegin();
-          rewriter.InsertText(loc, "[[maybe_unused]] ", true, true);
-      }
-      return true;
+    if (!param->isUsed() && !param->isImplicit() && 
+        !param->hasAttr<clang::UnusedAttr>()) {
+      outs() << "Marking parameter as maybe_unused: " 
+             << param->getNameAsString() << "\n";
+      auto *attr = clang::UnusedAttr::CreateImplicit(*context);
+      param->addAttr(attr);
+      clang::SourceLocation loc = param->getSourceRange().getBegin();
+      rewriter.InsertText(loc, "[[maybe_unused]] ", true, true);
     }
+    return true;
+  }
 
 private:
   clang::ASTContext *context;
@@ -48,8 +52,8 @@ public:
       : Label(ctx, rwrt) {}
 
   void HandleTranslationUnit(clang::ASTContext &ctx) override {
-      Label.TraverseDecl(ctx.getTranslationUnitDecl());
-    }
+    Label.TraverseDecl(ctx.getTranslationUnitDecl());
+  }
 
 private:
   UnusedVarLabel Label;
@@ -59,16 +63,18 @@ class PluginEntry final : public clang::PluginASTAction {
 public:
   std::unique_ptr<clang::ASTConsumer>
   CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
-      rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
-      return std::make_unique<ASTProcessor>(&ci.getASTContext(), rewriter);
+    rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
+    return std::make_unique<ASTProcessor>(&ci.getASTContext(), rewriter);
   }
 
-  bool ParseArgs(const clang::CompilerInstance &ci, const std::vector<std::string> &args) override {
-      return true;
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
   }
 
   void EndSourceFileAction() override {
-      rewriter.getEditBuffer(rewriter.getSourceMgr().getMainFileID()).write(llvm::outs());
+    rewriter.getEditBuffer(rewriter.getSourceMgr().getMainFileID())
+        .write(llvm::outs());
   }
 
 private:

--- a/clang/test/compiler-course/lysov_ivan_1stLabsTests/test.cpp
+++ b/clang/test/compiler-course/lysov_ivan_1stLabsTests/test.cpp
@@ -1,17 +1,32 @@
 // RUN: %clang_cc1 -load %llvmshlibdir/unUsedVarPlugin_LysovIvan_FIIT3_ClangAST%pluginext -plugin unUsedVarPlugin_LysovIvan_FIIT3_ClangAST %s -fsyntax-only 2>&1 | FileCheck %s
 
-// CHECK: Marking variable as maybe_unused: c
-// CHECK-NEXT: Marking variable as maybe_unused: value
-int foo(int a, int b, int c) {
+//CHECK: int FunctionFromTheProblemStatement(int a, int b, int c) {
+//CHECK: \[\[maybe_unused\]\] double value = 0.0;
+//CHECK: return a + b;
+int FunctionFromTheProblemStatement(int a, int b, int c) {
     double value = 0.0;
     return a + b;
 }
 
-// CHECK: Marking variable as maybe_unused: unused
-// CHECK-NEXT: Marking variable as maybe_unused: x
-void test_params(int used, int unused) {
+//CHECK: void test_params(int used, \[\[maybe_unused\]\] int unused) {
+//CHECK: int x = used;
+//CHECK: return x;
+int test_params(int used, int unused) {
     int x = used;
+    return x;
 }
 
-// CHECK: Marking variable as maybe_unused: globalVar
+//CHECK: \[\[maybe_unused\]\] int globalVar = 6;
 int globalVar = 6;
+
+//CHECK: void checkWithoutReturn(int a, \[\[maybe_unused\]\] long d){
+//CHECK: \[\[maybe_unused\]\] int g = a;
+void checkWithoutReturn(int a, long d){
+    int g = a;
+}
+
+//CHECK: void checkConstantParamsFunction(\[\[maybe_unused\]\] const int x, float j){
+//CHECK: \[\[maybe_unused\]\] float y = j ;
+void checkConstantParamsFunction(const int x, float j){
+    float y = j;
+}

--- a/clang/test/compiler-course/lysov_ivan_1stLabsTests/test.cpp
+++ b/clang/test/compiler-course/lysov_ivan_1stLabsTests/test.cpp
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/unUsedVarPlugin_LysovIvan_FIIT3_ClangAST%pluginext -plugin unUsedVarPlugin_LysovIvan_FIIT3_ClangAST %s -fsyntax-only 2>&1 | FileCheck %s
+
+// CHECK: Marking variable as maybe_unused: c
+// CHECK-NEXT: Marking variable as maybe_unused: value
+int foo(int a, int b, int c) {
+    double value = 0.0;
+    return a + b;
+}
+
+// CHECK: Marking variable as maybe_unused: unused
+// CHECK-NEXT: Marking variable as maybe_unused: x
+void test_params(int used, int unused) {
+    int x = used;
+}
+
+// CHECK: Marking variable as maybe_unused: globalVar
+int globalVar = 6;

--- a/clang/test/compiler-course/lysov_ivan_1stLabsTests/test.cpp
+++ b/clang/test/compiler-course/lysov_ivan_1stLabsTests/test.cpp
@@ -30,3 +30,11 @@ void checkWithoutReturn(int a, long d){
 void checkConstantParamsFunction(const int x, float j){
     float y = j;
 }
+
+//CHECK: void funcforReview(){
+//CHECK: int x __attribute__((unused));
+//CHECK: \[\[maybe_unused\]\] int y;
+void funcforReview() {
+    int x __attribute__((unused));
+    int y;
+}


### PR DESCRIPTION
Плагин который автоматически помечает неиспользуемые переменные и параметры атрибутом [[maybe_unused]].
Плагин анализирует AST, находит неиспользуемые переменные (VarDecl) и параметры функций (ParmVarDecl), после чего добавляет к ним атрибут [[maybe_unused]] с помощью Rewriter.