### PR TITLE
Дудченко Олеся. Лабораторная работа 1. Clang AST. Вариант 1.

### DIFF
--- a/clang/compiler-course/dudchenko_o_ast_var_1/CMakeLists.txt
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "Data_types")
+set(Student "Dudchenko_Olesya")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -35,11 +35,16 @@ public:
     if (record->method_begin() != record->method_end()) {
       llvm::outs() << "|_Methods\n";
       for (const auto *method : record->methods()) {
+        // Пропускаем автоматически сгенерированные методы
+        if (method->isImplicit() || method->isDefaulted()) {
+          continue;
+        }
+
         llvm::outs() << "| |_ " << method->getNameAsString() << " ("
                      << method->getReturnType().getAsString() << "()|"
                      << getAccessSpecifierString(method->getAccess()) << "|"
                      << (method->isVirtual() ? "virtual|" : "")
-                     << (method->isPureVirtual() ? "pure|" : "") // Используем isPureVirtual()
+                     << (method->isPureVirtual() ? "pure|" : "")
                      << (method->size_overridden_methods() > 0 ? "override" : "")
                      << ")\n";
       }

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -39,7 +39,7 @@ public:
     if (record->field_begin() != record->field_end()) {
       outs << "|_Fields\n";
       for (const auto *field : record->fields()) {
-        std::string fieldName = field->getName();
+        std::string fieldName = field->getName().str();
         if (fieldName.empty()) {
           fieldName = "(anonymous)";
         }

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -20,7 +20,7 @@ public:
       llvm::outs() << " -> " << record->bases_begin()->getType()->getAsCXXRecordDecl()->getName();
     }
 
-    llvm::outs() << "| \n";
+    llvm::outs() << " \n";
 
     if (record->field_begin() != record->field_end()) {
       llvm::outs() << "|_Fields\n";
@@ -32,6 +32,7 @@ public:
     }
 
     if (record->method_begin() != record->method_end()) {
+      llvm::outs() << "|\n";
       llvm::outs() << "|_Methods\n";
       bool firstMethod = true;
       for (const auto *method : record->methods()) {

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -47,25 +47,24 @@ public:
 
         llvm::outs() << "| |_ " << method->getNameAsString() << " (" 
         << method->getReturnType().getAsString() << "()|"
-        << getAccessSpecifierString(method->getAccess()) << "|";
+        << getAccessSpecifierString(method->getAccess());
 
         bool isVirtualMethod = method->isVirtual();
         bool isPureVirtual = method->isPureVirtual();
         bool hasOverride = method->size_overridden_methods() > 0;
 
-        // Обработка виртуальных методов
         if (isVirtualMethod) {
-          if (hasOverride) {
-            llvm::outs() << "override";
-          } else {
-            llvm::outs() << "virtual";
+        if (hasOverride) {
+          llvm::outs() << "|override";
+        } else {
+            llvm::outs() << "|virtual";
             if (isPureVirtual) {
               llvm::outs() << "|pure";
             }
           }
         } else {
           if (isPureVirtual) {
-            llvm::outs() << "pure";
+            llvm::outs() << "|pure";
           }
         }
 

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -17,7 +17,9 @@ public:
     llvm::outs() << record->getName();
 
     if (record->getNumBases() > 0) {
-      llvm::outs() << " -> " << record->bases_begin()->getType()->getAsCXXRecordDecl()->getName();
+      llvm::outs()
+          << " -> "
+          << record->bases_begin()->getType()->getAsCXXRecordDecl()->getName();
     }
 
     llvm::outs() << " \n";
@@ -25,9 +27,9 @@ public:
     if (record->field_begin() != record->field_end()) {
       llvm::outs() << "|_Fields\n";
       for (const auto *field : record->fields()) {
-          llvm::outs() << "| |_ " << field->getName() << " (" 
-                      << field->getType().getAsString() << "|"
-                      << getAccessSpecifierString(field->getAccess()) << ")\n";
+        llvm::outs() << "| |_ " << field->getName() << " ("
+                     << field->getType().getAsString() << "|"
+                     << getAccessSpecifierString(field->getAccess()) << ")\n";
       }
     }
 
@@ -45,18 +47,18 @@ public:
           firstMethod = false;
         }
 
-        llvm::outs() << "| |_ " << method->getNameAsString() << " (" 
-        << method->getReturnType().getAsString() << "()|"
-        << getAccessSpecifierString(method->getAccess());
+        llvm::outs() << "| |_ " << method->getNameAsString() << " ("
+                     << method->getReturnType().getAsString() << "()|"
+                     << getAccessSpecifierString(method->getAccess());
 
         bool isVirtualMethod = method->isVirtual();
         bool isPureVirtual = method->isPureVirtual();
         bool hasOverride = method->size_overridden_methods() > 0;
 
         if (isVirtualMethod) {
-        if (hasOverride) {
-          llvm::outs() << "|override";
-        } else {
+          if (hasOverride) {
+            llvm::outs() << "|override";
+          } else {
             llvm::outs() << "|virtual";
             if (isPureVirtual) {
               llvm::outs() << "|pure";
@@ -78,14 +80,14 @@ public:
 private:
   std::string getAccessSpecifierString(clang::AccessSpecifier access) {
     switch (access) {
-      case clang::AS_public:
-        return "public";
-      case clang::AS_protected:
-        return "protected";
-      case clang::AS_private:
-        return "private";
-      case clang::AS_none:
-        return "none";
+    case clang::AS_public:
+      return "public";
+    case clang::AS_protected:
+      return "protected";
+    case clang::AS_private:
+      return "private";
+    case clang::AS_none:
+      return "none";
     }
     return "unknown";
   }

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -48,8 +48,8 @@ public:
         llvm::outs() << "| |_ " << method->getNameAsString() << " (" 
                     << method->getReturnType().getAsString() << "()|"
                     << getAccessSpecifierString(method->getAccess()) << "|"
-                    << (method->isVirtual() ? "virtual|" : "")
-                    << (method->isPureVirtual() ? "pure|" : "")
+                    << (method->isVirtual() ? "virtual" : "")
+                    << (method->isPureVirtual() ? "pure" : "")
                     << (method->size_overridden_methods() > 0 ? "override" : "")
                     << ")\n";
       }

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -17,7 +17,9 @@ public:
     llvm::outs() << record->getName();
 
     if (record->getNumBases() > 0) {
-      llvm::outs() << " -> " << record->bases_begin()->getType()->getAsCXXRecordDecl()->getName();
+      llvm::outs()
+          << " -> "
+          << record->bases_begin()->getType()->getAsCXXRecordDecl()->getName();
     }
 
     llvm::outs() << " \n";
@@ -25,9 +27,9 @@ public:
     if (record->field_begin() != record->field_end()) {
       llvm::outs() << "|_Fields\n";
       for (const auto *field : record->fields()) {
-          llvm::outs() << "| |_ " << field->getName() << " (" 
-                      << field->getType().getAsString() << "|"
-                      << getAccessSpecifierString(field->getAccess()) << ")\n";
+        llvm::outs() << "| |_ " << field->getName() << " ("
+                     << field->getType().getAsString() << "|"
+                     << getAccessSpecifierString(field->getAccess()) << ")\n";
       }
     }
 
@@ -45,29 +47,28 @@ public:
           firstMethod = false;
         }
 
-        llvm::outs() << "| |_ " << method->getNameAsString() << " (" 
-        << method->getReturnType().getAsString() << "()|"
-        << getAccessSpecifierString(method->getAccess());
+        llvm::outs() << "| |_ " << method->getNameAsString() << " ("
+                     << method->getReturnType().getAsString() << "()|"
+                     << getAccessSpecifierString(method->getAccess());
 
         bool isVirtualMethod = method->isVirtual();
         bool isPureVirtual = method->isPureVirtual();
         bool hasOverride = method->size_overridden_methods() > 0;
 
         if (isVirtualMethod) {
-        if (hasOverride) {
-          llvm::outs() << "|override";
-        } else {
-            llvm::outs() << "|virtual";
+          if (hasOverride) {
+            llvm::outs() << "|override";
+          } else {
+              llvm::outs() << "|virtual";
+              if (isPureVirtual) {
+                llvm::outs() << "|pure";
+              }
+            }
+          } else {
             if (isPureVirtual) {
               llvm::outs() << "|pure";
             }
           }
-        } else {
-          if (isPureVirtual) {
-            llvm::outs() << "|pure";
-          }
-        }
-
         llvm::outs() << ")\n";
       }
     }
@@ -78,14 +79,14 @@ public:
 private:
   std::string getAccessSpecifierString(clang::AccessSpecifier access) {
     switch (access) {
-      case clang::AS_public:
-        return "public";
-      case clang::AS_protected:
-        return "protected";
-      case clang::AS_private:
-        return "private";
-      case clang::AS_none:
-        return "none";
+    case clang::AS_public:
+      return "public";
+    case clang::AS_protected:
+      return "protected";
+    case clang::AS_private:
+      return "private";
+    case clang::AS_none:
+      return "none";
     }
     return "unknown";
   }

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -1,0 +1,97 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+class TypeInfoVisitor : public clang::RecursiveASTVisitor<TypeInfoVisitor> {
+public:
+  explicit TypeInfoVisitor(clang::ASTContext *context) : m_context(context) {}
+
+  bool VisitCXXRecordDecl(clang::CXXRecordDecl *record) {
+    // Выводим имя структуры/класса
+    llvm::outs() << record->getName() << "\n";
+
+    // Выводим базовые классы
+    if (record->getNumBases() > 0) {
+      llvm::outs() << "|_Base Classes\n";
+      for (const auto &base : record->bases()) {
+        llvm::outs() << "| |_ " << base.getType()->getAsCXXRecordDecl()->getName() << "\n";
+      }
+    }
+
+    // Выводим поля
+    if (record->field_begin() != record->field_end()) {
+      llvm::outs() << "|_Fields\n";
+      for (const auto *field : record->fields()) {
+        llvm::outs() << "| |_ " << field->getName() << " (" 
+                     << field->getType().getAsString() << "|"
+                     << getAccessSpecifierString(field->getAccess()) << ")\n";
+      }
+    }
+
+    // Выводим методы
+    if (record->method_begin() != record->method_end()) {
+      llvm::outs() << "|_Methods\n";
+      for (const auto *method : record->methods()) {
+        llvm::outs() << "| |_ " << method->getNameAsString() << " ("
+                     << method->getReturnType().getAsString() << "()|"
+                     << getAccessSpecifierString(method->getAccess()) << "|"
+                     << (method->isVirtual() ? "virtual|" : "")
+                     << (method->isPure() ? "pure|" : "")
+                     << (method->size_overridden_methods() > 0 ? "override" : "")
+                     << ")\n";
+      }
+    }
+
+    llvm::outs() << "\n";
+    return true;
+  }
+
+private:
+  clang::ASTContext *m_context;
+
+  std::string getAccessSpecifierString(clang::AccessSpecifier access) {
+    switch (access) {
+      case clang::AS_public:
+        return "public";
+      case clang::AS_protected:
+        return "protected";
+      case clang::AS_private:
+        return "private";
+      case clang::AS_none:
+        return "none";
+    }
+    return "unknown";
+  }
+};
+
+class TypeInfoConsumer : public clang::ASTConsumer {
+public:
+  explicit TypeInfoConsumer(clang::ASTContext *context) : m_visitor(context) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+  }
+
+private:
+  TypeInfoVisitor m_visitor;
+};
+
+class TypeInfoAction : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    return std::make_unique<TypeInfoConsumer>(&ci.getASTContext());
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+};
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<TypeInfoAction>
+    X("type_info_plugin", "Prints information about user-defined types");

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -48,7 +48,6 @@ public:
       }
     }
 
-    llvm::outs() << "\n";
     return true;
   }
 

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -44,7 +44,7 @@ public:
           fieldName = "(anonymous)";
         }
         outs << "| |_ " << fieldName << " (" << field->getType().getAsString()
-          << "|" << getAccessSpecifierString(field->getAccess()) << ")\n";
+             << "|" << getAccessSpecifierString(field->getAccess()) << ")\n";
       }
     }
 
@@ -70,8 +70,8 @@ public:
           }
 
           outs << "| |_ " << methodName << " ("
-              << method->getReturnType().getAsString() << "()|"
-              << getAccessSpecifierString(method->getAccess());
+               << method->getReturnType().getAsString() << "()|"
+               << getAccessSpecifierString(method->getAccess());
 
           bool isVirtualMethod = method->isVirtual();
           bool isPureVirtual = method->isPureVirtual();

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -10,70 +10,96 @@ public:
   explicit TypeInfoVisitor(clang::ASTContext *context) {}
 
   bool VisitCXXRecordDecl(clang::CXXRecordDecl *record) {
-    if (record->isImplicit()) {
+    auto &outs = llvm::outs();  // Убрали дублирование кода
+    
+    if (record->isImplicit() || record->getName().empty()) {
       return true;
     }
 
-    llvm::outs() << record->getName();
-
+    // Print class name and inheritance
+    outs << record->getName();
+    
     if (record->getNumBases() > 0) {
-      llvm::outs()
-          << " -> "
-          << record->bases_begin()->getType()->getAsCXXRecordDecl()->getName();
+      outs << " -> ";
+      bool firstBase = true;
+      for (const auto &base : record->bases()) {
+        if (!firstBase) {
+          outs << ", ";
+        }
+        auto *baseDecl = base.getType()->getAsCXXRecordDecl();
+        if (baseDecl && !baseDecl->getName().empty()) {
+          outs << baseDecl->getName();
+        } else {
+          outs << base.getType().getAsString();
+        }
+        firstBase = false;
+      }
     }
+    outs << "\n";
 
-    llvm::outs() << " \n";
-
+    // Print fields
     if (record->field_begin() != record->field_end()) {
-      llvm::outs() << "|_Fields\n";
+      outs << "|_Fields\n";
       for (const auto *field : record->fields()) {
-        llvm::outs() << "| |_ " << field->getName() << " ("
-                     << field->getType().getAsString() << "|"
-                     << getAccessSpecifierString(field->getAccess()) << ")\n";
+        std::string fieldName = field->getName();
+        if (fieldName.empty()) {
+          fieldName = "(anonymous)";
+        }
+        outs << "| |_ " << fieldName << " ("
+           << field->getType().getAsString() << "|"
+           << getAccessSpecifierString(field->getAccess()) << ")\n";
       }
     }
 
-    llvm::outs() << "|\n";
-
+    // Print methods
     if (record->method_begin() != record->method_end()) {
-      llvm::outs() << "|_Methods\n";
-      bool firstMethod = true;
+      bool hasExplicitMethods = false;
       for (const auto *method : record->methods()) {
-        if (method->isImplicit() || method->isDefaulted()) {
-          continue;
+        if (!method->isImplicit() && !method->isDefaulted()) {
+          hasExplicitMethods = true;
+          break;
         }
+      }
 
-        if (firstMethod) {
-          firstMethod = false;
-        }
+      if (hasExplicitMethods) {
+        outs << "|_Methods\n";
+        for (const auto *method : record->methods()) {
+          if (method->isImplicit() || method->isDefaulted()) {
+            continue;
+          }
 
-        llvm::outs() << "| |_ " << method->getNameAsString() << " ("
-                     << method->getReturnType().getAsString() << "()|"
-                     << getAccessSpecifierString(method->getAccess());
+          std::string methodName = method->getNameAsString();
+          if (methodName.empty()) {
+            methodName = "(anonymous)";
+          }
 
-        bool isVirtualMethod = method->isVirtual();
-        bool isPureVirtual = method->isPureVirtual();
-        bool hasOverride = method->size_overridden_methods() > 0;
+          outs << "| |_ " << methodName << " ("
+             << method->getReturnType().getAsString() << "()|"
+             << getAccessSpecifierString(method->getAccess());
 
-        if (isVirtualMethod) {
-          if (hasOverride) {
-            llvm::outs() << "|override";
-          } else {
-            llvm::outs() << "|virtual";
-            if (isPureVirtual) {
-              llvm::outs() << "|pure";
+          bool isVirtualMethod = method->isVirtual();
+          bool isPureVirtual = method->isPureVirtual();
+          bool hasOverride = method->size_overridden_methods() > 0;
+
+          // ИСПРАВЛЕННАЯ ЛОГИКА: не-virtual метод не может быть pure
+          if (isVirtualMethod) {
+            if (hasOverride) {
+              outs << "|override";
+            } else {
+              outs << "|virtual";
+              if (isPureVirtual) {
+                outs << "|pure";
+              }
             }
           }
-        } else {
-          if (isPureVirtual) {
-            llvm::outs() << "|pure";
-          }
-        }
+          // Убрана некорректная ветка для не-virtual pure методов
 
-        llvm::outs() << ")\n";
+          outs << ")\n";
+        }
       }
     }
 
+    outs << "|\n";
     return true;
   }
 
@@ -115,6 +141,10 @@ public:
   bool ParseArgs(const clang::CompilerInstance &ci,
                  const std::vector<std::string> &args) override {
     return true;
+  }
+
+  PluginASTAction::ActionType getActionType() override {
+    return AddAfterMainAction;
   }
 };
 } // namespace

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -48,7 +48,7 @@ public:
         llvm::outs() << "| |_ " << method->getNameAsString() << " (" 
                     << method->getReturnType().getAsString() << "()|"
                     << getAccessSpecifierString(method->getAccess()) << "|"
-                    << (method->isVirtual() ? "virtual" : "")
+                    << (method->isVirtual() ? "virtual|" : "")
                     << (method->isPureVirtual() ? "pure" : "")
                     << (method->size_overridden_methods() > 0 ? "override" : "")
                     << ")\n";

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -10,15 +10,14 @@ public:
   explicit TypeInfoVisitor(clang::ASTContext *context) {}
 
   bool VisitCXXRecordDecl(clang::CXXRecordDecl *record) {
-    auto &outs = llvm::outs();  // Убрали дублирование кода
-    
+    auto &outs = llvm::outs();
+
     if (record->isImplicit() || record->getName().empty()) {
       return true;
     }
 
-    // Print class name and inheritance
     outs << record->getName();
-    
+
     if (record->getNumBases() > 0) {
       outs << " -> ";
       bool firstBase = true;
@@ -37,7 +36,6 @@ public:
     }
     outs << "\n";
 
-    // Print fields
     if (record->field_begin() != record->field_end()) {
       outs << "|_Fields\n";
       for (const auto *field : record->fields()) {
@@ -45,13 +43,11 @@ public:
         if (fieldName.empty()) {
           fieldName = "(anonymous)";
         }
-        outs << "| |_ " << fieldName << " ("
-           << field->getType().getAsString() << "|"
-           << getAccessSpecifierString(field->getAccess()) << ")\n";
+        outs << "| |_ " << fieldName << " (" << field->getType().getAsString()
+          << "|" << getAccessSpecifierString(field->getAccess()) << ")\n";
       }
     }
 
-    // Print methods
     if (record->method_begin() != record->method_end()) {
       bool hasExplicitMethods = false;
       for (const auto *method : record->methods()) {
@@ -74,14 +70,13 @@ public:
           }
 
           outs << "| |_ " << methodName << " ("
-             << method->getReturnType().getAsString() << "()|"
-             << getAccessSpecifierString(method->getAccess());
+              << method->getReturnType().getAsString() << "()|"
+              << getAccessSpecifierString(method->getAccess());
 
           bool isVirtualMethod = method->isVirtual();
           bool isPureVirtual = method->isPureVirtual();
           bool hasOverride = method->size_overridden_methods() > 0;
 
-          // ИСПРАВЛЕННАЯ ЛОГИКА: не-virtual метод не может быть pure
           if (isVirtualMethod) {
             if (hasOverride) {
               outs << "|override";
@@ -92,7 +87,6 @@ public:
               }
             }
           }
-          // Убрана некорректная ветка для не-virtual pure методов
 
           outs << ")\n";
         }

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -6,13 +6,28 @@
 
 namespace {
 class TypeInfoVisitor : public clang::RecursiveASTVisitor<TypeInfoVisitor> {
+private:
+  clang::ASTContext *m_context;
+
 public:
-  explicit TypeInfoVisitor(clang::ASTContext *context) {}
+  explicit TypeInfoVisitor(clang::ASTContext *context) : m_context(context) {
+    llvm::errs() << "DEBUG: TypeInfoVisitor created\n";
+  }
 
   bool VisitCXXRecordDecl(clang::CXXRecordDecl *record) {
+    llvm::errs() << "DEBUG: Visiting record: " 
+                 << (record->getIdentifier() ? record->getName() : "(anonymous)")
+                 << "\n";
+
     auto &outs = llvm::outs();
 
-    if (record->isImplicit() || !record->getIdentifier()) {
+    if (record->isImplicit()) {
+      llvm::errs() << "DEBUG: Skipping implicit record\n";
+      return true;
+    }
+    
+    if (!record->getIdentifier()) {
+      llvm::errs() << "DEBUG: Skipping anonymous record\n";
       return true;
     }
 
@@ -26,7 +41,7 @@ public:
           outs << ", ";
         }
         auto *baseDecl = base.getType()->getAsCXXRecordDecl();
-        if (baseDecl && !baseDecl->getName().empty()) {
+        if (baseDecl && baseDecl->getIdentifier()) {
           outs << baseDecl->getName();
         } else {
           outs << base.getType().getAsString();
@@ -115,10 +130,14 @@ private:
 
 class TypeInfoConsumer : public clang::ASTConsumer {
 public:
-  explicit TypeInfoConsumer(clang::ASTContext *context) : m_visitor(context) {}
+  explicit TypeInfoConsumer(clang::ASTContext *context) : m_visitor(context) {
+    llvm::errs() << "DEBUG: TypeInfoConsumer created\n";
+  }
 
   void HandleTranslationUnit(clang::ASTContext &context) override {
+    llvm::errs() << "DEBUG: Handling translation unit\n";
     m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+    llvm::errs() << "DEBUG: Finished traversal\n";
   }
 
 private:
@@ -129,16 +148,18 @@ class TypeInfoAction : public clang::PluginASTAction {
 public:
   std::unique_ptr<clang::ASTConsumer>
   CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    llvm::errs() << "DEBUG: Creating AST consumer\n";
     return std::make_unique<TypeInfoConsumer>(&ci.getASTContext());
   }
 
   bool ParseArgs(const clang::CompilerInstance &ci,
                  const std::vector<std::string> &args) override {
+    llvm::errs() << "DEBUG: ParseArgs called\n";
     return true;
   }
 
   PluginASTAction::ActionType getActionType() override {
-    return AddAfterMainAction;
+    return CmdlineBeforeMainAction;
   }
 };
 } // namespace

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -31,7 +31,7 @@ public:
 
     // Выводим методы
     if (record->method_begin() != record->method_end()) {
-      llvm::outs() << "|_Methods";
+      llvm::outs() << "|_Methods\n";  // Начинаем вывод методов сразу после полей.
       bool firstMethod = true;
       for (const auto *method : record->methods()) {
         // Пропускаем автоматически сгенерированные методы
@@ -40,10 +40,10 @@ public:
         }
 
         if (firstMethod) {
-          llvm::outs() << "\n";
           firstMethod = false;
         }
-        llvm::outs() << "| |_ " << method->getNameAsString() << " ("
+
+        llvm::outs() << "| |_ " << method->getNameAsString() << " (" 
                      << method->getReturnType().getAsString() << "()|"
                      << getAccessSpecifierString(method->getAccess()) << "|"
                      << (method->isVirtual() ? "virtual|" : "")

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -17,9 +17,7 @@ public:
     llvm::outs() << record->getName();
 
     if (record->getNumBases() > 0) {
-      llvm::outs()
-          << " -> "
-          << record->bases_begin()->getType()->getAsCXXRecordDecl()->getName();
+      llvm::outs() << " -> " << record->bases_begin()->getType()->getAsCXXRecordDecl()->getName();
     }
 
     llvm::outs() << " \n";
@@ -27,9 +25,9 @@ public:
     if (record->field_begin() != record->field_end()) {
       llvm::outs() << "|_Fields\n";
       for (const auto *field : record->fields()) {
-        llvm::outs() << "| |_ " << field->getName() << " ("
-                     << field->getType().getAsString() << "|"
-                     << getAccessSpecifierString(field->getAccess()) << ")\n";
+          llvm::outs() << "| |_ " << field->getName() << " (" 
+                      << field->getType().getAsString() << "|"
+                      << getAccessSpecifierString(field->getAccess()) << ")\n";
       }
     }
 
@@ -47,111 +45,51 @@ public:
           firstMethod = false;
         }
 
-        llvm::outs() << "| |_ " << method->getNameAsString() << " ("
-                     << method->getReturnType().getAsString() << "()|"
-                     << getAccessSpecifierString(method->getAccess());
+        llvm::outs() << "| |_ " << method->getNameAsString() << " (" 
+        << method->getReturnType().getAsString() << "()|"
+        << getAccessSpecifierString(method->getAccess());
 
         bool isVirtualMethod = method->isVirtual();
         bool isPureVirtual = method->isPureVirtual();
         bool hasOverride = method->size_overridden_methods() > 0;
 
         if (isVirtualMethod) {
-          if (hasOverride) {
-            llvm::outs() << "|override";
-          } else {
-namespace {
-class TypeInfoVisitor : public clang::RecursiveASTVisitor<TypeInfoVisitor> {
-public:
-  explicit TypeInfoVisitor(clang::ASTContext *context) {}
-
-  bool VisitCXXRecordDecl(clang::CXXRecordDecl *record) {
-    if (record->isImplicit()) {
-      return true;
-    }
-
-    llvm::outs() << record->getName();
-
-    if (record->getNumBases() > 0) {
-      llvm::outs()
-          << " -> "
-          << record->bases_begin()->getType()->getAsCXXRecordDecl()->getName();
-    }
-
-    llvm::outs() << " \n";
-
-    if (record->field_begin() != record->field_end()) {
-      llvm::outs() << "|_Fields\n";
-      for (const auto *field : record->fields()) {
-        llvm::outs() << "| |_ " << field->getName() << " ("
-                     << field->getType().getAsString() << "|"
-                     << getAccessSpecifierString(field->getAccess()) << ")\n";
-      }
-    }
-
-    llvm::outs() << "|\n";
-
-    if (record->method_begin() != record->method_end()) {
-      llvm::outs() << "|_Methods\n";
-      bool firstMethod = true;
-      for (const auto *method : record->methods()) {
-        if (method->isImplicit() || method->isDefaulted()) {
-          continue;
-        }
-
-        if (firstMethod) {
-          firstMethod = false;
-        }
-
-        llvm::outs() << "| |_ " << method->getNameAsString() << " ("
-                     << method->getReturnType().getAsString() << "()|"
-                     << getAccessSpecifierString(method->getAccess());
-
-        bool isVirtualMethod = method->isVirtual();
-        bool isPureVirtual = method->isPureVirtual();
-        bool hasOverride = method->size_overridden_methods() > 0;
-
-        if (isVirtualMethod) {
-          if (hasOverride) {
-            llvm::outs() << "|override";
-          } else {
+        if (hasOverride) {
+          llvm::outs() << "|override";
+        } else {
             llvm::outs() << "|virtual";
             if (isPureVirtual) {
               llvm::outs() << "|pure";
             }
           }
-         } else {
-            llvm::outs() << "|virtual";
-              if (isPureVirtual) {
-                llvm::outs() << "|pure";
-              }
-            }
         } else {
           if (isPureVirtual) {
             llvm::outs() << "|pure";
           }
         }
-      llvm::outs() << ")\n";
-    }
-  }
-  return true;
-}
 
-private : std::string
-          getAccessSpecifierString(clang::AccessSpecifier access) {
-  switch (access) {
-  case clang::AS_public:
-    return "public";
-  case clang::AS_protected:
-    return "protected";
-  case clang::AS_private:
-    return "private";
-  case clang::AS_none:
-    return "none";
+        llvm::outs() << ")\n";
+      }
+    }
+
+    return true;
   }
-  return "unknown";
-}
+
+private:
+  std::string getAccessSpecifierString(clang::AccessSpecifier access) {
+    switch (access) {
+      case clang::AS_public:
+        return "public";
+      case clang::AS_protected:
+        return "protected";
+      case clang::AS_private:
+        return "private";
+      case clang::AS_none:
+        return "none";
+    }
+    return "unknown";
+  }
 };
-} // namespace
 
 class TypeInfoConsumer : public clang::ASTConsumer {
 public:
@@ -177,6 +115,7 @@ public:
     return true;
   }
 };
+} // namespace
 
 static clang::FrontendPluginRegistry::Add<TypeInfoAction>
     X("type_info_plugin", "Prints information about user-defined types");

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -15,8 +15,8 @@ public:
   }
 
   bool VisitCXXRecordDecl(clang::CXXRecordDecl *record) {
-    llvm::errs() << "DEBUG: Visiting record: " 
-                 << (record->getIdentifier() ? record->getName() : "(anonymous)")
+    llvm::errs() << "DEBUG: Visiting record: "
+                 << (record->getIdentifier() ? record->getNameAsString() : "(anonymous)")
                  << "\n";
 
     auto &outs = llvm::outs();
@@ -25,13 +25,13 @@ public:
       llvm::errs() << "DEBUG: Skipping implicit record\n";
       return true;
     }
-    
+
     if (!record->getIdentifier()) {
       llvm::errs() << "DEBUG: Skipping anonymous record\n";
       return true;
     }
 
-    outs << record->getName();
+    outs << record->getNameAsString();
 
     if (record->getNumBases() > 0) {
       outs << " -> ";
@@ -42,7 +42,7 @@ public:
         }
         auto *baseDecl = base.getType()->getAsCXXRecordDecl();
         if (baseDecl && baseDecl->getIdentifier()) {
-          outs << baseDecl->getName();
+          outs << baseDecl->getNameAsString();
         } else {
           outs << base.getType().getAsString();
         }
@@ -84,8 +84,11 @@ public:
             methodName = "(anonymous)";
           }
 
+          llvm::StringRef retType =
+              llvm::StringRef(method->getReturnType().getAsString()).trim();
+
           outs << "| |_ " << methodName << " ("
-               << method->getReturnType().getAsString() << "()|"
+               << retType << "()|"
                << getAccessSpecifierString(method->getAccess());
 
           bool isVirtualMethod = method->isVirtual();

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -59,23 +59,82 @@ public:
           if (hasOverride) {
             llvm::outs() << "|override";
           } else {
+namespace {
+class TypeInfoVisitor : public clang::RecursiveASTVisitor<TypeInfoVisitor> {
+public:
+  explicit TypeInfoVisitor(clang::ASTContext *context) {}
+
+  bool VisitCXXRecordDecl(clang::CXXRecordDecl *record) {
+    if (record->isImplicit()) {
+      return true;
+    }
+
+    llvm::outs() << record->getName();
+
+    if (record->getNumBases() > 0) {
+      llvm::outs()
+          << " -> "
+          << record->bases_begin()->getType()->getAsCXXRecordDecl()->getName();
+    }
+
+    llvm::outs() << " \n";
+
+    if (record->field_begin() != record->field_end()) {
+      llvm::outs() << "|_Fields\n";
+      for (const auto *field : record->fields()) {
+        llvm::outs() << "| |_ " << field->getName() << " ("
+                     << field->getType().getAsString() << "|"
+                     << getAccessSpecifierString(field->getAccess()) << ")\n";
+      }
+    }
+
+    llvm::outs() << "|\n";
+
+    if (record->method_begin() != record->method_end()) {
+      llvm::outs() << "|_Methods\n";
+      bool firstMethod = true;
+      for (const auto *method : record->methods()) {
+        if (method->isImplicit() || method->isDefaulted()) {
+          continue;
+        }
+
+        if (firstMethod) {
+          firstMethod = false;
+        }
+
+        llvm::outs() << "| |_ " << method->getNameAsString() << " ("
+                     << method->getReturnType().getAsString() << "()|"
+                     << getAccessSpecifierString(method->getAccess());
+
+        bool isVirtualMethod = method->isVirtual();
+        bool isPureVirtual = method->isPureVirtual();
+        bool hasOverride = method->size_overridden_methods() > 0;
+
+        if (isVirtualMethod) {
+          if (hasOverride) {
+            llvm::outs() << "|override";
+          } else {
             llvm::outs() << "|virtual";
             if (isPureVirtual) {
               llvm::outs() << "|pure";
             }
           }
          } else {
-          llvm::outs() << "|virtual";
-             if (isPureVirtual) {
-               llvm::outs() << "|pure";
-             }
-           }
-      }
-      else {
-        if (isPureVirtual) {
-          llvm::outs() << "|pure";
+            llvm::outs() << "|virtual";
+              if (isPureVirtual) {
+                llvm::outs() << "|pure";
+              }
+            }
+        } else {
+          if (isPureVirtual) {
+            llvm::outs() << "|pure";
+          }
         }
-      }
+      llvm::outs() << ")\n";
+    }
+  }
+  return true;
+}
       llvm::outs() << ")\n";
     }
   }
@@ -97,6 +156,7 @@ private : std::string
   return "unknown";
 }
 };
+
 
 class TypeInfoConsumer : public clang::ASTConsumer {
 public:

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -49,28 +49,24 @@ public:
         << method->getReturnType().getAsString() << "()|"
         << getAccessSpecifierString(method->getAccess()) << "|";
 
-        if (method->isVirtual()) {
-          if (method->size_overridden_methods() == 0) {
-            if (method->isPureVirtual()) {
-              llvm::outs() << "virtual|";
-            }
-            else {
-              llvm::outs() << "virtual";
-            }
-          }
-        }
+        bool isVirtualMethod = method->isVirtual();
+        bool isPureVirtual = method->isPureVirtual();
+        bool hasOverride = method->size_overridden_methods() > 0;
 
-        if (method->isPureVirtual()) {
-          if (method->size_overridden_methods() > 0) {
-            llvm::outs() << "pure|";
+        // Обработка виртуальных методов
+        if (isVirtualMethod) {
+          if (hasOverride) {
+            llvm::outs() << "override";
+          } else {
+            llvm::outs() << "virtual";
+            if (isPureVirtual) {
+              llvm::outs() << "|pure";
+            }
           }
-          else{
+        } else {
+          if (isPureVirtual) {
             llvm::outs() << "pure";
           }
-        }
-
-        if (method->size_overridden_methods() > 0) {
-          llvm::outs() << "override";
         }
 
         llvm::outs() << ")\n";

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -65,13 +65,19 @@ public:
               }
             }
           } else {
-            if (isPureVirtual) {
-              llvm::outs() << "|pure";
-            }
+            llvm::outs() << "|virtual";
+             if (isPureVirtual) {
+               llvm::outs() << "|pure";
+             }
+           }
+        } else {
+          if (isPureVirtual) {
+            llvm::outs() << "|pure";
           }
-        llvm::outs() << ")\n";
-      }
-    }
+        }
+         llvm::outs() << ")\n";
+       }
+     }
 
     return true;
   }

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -12,7 +12,7 @@ public:
   bool VisitCXXRecordDecl(clang::CXXRecordDecl *record) {
     auto &outs = llvm::outs();
 
-    if (record->isImplicit() || record->getName().empty()) {
+    if (record->isImplicit() || !record->getIdentifier()) {
       return true;
     }
 

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -5,20 +5,21 @@
 #include "llvm/Support/raw_ostream.h"
 
 namespace {
-class DataTypesVisitor final : public clang::RecursiveASTVisitor<DataTypesVisitor> {
+class DataTypesVisitor final
+    : public clang::RecursiveASTVisitor<DataTypesVisitor> {
   clang::ASTContext *class_context_;
 
   std::string AccessSpecifierToString(clang::AccessSpecifier accessSpecifier) {
     switch (accessSpecifier) {
-      case clang::AS_public:
-        return "public";
-      case clang::AS_protected:
-        return "protected";
-      case clang::AS_private:
-        return "private";
-      default:
-        llvm::errs() << "Error: Unknown access specifier\n";
-        return "unknown access specifier";
+    case clang::AS_public:
+      return "public";
+    case clang::AS_protected:
+      return "protected";
+    case clang::AS_private:
+      return "private";
+    default:
+      llvm::errs() << "Error: Unknown access specifier\n";
+      return "unknown access specifier";
     }
   }
 
@@ -51,7 +52,8 @@ class DataTypesVisitor final : public clang::RecursiveASTVisitor<DataTypesVisito
   }
 
 public:
-  explicit DataTypesVisitor(clang::ASTContext *context) : class_context_(context) {}
+  explicit DataTypesVisitor(clang::ASTContext *context)
+      : class_context_(context) {}
 
   bool VisitCXXRecordDecl(clang::CXXRecordDecl *declaration) {
     auto &os = llvm::outs();
@@ -104,11 +106,13 @@ private:
 
 class DataTypesAction final : public clang::PluginASTAction {
 public:
-  std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
     return std::make_unique<DataTypesConsumer>(&ci.getASTContext());
   }
 
-  bool ParseArgs(const clang::CompilerInstance &ci, const std::vector<std::string> &args) override {
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
     return true;
   }
 };

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -59,43 +59,43 @@ public:
           if (hasOverride) {
             llvm::outs() << "|override";
           } else {
-              llvm::outs() << "|virtual";
-              if (isPureVirtual) {
-                llvm::outs() << "|pure";
-              }
-            }
-          } else {
             llvm::outs() << "|virtual";
+            if (isPureVirtual) {
+              llvm::outs() << "|pure";
+            }
+          }
+         } else {
+          llvm::outs() << "|virtual";
              if (isPureVirtual) {
                llvm::outs() << "|pure";
              }
            }
-        } else {
-          if (isPureVirtual) {
-            llvm::outs() << "|pure";
-          }
+      }
+      else {
+        if (isPureVirtual) {
+          llvm::outs() << "|pure";
         }
-         llvm::outs() << ")\n";
-       }
-     }
-
-    return true;
-  }
-
-private:
-  std::string getAccessSpecifierString(clang::AccessSpecifier access) {
-    switch (access) {
-    case clang::AS_public:
-      return "public";
-    case clang::AS_protected:
-      return "protected";
-    case clang::AS_private:
-      return "private";
-    case clang::AS_none:
-      return "none";
+      }
+      llvm::outs() << ")\n";
     }
-    return "unknown";
   }
+  return true;
+}
+
+private : std::string
+          getAccessSpecifierString(clang::AccessSpecifier access) {
+  switch (access) {
+  case clang::AS_public:
+    return "public";
+  case clang::AS_protected:
+    return "protected";
+  case clang::AS_private:
+    return "private";
+  case clang::AS_none:
+    return "none";
+  }
+  return "unknown";
+}
 };
 
 class TypeInfoConsumer : public clang::ASTConsumer {

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -46,12 +46,34 @@ public:
         }
 
         llvm::outs() << "| |_ " << method->getNameAsString() << " (" 
-                    << method->getReturnType().getAsString() << "()|"
-                    << getAccessSpecifierString(method->getAccess()) << "|"
-                    << (method->isVirtual() ? "virtual|" : "")
-                    << (method->isPureVirtual() ? "pure" : "")
-                    << (method->size_overridden_methods() > 0 ? "override" : "")
-                    << ")\n";
+        << method->getReturnType().getAsString() << "()|"
+        << getAccessSpecifierString(method->getAccess()) << "|";
+
+        if (method->isVirtual()) {
+          if (method->size_overridden_methods() == 0) {
+            if (method->isPureVirtual()) {
+              llvm::outs() << "virtual|";
+            }
+            else {
+              llvm::outs() << "virtual";
+            }
+          }
+        }
+
+        if (method->isPureVirtual()) {
+          if (method->size_overridden_methods() > 0) {
+            llvm::outs() << "pure|";
+          }
+          else{
+            llvm::outs() << "pure";
+          }
+        }
+
+        if (method->size_overridden_methods() > 0) {
+          llvm::outs() << "override";
+        }
+
+        llvm::outs() << ")\n";
       }
     }
 

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -20,7 +20,7 @@ public:
       llvm::outs() << " -> " << record->bases_begin()->getType()->getAsCXXRecordDecl()->getName();
     }
 
-    llvm::outs() << "\n";
+    llvm::outs() << "| \n";
 
     if (record->field_begin() != record->field_end()) {
       llvm::outs() << "|_Fields\n";

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -19,14 +19,15 @@ public:
     if (record->getNumBases() > 0) {
       llvm::outs() << " -> " << record->bases_begin()->getType()->getAsCXXRecordDecl()->getName();
     }
+
     llvm::outs() << "\n";
 
     if (record->field_begin() != record->field_end()) {
       llvm::outs() << "|_Fields\n";
       for (const auto *field : record->fields()) {
-        llvm::outs() << "| |_ " << field->getName() << " (" 
-                    << field->getType().getAsString() << "|"
-                    << getAccessSpecifierString(field->getAccess()) << ")\n";
+          llvm::outs() << "| |_ " << field->getName() << " (" 
+                      << field->getType().getAsString() << "|"
+                      << getAccessSpecifierString(field->getAccess()) << ")\n";
       }
     }
 

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -31,13 +31,18 @@ public:
 
     // Выводим методы
     if (record->method_begin() != record->method_end()) {
-      llvm::outs() << "|_Methods\n";
+      llvm::outs() << "|_Methods";
+      bool firstMethod = true;
       for (const auto *method : record->methods()) {
         // Пропускаем автоматически сгенерированные методы
         if (method->isImplicit() || method->isDefaulted()) {
           continue;
         }
 
+        if (firstMethod) {
+          llvm::outs() << "\n";
+          firstMethod = false;
+        }
         llvm::outs() << "| |_ " << method->getNameAsString() << " ("
                      << method->getReturnType().getAsString() << "()|"
                      << getAccessSpecifierString(method->getAccess()) << "|"

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -5,167 +5,115 @@
 #include "llvm/Support/raw_ostream.h"
 
 namespace {
-class TypeInfoVisitor : public clang::RecursiveASTVisitor<TypeInfoVisitor> {
-private:
-  clang::ASTContext *m_context;
+class DataTypesVisitor final : public clang::RecursiveASTVisitor<DataTypesVisitor> {
+  clang::ASTContext *class_context_;
+
+  std::string AccessSpecifierToString(clang::AccessSpecifier accessSpecifier) {
+    switch (accessSpecifier) {
+      case clang::AS_public:
+        return "public";
+      case clang::AS_protected:
+        return "protected";
+      case clang::AS_private:
+        return "private";
+      default:
+        llvm::errs() << "Error: Unknown access specifier\n";
+        return "unknown access specifier";
+    }
+  }
+
+  void PrintMember(const clang::ValueDecl *member) {
+    auto &os = llvm::outs();
+    os << "| |_ " << member->getNameAsString() << ' ';
+    os << '(';
+
+    if (const auto *method = llvm::dyn_cast<clang::CXXMethodDecl>(member)) {
+      os << method->getReturnType().getAsString();
+      os << '|' << AccessSpecifierToString(member->getAccess());
+      if (method->isStatic()) {
+        os << "|static";
+      }
+      if (method->isVirtual()) {
+        os << "|virtual";
+      }
+      if (method->isOverloadedOperator()) {
+        os << "|override";
+      }
+      if (method->isPureVirtual()) {
+        os << "|pure";
+      }
+    } else {
+      os << member->getType().getAsString() << '|'
+         << AccessSpecifierToString(member->getAccess());
+    }
+
+    os << ")\n";
+  }
 
 public:
-  explicit TypeInfoVisitor(clang::ASTContext *context) : m_context(context) {
-    llvm::errs() << "DEBUG: TypeInfoVisitor created\n";
-  }
+  explicit DataTypesVisitor(clang::ASTContext *context) : class_context_(context) {}
 
-  bool VisitCXXRecordDecl(clang::CXXRecordDecl *record) {
-    llvm::errs() << "DEBUG: Visiting record: "
-                 << (record->getIdentifier() ? record->getNameAsString() : "(anonymous)")
-                 << "\n";
+  bool VisitCXXRecordDecl(clang::CXXRecordDecl *declaration) {
+    auto &os = llvm::outs();
+    os << declaration->getNameAsString()
+       << (declaration->isStruct() ? "(struct" : "(class")
+       << (declaration->isTemplated() ? "|template)" : ")") << '\n';
 
-    auto &outs = llvm::outs();
-
-    if (record->isImplicit()) {
-      llvm::errs() << "DEBUG: Skipping implicit record\n";
-      return true;
-    }
-
-    if (!record->getIdentifier()) {
-      llvm::errs() << "DEBUG: Skipping anonymous record\n";
-      return true;
-    }
-
-    outs << record->getNameAsString();
-
-    if (record->getNumBases() > 0) {
-      outs << " -> ";
-      bool firstBase = true;
-      for (const auto &base : record->bases()) {
-        if (!firstBase) {
-          outs << ", ";
-        }
-        auto *baseDecl = base.getType()->getAsCXXRecordDecl();
-        if (baseDecl && baseDecl->getIdentifier()) {
-          outs << baseDecl->getNameAsString();
-        } else {
-          outs << base.getType().getAsString();
-        }
-        firstBase = false;
-      }
-    }
-    outs << "\n";
-
-    if (record->field_begin() != record->field_end()) {
-      outs << "|_Fields\n";
-      for (const auto *field : record->fields()) {
-        std::string fieldName = field->getName().str();
-        if (fieldName.empty()) {
-          fieldName = "(anonymous)";
-        }
-        outs << "| |_ " << fieldName << " (" << field->getType().getAsString()
-             << "|" << getAccessSpecifierString(field->getAccess()) << ")\n";
-      }
-    }
-
-    if (record->method_begin() != record->method_end()) {
-      bool hasExplicitMethods = false;
-      for (const auto *method : record->methods()) {
-        if (!method->isImplicit() && !method->isDefaulted()) {
-          hasExplicitMethods = true;
-          break;
-        }
-      }
-
-      if (hasExplicitMethods) {
-        outs << "|_Methods\n";
-        for (const auto *method : record->methods()) {
-          if (method->isImplicit() || method->isDefaulted()) {
-            continue;
-          }
-
-          std::string methodName = method->getNameAsString();
-          if (methodName.empty()) {
-            methodName = "(anonymous)";
-          }
-
-          llvm::StringRef retType =
-              llvm::StringRef(method->getReturnType().getAsString()).trim();
-
-          outs << "| |_ " << methodName << " ("
-               << retType << "()|"
-               << getAccessSpecifierString(method->getAccess());
-
-          bool isVirtualMethod = method->isVirtual();
-          bool isPureVirtual = method->isPureVirtual();
-          bool hasOverride = method->size_overridden_methods() > 0;
-
-          if (isVirtualMethod) {
-            if (hasOverride) {
-              outs << "|override";
-            } else {
-              outs << "|virtual";
-              if (isPureVirtual) {
-                outs << "|pure";
-              }
-            }
-          }
-
-          outs << ")\n";
+    if (!declaration->bases().empty()) {
+      for (const auto &base : declaration->bases()) {
+        if (auto *baseDecl = base.getType()->getAsCXXRecordDecl()) {
+          clang::AccessSpecifier accessSpecifier = base.getAccessSpecifier();
+          os << declaration->getName() << " -> "
+             << AccessSpecifierToString(accessSpecifier) << " "
+             << baseDecl->getName() << "\n";
         }
       }
     }
 
-    outs << "|\n";
+    if (!declaration->field_empty()) {
+      os << "|_Fields\n";
+      for (const auto *decl : declaration->decls()) {
+        if (auto *field = llvm::dyn_cast<clang::FieldDecl>(decl)) {
+          PrintMember(field);
+        }
+      }
+    }
+
+    if (!declaration->methods().empty()) {
+      os << "|_Methods\n";
+      for (const auto *method : declaration->methods()) {
+        PrintMember(method);
+      }
+    }
+    os << '\n';
     return true;
-  }
-
-private:
-  std::string getAccessSpecifierString(clang::AccessSpecifier access) {
-    switch (access) {
-    case clang::AS_public:
-      return "public";
-    case clang::AS_protected:
-      return "protected";
-    case clang::AS_private:
-      return "private";
-    case clang::AS_none:
-      return "none";
-    }
-    return "unknown";
   }
 };
 
-class TypeInfoConsumer : public clang::ASTConsumer {
+class DataTypesConsumer final : public clang::ASTConsumer {
 public:
-  explicit TypeInfoConsumer(clang::ASTContext *context) : m_visitor(context) {
-    llvm::errs() << "DEBUG: TypeInfoConsumer created\n";
-  }
+  explicit DataTypesConsumer(clang::ASTContext *context) : visitor_(context) {}
 
   void HandleTranslationUnit(clang::ASTContext &context) override {
-    llvm::errs() << "DEBUG: Handling translation unit\n";
-    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
-    llvm::errs() << "DEBUG: Finished traversal\n";
+    visitor_.TraverseDecl(context.getTranslationUnitDecl());
   }
 
 private:
-  TypeInfoVisitor m_visitor;
+  DataTypesVisitor visitor_;
 };
 
-class TypeInfoAction : public clang::PluginASTAction {
+class DataTypesAction final : public clang::PluginASTAction {
 public:
-  std::unique_ptr<clang::ASTConsumer>
-  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
-    llvm::errs() << "DEBUG: Creating AST consumer\n";
-    return std::make_unique<TypeInfoConsumer>(&ci.getASTContext());
+  std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    return std::make_unique<DataTypesConsumer>(&ci.getASTContext());
   }
 
-  bool ParseArgs(const clang::CompilerInstance &ci,
-                 const std::vector<std::string> &args) override {
-    llvm::errs() << "DEBUG: ParseArgs called\n";
+  bool ParseArgs(const clang::CompilerInstance &ci, const std::vector<std::string> &args) override {
     return true;
   }
-
-  PluginASTAction::ActionType getActionType() override {
-    return CmdlineBeforeMainAction;
-  }
 };
+
 } // namespace
 
-static clang::FrontendPluginRegistry::Add<TypeInfoAction>
-    X("type_info_plugin", "Prints information about user-defined types");
+static clang::FrontendPluginRegistry::Add<DataTypesAction>
+    X("DataTypesPlugin", "Print information about a custom data type");

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -11,15 +11,13 @@ public:
 
   bool VisitCXXRecordDecl(clang::CXXRecordDecl *record) {
     // Выводим имя структуры/класса
-    llvm::outs() << record->getName() << "\n";
+    llvm::outs() << record->getName();
 
     // Выводим базовые классы
     if (record->getNumBases() > 0) {
-      llvm::outs() << "|_Base Classes\n";
-      for (const auto &base : record->bases()) {
-        llvm::outs() << "| |_ " << base.getType()->getAsCXXRecordDecl()->getName() << "\n";
-      }
+      llvm::outs() << " -> " << record->bases_begin()->getType()->getAsCXXRecordDecl()->getName();
     }
+    llvm::outs() << "\n";
 
     // Выводим поля
     if (record->field_begin() != record->field_end()) {

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -135,11 +135,6 @@ public:
   }
   return true;
 }
-      llvm::outs() << ")\n";
-    }
-  }
-  return true;
-}
 
 private : std::string
           getAccessSpecifierString(clang::AccessSpecifier access) {
@@ -156,7 +151,7 @@ private : std::string
   return "unknown";
 }
 };
-
+} // namespace
 
 class TypeInfoConsumer : public clang::ASTConsumer {
 public:
@@ -182,7 +177,6 @@ public:
     return true;
   }
 };
-} // namespace
 
 static clang::FrontendPluginRegistry::Add<TypeInfoAction>
     X("type_info_plugin", "Prints information about user-defined types");

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -31,8 +31,9 @@ public:
       }
     }
 
+    llvm::outs() << "|\n";
+
     if (record->method_begin() != record->method_end()) {
-      llvm::outs() << "|\n";
       llvm::outs() << "|_Methods\n";
       bool firstMethod = true;
       for (const auto *method : record->methods()) {

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -10,31 +10,30 @@ public:
   explicit TypeInfoVisitor(clang::ASTContext *context) {}
 
   bool VisitCXXRecordDecl(clang::CXXRecordDecl *record) {
-    // Выводим имя структуры/класса
+    if (record->isImplicit()) {
+      return true;
+    }
+
     llvm::outs() << record->getName();
 
-    // Выводим базовые классы
     if (record->getNumBases() > 0) {
       llvm::outs() << " -> " << record->bases_begin()->getType()->getAsCXXRecordDecl()->getName();
     }
     llvm::outs() << "\n";
 
-    // Выводим поля
     if (record->field_begin() != record->field_end()) {
       llvm::outs() << "|_Fields\n";
       for (const auto *field : record->fields()) {
         llvm::outs() << "| |_ " << field->getName() << " (" 
-                     << field->getType().getAsString() << "|"
-                     << getAccessSpecifierString(field->getAccess()) << ")\n";
+                    << field->getType().getAsString() << "|"
+                    << getAccessSpecifierString(field->getAccess()) << ")\n";
       }
     }
 
-    // Выводим методы
     if (record->method_begin() != record->method_end()) {
-      llvm::outs() << "|_Methods\n";  // Начинаем вывод методов сразу после полей.
+      llvm::outs() << "|_Methods\n";
       bool firstMethod = true;
       for (const auto *method : record->methods()) {
-        // Пропускаем автоматически сгенерированные методы
         if (method->isImplicit() || method->isDefaulted()) {
           continue;
         }
@@ -44,12 +43,12 @@ public:
         }
 
         llvm::outs() << "| |_ " << method->getNameAsString() << " (" 
-                     << method->getReturnType().getAsString() << "()|"
-                     << getAccessSpecifierString(method->getAccess()) << "|"
-                     << (method->isVirtual() ? "virtual|" : "")
-                     << (method->isPureVirtual() ? "pure|" : "")
-                     << (method->size_overridden_methods() > 0 ? "override" : "")
-                     << ")\n";
+                    << method->getReturnType().getAsString() << "()|"
+                    << getAccessSpecifierString(method->getAccess()) << "|"
+                    << (method->isVirtual() ? "virtual|" : "")
+                    << (method->isPureVirtual() ? "pure|" : "")
+                    << (method->size_overridden_methods() > 0 ? "override" : "")
+                    << ")\n";
       }
     }
 

--- a/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
+++ b/clang/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1.cpp
@@ -7,7 +7,7 @@
 namespace {
 class TypeInfoVisitor : public clang::RecursiveASTVisitor<TypeInfoVisitor> {
 public:
-  explicit TypeInfoVisitor(clang::ASTContext *context) : m_context(context) {}
+  explicit TypeInfoVisitor(clang::ASTContext *context) {}
 
   bool VisitCXXRecordDecl(clang::CXXRecordDecl *record) {
     // Выводим имя структуры/класса
@@ -39,7 +39,7 @@ public:
                      << method->getReturnType().getAsString() << "()|"
                      << getAccessSpecifierString(method->getAccess()) << "|"
                      << (method->isVirtual() ? "virtual|" : "")
-                     << (method->isPure() ? "pure|" : "")
+                     << (method->isPureVirtual() ? "pure|" : "") // Используем isPureVirtual()
                      << (method->size_overridden_methods() > 0 ? "override" : "")
                      << ")\n";
       }
@@ -50,8 +50,6 @@ public:
   }
 
 private:
-  clang::ASTContext *m_context;
-
   std::string getAccessSpecifierString(clang::AccessSpecifier access) {
     switch (access) {
       case clang::AS_public:

--- a/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
+++ b/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -load %llvmshlibdir/Data_types_Dudchenko_Olesya_FIIT2_ClangAST%pluginext -plugin example_plugin -fsyntax-only %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -load %llvmshlibdir/Data_types_Dudchenko_Olesya_FIIT2_ClangAST%pluginext -plugin type_info_plugin -fsyntax-only %s 2>&1 | FileCheck %s
 
 // CHECK: Human
 // CHECK-NEXT: |_Fields

--- a/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
+++ b/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
@@ -15,14 +15,6 @@ struct Human {
   virtual void eat() = 0;
 };
 
-// CHECK: Engineer -> Human
-// CHECK-NEXT: |_Fields
-// CHECK-NEXT: | |_ salary (unsigned int|public)
-// CHECK-NEXT: |
-// CHECK-NEXT: |_Methods
-// CHECK-NEXT: | |_ sleep (void()|public|override)
-// CHECK-NEXT: | |_ eat (void()|public|override)
-// CHECK-NEXT: | |_ work (void()|public)
 struct Engineer : Human {
   unsigned salary;
   void sleep() override { /* something */ }

--- a/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
+++ b/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
@@ -1,11 +1,80 @@
-// RUN: %clang_cc1 -load %llvmshlibdir/Data_types_Dudchenko_Olesya_FIIT2_ClangAST%pluginext -plugin type_info_plugin -fsyntax-only %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -load %llvmshlibdir/Data_types_Dudchenko_Olesya_FIIT2_ClangAST%pluginext -plugin DataTypesPlugin -fsyntax-only %s 2>&1 | FileCheck %s
 
-// Сначала проверяем отладочный вывод
-// CHECK-DAG: DEBUG: ParseArgs called
-// CHECK-DAG: DEBUG: Creating AST consumer
-// CHECK-DAG: DEBUG: TypeInfoConsumer created
-// CHECK-DAG: DEBUG: TypeInfoVisitor created
-// CHECK-DAG: DEBUG: Handling translation unit
+// CHECK: A(class)
+class A {};
+
+// CHECK: B(struct)
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ a (A|public)
+struct B {
+    A a;
+};
+
+// CHECK: Simple(struct)
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ x (int|public)
+// CHECK-NEXT: | |_ y (double|public)
+// CHECK-NEXT: |_Methods
+// CHECK-NEXT: | |_ method (int|public)
+struct Simple {
+    int x;
+    double y;
+
+    int method(int x, int y) {}
+};
+
+// CHECK: Static(class)
+// CHECK-NEXT: |_Methods
+// CHECK-NEXT: | |_ method (void|private|static)
+class Static {
+    static void method() {}
+};
+
+// CHECK: Template(class|template)
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ x (T|private)
+// CHECK-NEXT: | |_ z (int|private)
+template <typename T>
+class Template {
+    T x;
+    int z;
+};
+
+// CHECK: MultiTemplate(class|template)
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ first (T|private)
+// CHECK-NEXT: | |_ second (U|private)
+template <typename T, typename U>
+class MultiTemplate {
+    T first;
+    U second;
+};
+
+// CHECK: C -> public A
+// CHECK: C -> public B
+class C : public A, public B {};
+
+// CHECK: PublicDerived -> public Base
+// CHECK: ProtectedDerived -> protected Base
+// CHECK: PrivateDerived -> private Base
+class Base {};
+class PublicDerived : public Base {};
+class ProtectedDerived : protected Base {};
+class PrivateDerived : private Base {};
+
+// CHECK: AccessModifiers
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ x (float|private)
+// CHECK-NEXT: | |_ y (double|protected)
+// CHECK-NEXT: | |_ z (long long|public)
+class AccessModifiers {
+private:
+    float x;
+protected:
+    double y;
+public:
+    long long z;
+};
 
 // CHECK: Human
 // CHECK-NEXT: |_Fields
@@ -14,7 +83,6 @@
 // CHECK-NEXT: |_Methods
 // CHECK-NEXT: | |_ sleep (void()|public|virtual|pure)
 // CHECK-NEXT: | |_ eat (void()|public|virtual|pure)
-// CHECK-NEXT: |
 struct Human {
   unsigned age;
   unsigned height;
@@ -29,34 +97,9 @@ struct Human {
 // CHECK-NEXT: | |_ sleep (void()|public|override)
 // CHECK-NEXT: | |_ eat (void()|public|override)
 // CHECK-NEXT: | |_ work (void()|public)
-// CHECK-NEXT: |
 struct Engineer : Human {
   unsigned salary;
   void sleep() override { /* something */ }
   void eat() override { /* something */ }
   void work() { /* something */ }
-};
-
-// ДОБАВЛЕННЫЕ ТЕСТЫ из ревью:
-
-// CHECK: A
-// CHECK-NEXT: |
-struct A {};
-
-// CHECK: B
-// CHECK-NEXT: |
-struct B {
-  struct A {};
-};
-
-// CHECK: EmptyClass
-// CHECK-NEXT: |
-struct EmptyClass {};
-
-// CHECK: WithNested
-// CHECK-NEXT: |_Fields
-// CHECK-NEXT: | |_ nested (B::A|public)
-// CHECK-NEXT: |
-struct WithNested {
-  B::A nested;
 };

--- a/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
+++ b/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
@@ -4,10 +4,10 @@
 // CHECK-NEXT: |_Fields
 // CHECK-NEXT: | |_ age (unsigned int|public)
 // CHECK-NEXT: | |_ height (unsigned int|public)
-// CHECK-NEXT: |
 // CHECK-NEXT: |_Methods
 // CHECK-NEXT: | |_ sleep (void()|public|virtual|pure)
 // CHECK-NEXT: | |_ eat (void()|public|virtual|pure)
+// CHECK-NEXT: |
 struct Human {
   unsigned age;
   unsigned height;
@@ -18,14 +18,38 @@ struct Human {
 // CHECK: Engineer -> Human
 // CHECK-NEXT: |_Fields
 // CHECK-NEXT: | |_ salary (unsigned int|public)
-// CHECK-NEXT: |
 // CHECK-NEXT: |_Methods
 // CHECK-NEXT: | |_ sleep (void()|public|override)
 // CHECK-NEXT: | |_ eat (void()|public|override)
 // CHECK-NEXT: | |_ work (void()|public)
+// CHECK-NEXT: |
 struct Engineer : Human {
   unsigned salary;
   void sleep() override { /* something */ }
   void eat() override { /* something */ }
   void work() { /* something */ }
+};
+
+// ДОБАВЛЕННЫЕ ТЕСТЫ из ревью:
+
+// CHECK: A
+// CHECK-NEXT: |
+struct A {};
+
+// CHECK: B
+// CHECK-NEXT: |
+struct B {
+  struct A {};
+};
+
+// CHECK: EmptyClass
+// CHECK-NEXT: |
+struct EmptyClass {};
+
+// CHECK: WithNested
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ nested (B::A|public)
+// CHECK-NEXT: |
+struct WithNested {
+  B::A nested;
 };

--- a/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
+++ b/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
@@ -24,8 +24,8 @@ struct Human {
 // CHECK-NEXT: | |_ eat (void()|public|override)
 // CHECK-NEXT: | |_ work (void()|public)
 struct Engineer : Human {
-unsigned salary;
-void sleep() override { /* something */ }
-void eat() override { /* something */ }
-void work() { /* something */ }
+  unsigned salary;
+  void sleep() override { /* something */ }
+  void eat() override { /* something */ }
+  void work() { /* something */ }
 };

--- a/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
+++ b/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/Data_types_Dudchenko_Olesya_FIIT2_ClangAST%pluginext -plugin example_plugin -fsyntax-only %s 2>&1 | FileCheck %s
+
+// CHECK: Human
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ age (unsigned int|public)
+// CHECK-NEXT: | |_ height (unsigned int|public)
+// CHECK-NEXT: |
+// CHECK-NEXT: |_Methods
+// CHECK-NEXT: | |_ sleep (void()|public|virtual|pure)
+// CHECK-NEXT: | |_ eat (void()|public|virtual|pure)
+struct Human {
+    unsigned age;
+    unsigned height;
+    virtual void sleep() = 0;
+    virtual void eat() = 0;
+  };
+
+// CHECK: Engineer -> Human
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ salary (unsigned int|public)
+// CHECK-NEXT: |
+// CHECK-NEXT: |_Methods
+// CHECK-NEXT: | |_ sleep (void()|public|override)
+// CHECK-NEXT: | |_ eat (void()|public|override)
+// CHECK-NEXT: | |_ work (void()|public)
+struct Engineer : Human {
+unsigned salary;
+void sleep() override { /* something */ }
+void eat() override { /* something */ }
+void work() { /* something */ }
+};

--- a/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
+++ b/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
@@ -9,11 +9,11 @@
 // CHECK-NEXT: | |_ sleep (void()|public|virtual|pure)
 // CHECK-NEXT: | |_ eat (void()|public|virtual|pure)
 struct Human {
-    unsigned age;
-    unsigned height;
-    virtual void sleep() = 0;
-    virtual void eat() = 0;
-  };
+  unsigned age;
+  unsigned height;
+  virtual void sleep() = 0;
+  virtual void eat() = 0;
+};
 
 // CHECK: Engineer -> Human
 // CHECK-NEXT: |_Fields

--- a/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
+++ b/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
@@ -15,6 +15,14 @@ struct Human {
   virtual void eat() = 0;
 };
 
+// CHECK: Engineer -> Human
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ salary (unsigned int|public)
+// CHECK-NEXT: |
+// CHECK-NEXT: |_Methods
+// CHECK-NEXT: | |_ sleep (void()|public|override)
+// CHECK-NEXT: | |_ eat (void()|public|override)
+// CHECK-NEXT: | |_ work (void()|public)
 struct Engineer : Human {
   unsigned salary;
   void sleep() override { /* something */ }

--- a/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
+++ b/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
@@ -1,5 +1,12 @@
 // RUN: %clang_cc1 -load %llvmshlibdir/Data_types_Dudchenko_Olesya_FIIT2_ClangAST%pluginext -plugin type_info_plugin -fsyntax-only %s 2>&1 | FileCheck %s
 
+// Сначала проверяем отладочный вывод
+// CHECK-DAG: DEBUG: ParseArgs called
+// CHECK-DAG: DEBUG: Creating AST consumer
+// CHECK-DAG: DEBUG: TypeInfoConsumer created
+// CHECK-DAG: DEBUG: TypeInfoVisitor created
+// CHECK-DAG: DEBUG: Handling translation unit
+
 // CHECK: Human
 // CHECK-NEXT: |_Fields
 // CHECK-NEXT: | |_ age (unsigned int|public)

--- a/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
+++ b/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
@@ -81,25 +81,12 @@ public:
 // CHECK: | |_ age (unsigned int|public)
 // CHECK: | |_ height (unsigned int|public)
 // CHECK: |_Methods
-// CHECK: | |_ sleep (void()|public|virtual|pure)
-// CHECK: | |_ eat (void()|public|virtual|pure)
+// CHECK: | |_ sleep (void|public|virtual|pure)
+// CHECK: | |_ eat (void|public|virtual|pure)
 struct Human {
-  unsigned age;
-  unsigned height;
-  virtual void sleep() = 0;
-  virtual void eat() = 0;
-};
+    unsigned age;
+    unsigned height;
 
-// CHECK: Engineer -> Human
-// CHECK: |_Fields
-// CHECK: | |_ salary (unsigned int|public)
-// CHECK: |_Methods
-// CHECK: | |_ sleep (void()|public|override)
-// CHECK: | |_ eat (void()|public|override)
-// CHECK: | |_ work (void()|public)
-struct Engineer : Human {
-  unsigned salary;
-  void sleep() override { /* something */ }
-  void eat() override { /* something */ }
-  void work() { /* something */ }
+    virtual void sleep() = 0;
+    virtual void eat() = 0;
 };

--- a/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
+++ b/clang/test/compiler-course/dudchenko_o_ast_var_1/dudchenko_o_ast_var_1_test.cpp
@@ -77,12 +77,12 @@ public:
 };
 
 // CHECK: Human
-// CHECK-NEXT: |_Fields
-// CHECK-NEXT: | |_ age (unsigned int|public)
-// CHECK-NEXT: | |_ height (unsigned int|public)
-// CHECK-NEXT: |_Methods
-// CHECK-NEXT: | |_ sleep (void()|public|virtual|pure)
-// CHECK-NEXT: | |_ eat (void()|public|virtual|pure)
+// CHECK: |_Fields
+// CHECK: | |_ age (unsigned int|public)
+// CHECK: | |_ height (unsigned int|public)
+// CHECK: |_Methods
+// CHECK: | |_ sleep (void()|public|virtual|pure)
+// CHECK: | |_ eat (void()|public|virtual|pure)
 struct Human {
   unsigned age;
   unsigned height;
@@ -91,12 +91,12 @@ struct Human {
 };
 
 // CHECK: Engineer -> Human
-// CHECK-NEXT: |_Fields
-// CHECK-NEXT: | |_ salary (unsigned int|public)
-// CHECK-NEXT: |_Methods
-// CHECK-NEXT: | |_ sleep (void()|public|override)
-// CHECK-NEXT: | |_ eat (void()|public|override)
-// CHECK-NEXT: | |_ work (void()|public)
+// CHECK: |_Fields
+// CHECK: | |_ salary (unsigned int|public)
+// CHECK: |_Methods
+// CHECK: | |_ sleep (void()|public|override)
+// CHECK: | |_ eat (void()|public|override)
+// CHECK: | |_ work (void()|public)
 struct Engineer : Human {
   unsigned salary;
   void sleep() override { /* something */ }


### PR DESCRIPTION
Это плагин для Clang, который анализирует C++ код и выводит информацию о классах и структурах. Вот что он делает:
TypeInfoVisitor
Задача:
Ищет все классы и структуры в коде. Для каждого класса или структуры:
Выводит имя.
Если есть родительские классы, выводит их имена.
Выводит все поля (переменные) с их типами и доступом (public, protected, private).
Выводит все методы (функции) с их возвращаемыми типами, доступом и дополнительной информацией (например, virtual, override, pure).
Игнорирует автоматически созданные методы (например, конструкторы по умолчанию).

TypeInfoConsumer
Управляет обходом кода.
Использует TypeInfoVisitor для анализа всех классов и структур в файле.

TypeInfoAction
Точка входа для плагина.
Создает TypeInfoConsumer и передает ему данные для анализа.