### PR TITLE
Иванов Михаил. Лабораторная работа 1. Clang AST. Вариант 4.

### DIFF
--- a/clang/compiler-course/ivanov_m_prefix_4/CMakeLists.txt
+++ b/clang/compiler-course/ivanov_m_prefix_4/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "Prefix_Plugin")
+set(Student "Ivanov_Mikhail")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/ivanov_m_prefix_4/ivanov_m_prefix.cpp
+++ b/clang/compiler-course/ivanov_m_prefix_4/ivanov_m_prefix.cpp
@@ -1,0 +1,97 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "llvm/Support/raw_ostream.h"
+#include <unordered_map>
+
+namespace {
+class NewPrefixVisitor final : public clang::RecursiveASTVisitor<NewPrefixVisitor> {
+    clang::Rewriter &m_rewriter;
+    std::unordered_map<clang::VarDecl*, std::string> rewrittenDecl;
+  public:
+  explicit NewPrefixVisitor(clang::ASTContext *context, clang::Rewriter &rewriter) : m_rewriter(rewriter) {}
+  bool VisitVarDecl(clang::VarDecl *varDecl) {
+    if(!varDecl)
+      return true;
+
+    std::string prevName = varDecl->getName().str();
+
+    if(prevName.empty())
+      return true;
+
+    std::string prefix;
+
+    if(varDecl->isStaticLocal()){
+      prefix = "static_";
+    }
+    else if(varDecl->hasGlobalStorage()){
+      prefix = "global_";
+    }
+    else if(varDecl->isLocalVarDecl()){
+      prefix = "local_";
+    }
+
+    if(!prefix.empty()){
+      std::string newName = prefix + prevName;
+      m_rewriter.ReplaceText(varDecl->getLocation(), prevName.size(), newName);
+      rewrittenDecl[varDecl] = newName;
+    }
+    return true;
+  }
+
+  bool VisitParmVarDecl(clang::ParmVarDecl *parDecl){
+    std::string prevName = parDecl->getName().str();
+    if(prevName.empty())
+      return true;
+
+    std::string newName = "param_" + prevName;
+    m_rewriter.ReplaceText(parDecl->getLocation(), prevName.size(), newName);
+    rewrittenDecl[parDecl] = newName;
+    return true;
+  }
+
+  bool VisitDeclRefExpr(clang::DeclRefExpr *declRef){
+    auto *varDecl = clang::dyn_cast<clang::VarDecl>(declRef->getDecl());
+    auto it = rewrittenDecl.find(varDecl);
+    if(it != rewrittenDecl.end()){
+      std::string newName = it->second;
+      clang::SourceLocation loc = declRef->getLocation();
+      std::string prevName = varDecl->getName().str();
+      m_rewriter.ReplaceText(loc, prevName.size(), newName);
+    }
+    return true;
+  }
+};
+
+class NewPrefixConsumer final : public clang::ASTConsumer {
+  clang::Rewriter &m_rewriter;
+  NewPrefixVisitor m_visitor;
+public:
+  explicit NewPrefixConsumer(clang::ASTContext *context, clang::Rewriter &rewriter) : m_rewriter(rewriter), m_visitor(context, rewriter) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+    m_rewriter.getEditBuffer(context.getSourceManager().getMainFileID()).write(llvm::outs());
+  }
+};
+
+class NewPrefixAction : public clang::PluginASTAction {
+  clang::Rewriter m_rewriter;
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    m_rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
+    return std::make_unique<NewPrefixConsumer>(&ci.getASTContext(), m_rewriter);
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+};
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<NewPrefixAction>
+    X("Prefix_Plugin_Ivanov_Mikhail_FIIT1_ClangAST", "Plugin adds corresponding prefixes to static, local and global variables and parameters");

--- a/clang/compiler-course/ivanov_m_prefix_4/ivanov_m_prefix.cpp
+++ b/clang/compiler-course/ivanov_m_prefix_4/ivanov_m_prefix.cpp
@@ -10,7 +10,7 @@ namespace {
 class NewPrefixVisitor final
     : public clang::RecursiveASTVisitor<NewPrefixVisitor> {
   clang::Rewriter &m_rewriter;
-  std::unordered_map<clang::VarDecl*, std::string> rewrittenDecl;
+  std::unordered_map<clang::VarDecl *, std::string> rewrittenDecl;
 
 public:
   explicit NewPrefixVisitor(clang::ASTContext *context,
@@ -101,6 +101,6 @@ public:
 } // namespace
 
 static clang::FrontendPluginRegistry::Add<NewPrefixAction>
-    X("Prefix_Plugin_Ivanov_Mikhail_FIIT1_ClangAST", 
+    X("Prefix_Plugin_Ivanov_Mikhail_FIIT1_ClangAST",
       "Plugin adds corresponding prefixes to static, local and global "
       "variables and parameters");

--- a/clang/compiler-course/ivanov_m_prefix_4/ivanov_m_prefix.cpp
+++ b/clang/compiler-course/ivanov_m_prefix_4/ivanov_m_prefix.cpp
@@ -7,33 +7,35 @@
 #include <unordered_map>
 
 namespace {
-class NewPrefixVisitor final : public clang::RecursiveASTVisitor<NewPrefixVisitor> {
-    clang::Rewriter &m_rewriter;
-    std::unordered_map<clang::VarDecl*, std::string> rewrittenDecl;
-  public:
-  explicit NewPrefixVisitor(clang::ASTContext *context, clang::Rewriter &rewriter) : m_rewriter(rewriter) {}
+class NewPrefixVisitor final
+    : public clang::RecursiveASTVisitor<NewPrefixVisitor> {
+  clang::Rewriter &m_rewriter;
+  std::unordered_map<clang::VarDecl*, std::string> rewrittenDecl;
+
+public:
+  explicit NewPrefixVisitor(clang::ASTContext *context,
+                            clang::Rewriter &rewriter)
+      : m_rewriter(rewriter) {}
   bool VisitVarDecl(clang::VarDecl *varDecl) {
-    if(!varDecl)
+    if (!varDecl)
       return true;
 
     std::string prevName = varDecl->getName().str();
 
-    if(prevName.empty())
+    if (prevName.empty())
       return true;
 
     std::string prefix;
 
-    if(varDecl->isStaticLocal()){
+    if (varDecl->isStaticLocal()) {
       prefix = "static_";
-    }
-    else if(varDecl->hasGlobalStorage()){
+    } else if (varDecl->hasGlobalStorage()) {
       prefix = "global_";
-    }
-    else if(varDecl->isLocalVarDecl()){
+    } else if (varDecl->isLocalVarDecl()) {
       prefix = "local_";
     }
 
-    if(!prefix.empty()){
+    if (!prefix.empty()) {
       std::string newName = prefix + prevName;
       m_rewriter.ReplaceText(varDecl->getLocation(), prevName.size(), newName);
       rewrittenDecl[varDecl] = newName;
@@ -41,9 +43,9 @@ class NewPrefixVisitor final : public clang::RecursiveASTVisitor<NewPrefixVisito
     return true;
   }
 
-  bool VisitParmVarDecl(clang::ParmVarDecl *parDecl){
+  bool VisitParmVarDecl(clang::ParmVarDecl *parDecl) {
     std::string prevName = parDecl->getName().str();
-    if(prevName.empty())
+    if (prevName.empty())
       return true;
 
     std::string newName = "param_" + prevName;
@@ -52,10 +54,10 @@ class NewPrefixVisitor final : public clang::RecursiveASTVisitor<NewPrefixVisito
     return true;
   }
 
-  bool VisitDeclRefExpr(clang::DeclRefExpr *declRef){
+  bool VisitDeclRefExpr(clang::DeclRefExpr *declRef) {
     auto *varDecl = clang::dyn_cast<clang::VarDecl>(declRef->getDecl());
     auto it = rewrittenDecl.find(varDecl);
-    if(it != rewrittenDecl.end()){
+    if (it != rewrittenDecl.end()) {
       std::string newName = it->second;
       clang::SourceLocation loc = declRef->getLocation();
       std::string prevName = varDecl->getName().str();
@@ -68,17 +70,22 @@ class NewPrefixVisitor final : public clang::RecursiveASTVisitor<NewPrefixVisito
 class NewPrefixConsumer final : public clang::ASTConsumer {
   clang::Rewriter &m_rewriter;
   NewPrefixVisitor m_visitor;
+
 public:
-  explicit NewPrefixConsumer(clang::ASTContext *context, clang::Rewriter &rewriter) : m_rewriter(rewriter), m_visitor(context, rewriter) {}
+  explicit NewPrefixConsumer(clang::ASTContext *context,
+                             clang::Rewriter &rewriter)
+      : m_rewriter(rewriter), m_visitor(context, rewriter) {}
 
   void HandleTranslationUnit(clang::ASTContext &context) override {
     m_visitor.TraverseDecl(context.getTranslationUnitDecl());
-    m_rewriter.getEditBuffer(context.getSourceManager().getMainFileID()).write(llvm::outs());
+    m_rewriter.getEditBuffer(context.getSourceManager().getMainFileID())
+        .write(llvm::outs());
   }
 };
 
 class NewPrefixAction : public clang::PluginASTAction {
   clang::Rewriter m_rewriter;
+
 public:
   std::unique_ptr<clang::ASTConsumer>
   CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
@@ -95,4 +102,5 @@ public:
 
 static clang::FrontendPluginRegistry::Add<NewPrefixAction>
     X("Prefix_Plugin_Ivanov_Mikhail_FIIT1_ClangAST", 
-      "Plugin adds corresponding prefixes to static, local and global variables and parameters");
+      "Plugin adds corresponding prefixes to static, local and global "
+      "variables and parameters");

--- a/clang/compiler-course/ivanov_m_prefix_4/ivanov_m_prefix.cpp
+++ b/clang/compiler-course/ivanov_m_prefix_4/ivanov_m_prefix.cpp
@@ -94,4 +94,5 @@ public:
 } // namespace
 
 static clang::FrontendPluginRegistry::Add<NewPrefixAction>
-    X("Prefix_Plugin_Ivanov_Mikhail_FIIT1_ClangAST", "Plugin adds corresponding prefixes to static, local and global variables and parameters");
+    X("Prefix_Plugin_Ivanov_Mikhail_FIIT1_ClangAST", 
+      "Plugin adds corresponding prefixes to static, local and global variables and parameters");

--- a/clang/test/compiler-course/ivanov_m_prefix_4_test/ivanov_m_prefix_test.cpp
+++ b/clang/test/compiler-course/ivanov_m_prefix_4_test/ivanov_m_prefix_test.cpp
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/Prefix_Plugin_Ivanov_Mikhail_FIIT1_ClangAST%pluginext -plugin Prefix_Plugin_Ivanov_Mikhail_FIIT1_ClangAST -fsyntax-only %s 2>&1 | FileCheck --match-full-lines %s -dump-input=always
+
+// CHECK: int global_var1 = 1;
+// CHECK-NEXT: int foo(int param_a, int param_b){
+// CHECK-NEXT:    int local_var2 = 0;
+// CHECK-NEXT:    static int static_var3 = 10;
+// CHECK-NEXT:    ++local_var2;
+// CHECK-NEXT:    return param_a + param_b;
+// CHECK-NEXT: }
+// CHECK-NEXT: static int global_var4 = foo(global_var1, 10);
+// CHECK-NEXT: extern double global_dvar1 = 0;
+// CHECK-NEXT: static double global_dvar2 = 1;
+
+int var1 = 1;
+int foo(int a, int b){
+    int var2 = 0;
+    static int var3 = 10;
+    ++var2;
+    return a + b;
+}
+static int var4 = foo(var1, 10);
+extern double dvar1 = 0;
+static double dvar2 = 1;


### PR DESCRIPTION
Цель лабораторной работы: с помощью механизма обхода AST переименовать переменные в соответствии со следующим правилом:
- для локальных переменных добавляется приставка `local_`
- для глобальных переменных добавляется приставка `global_`
- для статических переменных добавляется приставка `static_`
- для параметров функции добавляется приставка `param_`

Основной задействованный функционал:
- `VisitVarDecl` - обрабатывает объявления переменных
- - проверяет валидность имени переменной
- - конструирует новое имя
- - заменяет исходное имя на новое
- - сохраняет имя в `unordered_map` `rewrittenDecl`
- `VisitParmVarDecl `- обрабатывает объявления параметров функций (аналогично `VisitVarDecl`)
- `VisitDeclRefExpr `- обрабатывает ссылки на переменные (заменяет на соответствующее имя из `rewrittenDecl`)