### PR TITLE
Чистов Алексей. Лабораторная работа 2. LLVM IR. Вариант 1.

### DIFF
--- a/llvm/compiler-course/llvm-ir/chistov_a_fmuladd_pass/CMakeLists.txt
+++ b/llvm/compiler-course/llvm-ir/chistov_a_fmuladd_pass/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(Title "FmuladdPass")
+set(Student "Chistov_Alexey")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_LLVM_IR")
+
+if (NOT WIN32 AND NOT CYGWIN)
+    file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+    add_llvm_pass_plugin(${TARGET_NAME} ${SOURCES}
+        DEPENDS
+        intrinsics_gen
+        BUILDTREE_ONLY
+    )
+    set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)
+endif()

--- a/llvm/compiler-course/llvm-ir/chistov_a_fmuladd_pass/chistov_a.cpp
+++ b/llvm/compiler-course/llvm-ir/chistov_a_fmuladd_pass/chistov_a.cpp
@@ -11,18 +11,13 @@ private:
   bool changed = false;
 
   void ProcessFAdd(llvm::BinaryOperator *add_op) {
-    if (auto *mul_op1 =
-            llvm::dyn_cast<llvm::BinaryOperator>(add_op->getOperand(0));
-        mul_op1 && mul_op1->getOpcode() == llvm::Instruction::FMul) {
-      ReplaceWithFMA(add_op, mul_op1);
-      changed = true;
-      return;
-    }
-    if (auto *mul_op2 =
-            llvm::dyn_cast<llvm::BinaryOperator>(add_op->getOperand(1));
-        mul_op2 && mul_op2->getOpcode() == llvm::Instruction::FMul) {
-      ReplaceWithFMA(add_op, mul_op2);
-      changed = true;
+    for (int i = 0; i < 2; ++i) {
+      if (auto *mul_op =
+              llvm::dyn_cast<llvm::BinaryOperator>(add_op->getOperand(i));
+          mul_op && mul_op->getOpcode() == llvm::Instruction::FMul) {
+        ReplaceWithFMA(add_op, mul_op);
+        return;
+      }
     }
   }
 
@@ -36,8 +31,10 @@ private:
         {mul->getOperand(0), mul->getOperand(1), other_op}));
 
     add->eraseFromParent();
-    if (mul->use_empty())
+    if (mul->use_empty()) {
       mul->eraseFromParent();
+    }
+    changed = true;
   }
 
 public:

--- a/llvm/compiler-course/llvm-ir/chistov_a_fmuladd_pass/chistov_a.cpp
+++ b/llvm/compiler-course/llvm-ir/chistov_a_fmuladd_pass/chistov_a.cpp
@@ -10,37 +10,31 @@ class FmuladdPass : public llvm::PassInfoMixin<FmuladdPass> {
 private:
   bool changed = false;
 
-  bool ProcessFAdd(llvm::BinaryOperator *add_op) {
+  void ProcessFAdd(llvm::BinaryOperator *add_op) {
     if (auto *mul_op =
             llvm::dyn_cast<llvm::BinaryOperator>(add_op->getOperand(0));
         mul_op && mul_op->getOpcode() == llvm::Instruction::FMul) {
       ReplaceWithFMA(add_op, mul_op);
       changed = true;
     }
-    return changed;
   }
 
   void ReplaceWithFMA(llvm::BinaryOperator *add, llvm::BinaryOperator *mul) {
     llvm::IRBuilder<> irb(add);
-    auto fma = irb.CreateIntrinsic(
-        llvm::Intrinsic::fmuladd, {mul->getOperand(0)->getType()},
-        {mul->getOperand(0), mul->getOperand(1), add->getOperand(1)});
-
-    add->replaceAllUsesWith(fma);
+    add->replaceAllUsesWith(irb.CreateIntrinsic(
+        llvm::Intrinsic::fmuladd, {mul->getType()},
+        {mul->getOperand(0), mul->getOperand(1), add->getOperand(1)}));
     add->eraseFromParent();
-    if (mul->use_empty()) {
+    if (mul->use_empty())
       mul->eraseFromParent();
-    }
   }
 
 public:
   llvm::PreservedAnalyses run(llvm::Function &function,
                               llvm::FunctionAnalysisManager &) {
-    for (llvm::BasicBlock &basic_block : function) {
-      for (auto it = basic_block.begin(); it != basic_block.end();) {
-        llvm::Instruction *instruction = &*(it++);
-
-        if (auto *bin_op = llvm::dyn_cast<llvm::BinaryOperator>(instruction);
+    for (auto &basic_block : function) {
+      for (auto &instruction : llvm::make_early_inc_range(basic_block)) {
+        if (auto *bin_op = llvm::dyn_cast<llvm::BinaryOperator>(&instruction);
             bin_op && bin_op->getOpcode() == llvm::Instruction::FAdd) {
           ProcessFAdd(bin_op);
         }

--- a/llvm/compiler-course/llvm-ir/chistov_a_fmuladd_pass/chistov_a.cpp
+++ b/llvm/compiler-course/llvm-ir/chistov_a_fmuladd_pass/chistov_a.cpp
@@ -1,0 +1,33 @@
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+struct FmuladdPass : llvm::PassInfoMixin<FmuladdPass> {
+  llvm::PreservedAnalyses run(llvm::Function &func,
+                              llvm::FunctionAnalysisManager &) {
+    llvm::outs() << func.getName() << '\n';
+    return llvm::PreservedAnalyses::all();
+  }
+
+  static bool isRequired() { return true; }
+};
+} // namespace
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "FmuladdPass", "0.1",
+          [](llvm::PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](llvm::StringRef name, llvm::FunctionPassManager &FPM,
+                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) -> bool {
+                  if (name == "example") {
+                    FPM.addPass(FmuladdPass{});
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}

--- a/llvm/compiler-course/llvm-ir/chistov_a_fmuladd_pass/chistov_a.cpp
+++ b/llvm/compiler-course/llvm-ir/chistov_a_fmuladd_pass/chistov_a.cpp
@@ -7,11 +7,12 @@
 namespace {
 
 class FmuladdPass : public llvm::PassInfoMixin<FmuladdPass> {
- private:
+private:
   bool changed = false;
 
   bool ProcessFAdd(llvm::BinaryOperator *add_op) {
-    if (auto *mul_op = llvm::dyn_cast<llvm::BinaryOperator>(add_op->getOperand(0));
+    if (auto *mul_op =
+            llvm::dyn_cast<llvm::BinaryOperator>(add_op->getOperand(0));
         mul_op && mul_op->getOpcode() == llvm::Instruction::FMul) {
       ReplaceWithFMA(add_op, mul_op);
       changed = true;
@@ -21,9 +22,9 @@ class FmuladdPass : public llvm::PassInfoMixin<FmuladdPass> {
 
   void ReplaceWithFMA(llvm::BinaryOperator *add, llvm::BinaryOperator *mul) {
     llvm::IRBuilder<> irb(add);
-    auto fma = irb.CreateIntrinsic(llvm::Intrinsic::fmuladd,
-                                  {mul->getOperand(0)->getType()},
-                                  {mul->getOperand(0), mul->getOperand(1), add->getOperand(1)});
+    auto fma = irb.CreateIntrinsic(
+        llvm::Intrinsic::fmuladd, {mul->getOperand(0)->getType()},
+        {mul->getOperand(0), mul->getOperand(1), add->getOperand(1)});
 
     add->replaceAllUsesWith(fma);
     add->eraseFromParent();
@@ -32,9 +33,9 @@ class FmuladdPass : public llvm::PassInfoMixin<FmuladdPass> {
     }
   }
 
- public:
+public:
   llvm::PreservedAnalyses run(llvm::Function &function,
-                               llvm::FunctionAnalysisManager &) {
+                              llvm::FunctionAnalysisManager &) {
     for (llvm::BasicBlock &basic_block : function) {
       for (auto it = basic_block.begin(); it != basic_block.end();) {
         llvm::Instruction *instruction = &*(it++);
@@ -51,15 +52,14 @@ class FmuladdPass : public llvm::PassInfoMixin<FmuladdPass> {
   }
 };
 
-}  // namespace
+} // namespace
 
 llvm::PassPluginLibraryInfo GetPluginInfo() {
   return {LLVM_PLUGIN_API_VERSION, "FmuladdPass", "0.1",
           [](llvm::PassBuilder &PB) {
             PB.registerPipelineParsingCallback(
                 [](llvm::StringRef name, llvm::FunctionPassManager &FPM,
-                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>)
-                    -> bool {
+                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) -> bool {
                   if (name == "FmuladdPass") {
                     FPM.addPass(FmuladdPass{});
                     return true;

--- a/llvm/compiler-course/llvm-ir/chistov_a_fmuladd_pass/chistov_a.cpp
+++ b/llvm/compiler-course/llvm-ir/chistov_a_fmuladd_pass/chistov_a.cpp
@@ -11,19 +11,30 @@ private:
   bool changed = false;
 
   void ProcessFAdd(llvm::BinaryOperator *add_op) {
-    if (auto *mul_op =
+    if (auto *mul_op1 =
             llvm::dyn_cast<llvm::BinaryOperator>(add_op->getOperand(0));
-        mul_op && mul_op->getOpcode() == llvm::Instruction::FMul) {
-      ReplaceWithFMA(add_op, mul_op);
+        mul_op1 && mul_op1->getOpcode() == llvm::Instruction::FMul) {
+      ReplaceWithFMA(add_op, mul_op1);
+      changed = true;
+      return;
+    }
+    if (auto *mul_op2 =
+            llvm::dyn_cast<llvm::BinaryOperator>(add_op->getOperand(1));
+        mul_op2 && mul_op2->getOpcode() == llvm::Instruction::FMul) {
+      ReplaceWithFMA(add_op, mul_op2);
       changed = true;
     }
   }
 
   void ReplaceWithFMA(llvm::BinaryOperator *add, llvm::BinaryOperator *mul) {
     llvm::IRBuilder<> irb(add);
+    llvm::Value *other_op =
+        add->getOperand(0) == mul ? add->getOperand(1) : add->getOperand(0);
+
     add->replaceAllUsesWith(irb.CreateIntrinsic(
         llvm::Intrinsic::fmuladd, {mul->getType()},
-        {mul->getOperand(0), mul->getOperand(1), add->getOperand(1)}));
+        {mul->getOperand(0), mul->getOperand(1), other_op}));
+
     add->eraseFromParent();
     if (mul->use_empty())
       mul->eraseFromParent();

--- a/llvm/compiler-course/llvm-ir/chistov_a_fmuladd_pass/chistov_a.cpp
+++ b/llvm/compiler-course/llvm-ir/chistov_a_fmuladd_pass/chistov_a.cpp
@@ -5,29 +5,71 @@
 #include "llvm/Support/raw_ostream.h"
 
 namespace {
-struct FmuladdPass : llvm::PassInfoMixin<FmuladdPass> {
-  llvm::PreservedAnalyses run(llvm::Function &func,
-                              llvm::FunctionAnalysisManager &) {
-    llvm::outs() << func.getName() << '\n';
-    return llvm::PreservedAnalyses::all();
+
+class FmuladdPass : public llvm::PassInfoMixin<FmuladdPass> {
+ private:
+  bool changed = false;
+
+  bool ProcessFAdd(llvm::BinaryOperator *add_op) {
+    if (auto *mul_op = llvm::dyn_cast<llvm::BinaryOperator>(add_op->getOperand(0));
+        mul_op && mul_op->getOpcode() == llvm::Instruction::FMul) {
+      ReplaceWithFMA(add_op, mul_op);
+      changed = true;
+    }
+    return changed;
   }
 
-  static bool isRequired() { return true; }
-};
-} // namespace
+  void ReplaceWithFMA(llvm::BinaryOperator *add, llvm::BinaryOperator *mul) {
+    llvm::IRBuilder<> irb(add);
+    auto fma = irb.CreateIntrinsic(llvm::Intrinsic::fmuladd,
+                                  {mul->getOperand(0)->getType()},
+                                  {mul->getOperand(0), mul->getOperand(1), add->getOperand(1)});
 
-extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
-llvmGetPassPluginInfo() {
+    add->replaceAllUsesWith(fma);
+    add->eraseFromParent();
+    if (mul->use_empty()) {
+      mul->eraseFromParent();
+    }
+  }
+
+ public:
+  llvm::PreservedAnalyses run(llvm::Function &function,
+                               llvm::FunctionAnalysisManager &) {
+    for (llvm::BasicBlock &basic_block : function) {
+      for (auto it = basic_block.begin(); it != basic_block.end();) {
+        llvm::Instruction *instruction = &*(it++);
+
+        if (auto *bin_op = llvm::dyn_cast<llvm::BinaryOperator>(instruction);
+            bin_op && bin_op->getOpcode() == llvm::Instruction::FAdd) {
+          ProcessFAdd(bin_op);
+        }
+      }
+    }
+
+    return changed ? llvm::PreservedAnalyses::none()
+                   : llvm::PreservedAnalyses::all();
+  }
+};
+
+}  // namespace
+
+llvm::PassPluginLibraryInfo GetPluginInfo() {
   return {LLVM_PLUGIN_API_VERSION, "FmuladdPass", "0.1",
           [](llvm::PassBuilder &PB) {
             PB.registerPipelineParsingCallback(
                 [](llvm::StringRef name, llvm::FunctionPassManager &FPM,
-                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) -> bool {
-                  if (name == "example") {
+                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>)
+                    -> bool {
+                  if (name == "FmuladdPass") {
                     FPM.addPass(FmuladdPass{});
                     return true;
                   }
                   return false;
                 });
           }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return GetPluginInfo();
 }

--- a/llvm/test/compiler-course/chistov_a_fmuladd_pass_test/chistov_a_llvm_ir.ll
+++ b/llvm/test/compiler-course/chistov_a_fmuladd_pass_test/chistov_a_llvm_ir.ll
@@ -111,3 +111,20 @@ entry:
   %add1 = fadd float %x1, %x2
   ret float %add1
 }
+
+; float faddmul(float a, float b, float c) {
+;   float x = a * b;
+;   return c+x;
+; }
+; CHECK-LABEL: define dso_local noundef float @review2(float noundef %a, float noundef %b, float noundef %c) {
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+; CHECK-NEXT: ret float %0
+; CHECK-NEXT: }
+
+define dso_local noundef float @review2(float noundef %a, float noundef %b, float noundef %c){
+entry:
+  %mul = fmul float %a, %b
+  %add = fadd float %mul, %c
+  ret float %add
+}

--- a/llvm/test/compiler-course/chistov_a_fmuladd_pass_test/chistov_a_llvm_ir.ll
+++ b/llvm/test/compiler-course/chistov_a_fmuladd_pass_test/chistov_a_llvm_ir.ll
@@ -125,6 +125,6 @@ entry:
 define dso_local noundef float @review2(float noundef %a, float noundef %b, float noundef %c){
 entry:
   %mul = fmul float %a, %b
-  %add = fadd float %mul, %c
+  %add = fadd float %c, %mul
   ret float %add
 }

--- a/llvm/test/compiler-course/chistov_a_fmuladd_pass_test/chistov_a_llvm_ir.ll
+++ b/llvm/test/compiler-course/chistov_a_fmuladd_pass_test/chistov_a_llvm_ir.ll
@@ -1,0 +1,13 @@
+; RUN: opt -load-pass-plugin %llvmshlibdir/FmuladdPass_Chistov_Alexey_FIIT1_LLVM_IR%pluginext\
+; RUN: -passes=example -S %s | FileCheck %s
+
+; CHECK: _Z6isEveni
+
+define dso_local noundef zeroext i1 @_Z6isEveni(i32 noundef %0) {
+  %2 = alloca i32, align 4
+  store i32 %0, ptr %2, align 4
+  %3 = load i32, ptr %2, align 4
+  %4 = srem i32 %3, 2
+  %5 = icmp eq i32 %4, 0
+  ret i1 %5
+}

--- a/llvm/test/compiler-course/chistov_a_fmuladd_pass_test/chistov_a_llvm_ir.ll
+++ b/llvm/test/compiler-course/chistov_a_fmuladd_pass_test/chistov_a_llvm_ir.ll
@@ -1,6 +1,6 @@
 ; RUN: opt -load-pass-plugin %llvmshlibdir/FmuladdPass_Chistov_Alexey_FIIT1_LLVM_IR%pluginext -passes=FmuladdPass -S %s | FileCheck %s
 
-; a+b (test checks that no transformation is applied for a simple addition operation)
+; a+b(test checks that no transformation is applied for a simple addition operation)
 ; CHECK-LABEL: define dso_local noundef double @simple_sum(double noundef %0, double noundef %1) {
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT: %add = fadd double %0, %1
@@ -13,19 +13,19 @@ entry:
   ret double %add
 }
 
-; a * b(separately) + c (test where optimization is not applied)
-; CHECK-LABEL: define dso_local noundef double @no_fma_separate(double noundef %a, double noundef %b, double noundef %c) {
+; (a + b) * c (test checks that no transformation is applied when addition occurs before multiplication)
+; CHECK-LABEL: define dso_local noundef double @no_optimization(double noundef %0, double noundef %1, double noundef %2) {
 ; CHECK-NEXT: entry:
-; CHECK-NEXT: %mul = fmul double %a, %b
-; CHECK-NEXT: %add = fadd double %c, %mul
-; CHECK-NEXT: ret double %add
+; CHECK-NEXT: %sum = fadd double %0, %1
+; CHECK-NEXT: %mul = fmul double %sum, %2
+; CHECK-NEXT: ret double %mul
 ; CHECK-NEXT: }
 
-define dso_local noundef double @no_fma_separate(double noundef %a, double noundef %b, double noundef %c) {
+define dso_local noundef double @no_optimization(double noundef %0, double noundef %1, double noundef %2) {
 entry:
-  %mul = fmul double %a, %b
-  %add = fadd double %c, %mul
-  ret double %add
+  %sum = fadd double %0, %1
+  %mul = fmul double %sum, %2
+  ret double %mul
 }
 
 ; a * b + c
@@ -89,4 +89,25 @@ entry:
   %add2 = fadd double %mul2, %z
   %sum = fadd double %add1, %add2
   ret double %sum
+}
+
+; float fmax2(float a, float b, float c) {
+;   float x1 = a * b;
+;   float x2 = x1 + c;
+;   float x3 = x1 + x2;
+;   return x3;
+; }
+; CHECK-LABEL: define dso_local noundef float @review(float noundef %a, float noundef %b, float noundef %c) {
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+; CHECK-NEXT: %1 = call float @llvm.fmuladd.f32(float %a, float %b, float %0)
+; CHECK-NEXT: ret float %1
+; CHECK-NEXT: }
+
+define dso_local noundef float @review(float noundef %a, float noundef %b, float noundef %c) {
+entry:
+  %x1 = fmul float %a, %b
+  %x2 = fadd float %x1, %c
+  %add1 = fadd float %x1, %x2
+  ret float %add1
 }

--- a/llvm/test/compiler-course/chistov_a_fmuladd_pass_test/chistov_a_llvm_ir.ll
+++ b/llvm/test/compiler-course/chistov_a_fmuladd_pass_test/chistov_a_llvm_ir.ll
@@ -1,7 +1,7 @@
 ; RUN: opt -load-pass-plugin %llvmshlibdir/FmuladdPass_Chistov_Alexey_FIIT1_LLVM_IR%pluginext -passes=FmuladdPass -S %s | FileCheck %s
 
-; This test checks that no transformation is applied for a simple addition operation.
-; CHECK: define dso_local noundef double @simple_sum(double noundef %0, double noundef %1) {
+; a+b (test checks that no transformation is applied for a simple addition operation)
+; CHECK-LABEL: define dso_local noundef double @simple_sum(double noundef %0, double noundef %1) {
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT: %add = fadd double %0, %1
 ; CHECK-NEXT: ret double %add
@@ -13,8 +13,23 @@ entry:
   ret double %add
 }
 
+; a * b(separately) + c (test where optimization is not applied)
+; CHECK-LABEL: define dso_local noundef double @no_fma_separate(double noundef %a, double noundef %b, double noundef %c) {
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %mul = fmul double %a, %b
+; CHECK-NEXT: %add = fadd double %c, %mul
+; CHECK-NEXT: ret double %add
+; CHECK-NEXT: }
+
+define dso_local noundef double @no_fma_separate(double noundef %a, double noundef %b, double noundef %c) {
+entry:
+  %mul = fmul double %a, %b
+  %add = fadd double %c, %mul
+  ret double %add
+}
+
 ; a * b + c
-; CHECK: define dso_local noundef double @example(double noundef %0, double noundef %1, double noundef %2) {
+; CHECK-LABEL: define dso_local noundef double @example(double noundef %0, double noundef %1, double noundef %2) {
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT: %3 = call double @llvm.fmuladd.f64(double %0, double %1, double %2)
 ; CHECK-NEXT: ret double %3
@@ -28,7 +43,7 @@ entry:
 }
 
 ; a * 5.0 + 2.0
-; CHECK: define dso_local noundef double @const(double noundef %a) {
+; CHECK-LABEL: define dso_local noundef double @const(double noundef %a) {
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT: %0 = call double @llvm.fmuladd.f64(double %a, double 5.000000e+00, double 2.000000e+00)
 ; CHECK-NEXT: ret double %0
@@ -42,7 +57,7 @@ entry:
 }
 
 ; a * b + c + d
-; CHECK: define dso_local noundef double @chain(double noundef %a, double noundef %b, double noundef %c, double noundef %d) {
+; CHECK-LABEL:define dso_local noundef double @chain(double noundef %a, double noundef %b, double noundef %c, double noundef %d) {
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT: %0 = call double @llvm.fmuladd.f64(double %a, double %b, double %c)
 ; CHECK-NEXT: %add2 = fadd double %0, %d
@@ -58,7 +73,7 @@ entry:
 }
 
 ; (a * b + c)+ (x * y + z)
-; CHECK: define dso_local noundef double @several(double noundef %a, double noundef %b, double noundef %c, double noundef %x, double noundef %y, double noundef %z) {
+; CHECK-LABEL: define dso_local noundef double @several(double noundef %a, double noundef %b, double noundef %c, double noundef %x, double noundef %y, double noundef %z) {
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT: %0 = call double @llvm.fmuladd.f64(double %a, double %b, double %c)
 ; CHECK-NEXT: %1 = call double @llvm.fmuladd.f64(double %x, double %y, double %z)

--- a/llvm/test/compiler-course/chistov_a_fmuladd_pass_test/chistov_a_llvm_ir.ll
+++ b/llvm/test/compiler-course/chistov_a_fmuladd_pass_test/chistov_a_llvm_ir.ll
@@ -1,13 +1,77 @@
-; RUN: opt -load-pass-plugin %llvmshlibdir/FmuladdPass_Chistov_Alexey_FIIT1_LLVM_IR%pluginext\
-; RUN: -passes=example -S %s | FileCheck %s
+; RUN: opt -load-pass-plugin %llvmshlibdir/FmuladdPass_Chistov_Alexey_FIIT1_LLVM_IR%pluginext -passes=FmuladdPass -S %s | FileCheck %s
 
-; CHECK: _Z6isEveni
+; This test checks that no transformation is applied for a simple addition operation.
+; CHECK: define dso_local noundef double @simple_sum(double noundef %0, double noundef %1) {
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %add = fadd double %0, %1
+; CHECK-NEXT: ret double %add
+; CHECK-NEXT: }
 
-define dso_local noundef zeroext i1 @_Z6isEveni(i32 noundef %0) {
-  %2 = alloca i32, align 4
-  store i32 %0, ptr %2, align 4
-  %3 = load i32, ptr %2, align 4
-  %4 = srem i32 %3, 2
-  %5 = icmp eq i32 %4, 0
-  ret i1 %5
+define dso_local noundef double @simple_sum(double noundef %0, double noundef %1) {
+entry:
+  %add = fadd double %0, %1
+  ret double %add
+}
+
+; a * b + c
+; CHECK: define dso_local noundef double @example(double noundef %0, double noundef %1, double noundef %2) {
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %3 = call double @llvm.fmuladd.f64(double %0, double %1, double %2)
+; CHECK-NEXT: ret double %3
+; CHECK-NEXT: }
+
+define dso_local noundef double @example(double noundef %0, double noundef %1, double noundef %2) {
+entry:
+  %mul = fmul double %0, %1
+  %add = fadd double %mul, %2
+  ret double %add
+}
+
+; a * 5.0 + 2.0
+; CHECK: define dso_local noundef double @const(double noundef %a) {
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %0 = call double @llvm.fmuladd.f64(double %a, double 5.000000e+00, double 2.000000e+00)
+; CHECK-NEXT: ret double %0
+; CHECK-NEXT: }
+
+define dso_local noundef double @const(double noundef %a) {
+entry:
+  %mul = fmul double %a, 5.0
+  %add = fadd double %mul, 2.0
+  ret double %add
+}
+
+; a * b + c + d
+; CHECK: define dso_local noundef double @chain(double noundef %a, double noundef %b, double noundef %c, double noundef %d) {
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %0 = call double @llvm.fmuladd.f64(double %a, double %b, double %c)
+; CHECK-NEXT: %add2 = fadd double %0, %d
+; CHECK-NEXT: ret double %add2
+; CHECK-NEXT: }
+
+define dso_local noundef double @chain(double noundef %a, double noundef %b, double noundef %c, double noundef %d) {
+entry:
+  %mul = fmul double %a, %b
+  %add1 = fadd double %mul, %c
+  %add2 = fadd double %add1, %d
+  ret double %add2
+}
+
+; (a * b + c)+ (x * y + z)
+; CHECK: define dso_local noundef double @several(double noundef %a, double noundef %b, double noundef %c, double noundef %x, double noundef %y, double noundef %z) {
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %0 = call double @llvm.fmuladd.f64(double %a, double %b, double %c)
+; CHECK-NEXT: %1 = call double @llvm.fmuladd.f64(double %x, double %y, double %z)
+; CHECK-NEXT: %sum = fadd double %0, %1
+; CHECK-NEXT: ret double %sum
+; CHECK-NEXT: }
+
+define dso_local noundef double @several(double noundef %a, double noundef %b, double noundef %c, double noundef %x, double noundef %y, double noundef %z) {
+entry:
+  %mul1 = fmul double %a, %b
+  %add1 = fadd double %mul1, %c
+  %mul2 = fmul double %x, %y
+  %add2 = fadd double %mul2, %z
+  %sum = fadd double %add1, %add2
+  ret double %sum
 }


### PR DESCRIPTION
`FmuladdPass` находит инструкции сложения (`FAdd`), у которых один из операндов является результатом умножения (`FMul`), и заменяя их на `llvm.fmuladd` (FMA) с основными функциями `ProcessFAdd` для поиска и замены инструкций и `ReplaceWithFMA` для создания FMA-инструкции с помощью `IRBuilder`. Регистрация пасса осуществляется через `llvmGetPassPluginInfo()`. 


