### PR TITLE
Шурыгин Сергей. Лабораторная работа 2: LLVM IR. Вариант 4.

### DIFF
--- a/llvm/compiler-course/llvm-ir/Shurigin_LLVM_IR_LAB2/CMakeLists.txt
+++ b/llvm/compiler-course/llvm-ir/Shurigin_LLVM_IR_LAB2/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(Title "LLVM_IR_LAB2")
+set(Student "Shurigin")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_LLVM_IR")
+
+if (NOT WIN32 AND NOT CYGWIN)
+    file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+    add_llvm_pass_plugin(${TARGET_NAME} ${SOURCES}
+        DEPENDS
+        intrinsics_gen
+        BUILDTREE_ONLY
+    )
+    set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)
+endif()

--- a/llvm/compiler-course/llvm-ir/Shurigin_LLVM_IR_LAB2/Shurigin_LLVM_IR_LAB2.cpp
+++ b/llvm/compiler-course/llvm-ir/Shurigin_LLVM_IR_LAB2/Shurigin_LLVM_IR_LAB2.cpp
@@ -1,3 +1,4 @@
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
@@ -6,96 +7,85 @@
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Support/raw_ostream.h"
 
-using namespace llvm;
-
 namespace {
-
-static bool isPowerOfTwo(int64_t n) {
-  if (n > 0) {
-    return (n & (n - 1)) == 0;
-  } else if (n < 0) {
-    return isPowerOfTwo(-n);
-  }
-  return false;
-}
-
-static unsigned getLog2(int64_t n) {
-  n = n < 0 ? -n : n;
-  unsigned log = 0;
-  while (n >>= 1)
-    ++log;
-  return log;
-}
-
-struct DivisionToShiftPass : PassInfoMixin<DivisionToShiftPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &) {
+struct DivisionToShiftPass : llvm::PassInfoMixin<DivisionToShiftPass> {
+  llvm::PreservedAnalyses run(llvm::Function &F,
+                              llvm::FunctionAnalysisManager &) {
     bool changed = false;
 
     for (auto &BB : F) {
-      std::vector<Instruction *> toReplace;
+      llvm::SmallVector<llvm::Instruction *, 8> toReplace;
 
       for (auto &I : BB) {
-        if (auto *BO = dyn_cast<BinaryOperator>(&I)) {
-          if (BO->getOpcode() == Instruction::SDiv ||
-              BO->getOpcode() == Instruction::UDiv) {
-            if (auto *C = dyn_cast<ConstantInt>(BO->getOperand(1))) {
-              int64_t divisor = C->getSExtValue();
+        auto *BO = llvm::dyn_cast<llvm::BinaryOperator>(&I);
+        if (!BO || (BO->getOpcode() != llvm::Instruction::SDiv &&
+                    BO->getOpcode() != llvm::Instruction::UDiv)) {
+          continue;
+        }
 
-              if (divisor == 1) {
-                IRBuilder<> Builder(BO);
-                Value *Result = Builder.CreateAdd(
-                    BO->getOperand(0), ConstantInt::get(C->getType(), 0));
-                BO->replaceAllUsesWith(Result);
-                toReplace.push_back(BO);
-                changed = true;
-                continue;
-              }
+        auto *C = llvm::dyn_cast<llvm::ConstantInt>(BO->getOperand(1));
+        if (!C) {
+          continue;
+        }
 
-              if (isPowerOfTwo(std::abs(divisor))) {
-                unsigned shift = getLog2(std::abs(divisor));
-                IRBuilder<> Builder(BO);
-                Value *ShiftResult;
+        int64_t divisor = C->getSExtValue();
+        if (divisor == 1) {
+          llvm::IRBuilder<> Builder(BO);
+          llvm::Value *Result = Builder.CreateAdd(
+              BO->getOperand(0), llvm::ConstantInt::get(C->getType(), 0));
+          BO->replaceAllUsesWith(Result);
+          toReplace.push_back(BO);
+          changed = true;
+          continue;
+        }
 
-                if (BO->getOpcode() == Instruction::SDiv) {
-                  ShiftResult = Builder.CreateAShr(
-                      BO->getOperand(0), ConstantInt::get(C->getType(), shift));
-                } else {
-                  ShiftResult = Builder.CreateLShr(
-                      BO->getOperand(0), ConstantInt::get(C->getType(), shift));
-                }
+        if (llvm::isPowerOf2_64(std::abs(divisor))) {
+          unsigned shift = llvm::Log2(std::abs(divisor));
+          llvm::IRBuilder<> Builder(BO);
+          llvm::Value *ShiftResult;
 
-                if (divisor < 0) {
-                  ShiftResult = Builder.CreateSub(
-                      ConstantInt::get(C->getType(), 0), ShiftResult);
-                }
-
-                BO->replaceAllUsesWith(ShiftResult);
-                toReplace.push_back(BO);
-                changed = true;
-              }
-            }
+          if (BO->getOpcode() == llvm::Instruction::SDiv) {
+            ShiftResult = Builder.CreateAShr(
+                BO->getOperand(0), llvm::ConstantInt::get(C->getType(), shift));
+          } else {
+            ShiftResult = Builder.CreateLShr(
+                BO->getOperand(0), llvm::ConstantInt::get(C->getType(), shift));
           }
+
+          if (divisor < 0) {
+            ShiftResult = Builder.CreateSub(
+                llvm::ConstantInt::get(C->getType(), 0), ShiftResult);
+          }
+
+          BO->replaceAllUsesWith(ShiftResult);
+          toReplace.push_back(BO);
+          changed = true;
         }
       }
-
-      for (auto *I : toReplace) {
-        I->eraseFromParent();
-      }
     }
-
-    return changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
   }
+}
 
-  static bool isRequired() { return true; }
-};
+for (auto *I : toReplace) {
+  I->eraseFromParent();
+}
+}
+
+return changed ? llvm::PreservedAnalyses::none()
+               : llvm::PreservedAnalyses::all();
+}
+
+static bool isRequired() { return true; }
+}
+;
 } // namespace
 
 llvm::PassPluginLibraryInfo getDivToShiftPluginInfo() {
   return {LLVM_PLUGIN_API_VERSION, "DivisionToShiftPass", "v1.0",
-          [](PassBuilder &PB) {
+          [](llvm::PassBuilder &PB) {
             PB.registerPipelineParsingCallback(
-                [](StringRef Name, FunctionPassManager &FPM,
-                   ArrayRef<PassBuilder::PipelineElement>) -> bool {
+                [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
+                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) -> bool {
                   if (Name == "div2shift") {
                     FPM.addPass(DivisionToShiftPass());
                     return true;

--- a/llvm/compiler-course/llvm-ir/Shurigin_LLVM_IR_LAB2/Shurigin_LLVM_IR_LAB2.cpp
+++ b/llvm/compiler-course/llvm-ir/Shurigin_LLVM_IR_LAB2/Shurigin_LLVM_IR_LAB2.cpp
@@ -1,3 +1,4 @@
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
@@ -5,7 +6,6 @@
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/ADT/SmallVector.h"
 
 namespace {
 
@@ -27,7 +27,8 @@ static unsigned getLog2(int64_t n) {
 }
 
 struct DivisionToShiftPass : llvm::PassInfoMixin<DivisionToShiftPass> {
-  llvm::PreservedAnalyses run(llvm::Function &F, llvm::FunctionAnalysisManager &) {
+  llvm::PreservedAnalyses run(llvm::Function &F,
+                              llvm::FunctionAnalysisManager &) {
     bool changed = false;
 
     for (auto &BB : F) {
@@ -37,7 +38,8 @@ struct DivisionToShiftPass : llvm::PassInfoMixin<DivisionToShiftPass> {
         if (auto *BO = llvm::dyn_cast<llvm::BinaryOperator>(&I)) {
           if (BO->getOpcode() == llvm::Instruction::SDiv ||
               BO->getOpcode() == llvm::Instruction::UDiv) {
-            if (auto *C = llvm::dyn_cast<llvm::ConstantInt>(BO->getOperand(1))) {
+            if (auto *C =
+                    llvm::dyn_cast<llvm::ConstantInt>(BO->getOperand(1))) {
               int64_t divisor = C->getSExtValue();
 
               if (divisor == 1) {
@@ -57,10 +59,12 @@ struct DivisionToShiftPass : llvm::PassInfoMixin<DivisionToShiftPass> {
 
                 if (BO->getOpcode() == llvm::Instruction::SDiv) {
                   ShiftResult = Builder.CreateAShr(
-                      BO->getOperand(0), llvm::ConstantInt::get(C->getType(), shift));
+                      BO->getOperand(0), 
+                      llvm::ConstantInt::get(C->getType(), shift));
                 } else {
                   ShiftResult = Builder.CreateLShr(
-                      BO->getOperand(0), llvm::ConstantInt::get(C->getType(), shift));
+                      BO->getOperand(0), 
+                      llvm::ConstantInt::get(C->getType(), shift));
                 }
 
                 if (divisor < 0) {
@@ -82,7 +86,8 @@ struct DivisionToShiftPass : llvm::PassInfoMixin<DivisionToShiftPass> {
       }
     }
 
-    return changed ? llvm::PreservedAnalyses::none() : llvm::PreservedAnalyses::all();
+    return changed ? llvm::PreservedAnalyses::none() 
+                   : llvm::PreservedAnalyses::all();
   }
 
   static bool isRequired() { return true; }

--- a/llvm/compiler-course/llvm-ir/Shurigin_LLVM_IR_LAB2/Shurigin_LLVM_IR_LAB2.cpp
+++ b/llvm/compiler-course/llvm-ir/Shurigin_LLVM_IR_LAB2/Shurigin_LLVM_IR_LAB2.cpp
@@ -1,0 +1,111 @@
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+
+namespace {
+
+static bool isPowerOfTwo(int64_t n) {
+  if (n > 0) {
+    return (n & (n - 1)) == 0;
+  } else if (n < 0) {
+    return isPowerOfTwo(-n);
+  }
+  return false;
+}
+
+static unsigned getLog2(int64_t n) {
+  n = n < 0 ? -n : n;
+  unsigned log = 0;
+  while (n >>= 1)
+    ++log;
+  return log;
+}
+
+struct DivisionToShiftPass : PassInfoMixin<DivisionToShiftPass> {
+  PreservedAnalyses run(Function &F, FunctionAnalysisManager &) {
+    bool changed = false;
+
+    for (auto &BB : F) {
+      std::vector<Instruction *> toReplace;
+
+      for (auto &I : BB) {
+        if (auto *BO = dyn_cast<BinaryOperator>(&I)) {
+          if (BO->getOpcode() == Instruction::SDiv ||
+              BO->getOpcode() == Instruction::UDiv) {
+            if (auto *C = dyn_cast<ConstantInt>(BO->getOperand(1))) {
+              int64_t divisor = C->getSExtValue();
+
+              if (divisor == 1) {
+                IRBuilder<> Builder(BO);
+                Value *Result = Builder.CreateAdd(
+                    BO->getOperand(0), ConstantInt::get(C->getType(), 0));
+                BO->replaceAllUsesWith(Result);
+                toReplace.push_back(BO);
+                changed = true;
+                continue;
+              }
+
+              if (isPowerOfTwo(std::abs(divisor))) {
+                unsigned shift = getLog2(std::abs(divisor));
+                IRBuilder<> Builder(BO);
+                Value *ShiftResult;
+
+                if (BO->getOpcode() == Instruction::SDiv) {
+                  ShiftResult = Builder.CreateAShr(
+                      BO->getOperand(0), ConstantInt::get(C->getType(), shift));
+                } else {
+                  ShiftResult = Builder.CreateLShr(
+                      BO->getOperand(0), ConstantInt::get(C->getType(), shift));
+                }
+
+                if (divisor < 0) {
+                  ShiftResult = Builder.CreateSub(
+                      ConstantInt::get(C->getType(), 0), ShiftResult);
+                }
+
+                BO->replaceAllUsesWith(ShiftResult);
+                toReplace.push_back(BO);
+                changed = true;
+              }
+            }
+          }
+        }
+      }
+
+      for (auto *I : toReplace) {
+        I->eraseFromParent();
+      }
+    }
+
+    return changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+  }
+
+  static bool isRequired() { return true; }
+};
+} // namespace
+
+llvm::PassPluginLibraryInfo getDivToShiftPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "DivisionToShiftPass", "v1.0",
+          [](PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](StringRef Name, FunctionPassManager &FPM,
+                   ArrayRef<PassBuilder::PipelineElement>) -> bool {
+                  if (Name == "div2shift") {
+                    FPM.addPass(DivisionToShiftPass());
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return getDivToShiftPluginInfo();
+}

--- a/llvm/compiler-course/llvm-ir/Shurigin_LLVM_IR_LAB2/Shurigin_LLVM_IR_LAB2.cpp
+++ b/llvm/compiler-course/llvm-ir/Shurigin_LLVM_IR_LAB2/Shurigin_LLVM_IR_LAB2.cpp
@@ -5,6 +5,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace {
@@ -52,8 +53,8 @@ struct DivisionToShiftPass : llvm::PassInfoMixin<DivisionToShiftPass> {
                 continue;
               }
 
-              if (isPowerOfTwo(std::abs(divisor))) {
-                unsigned shift = getLog2(std::abs(divisor));
+              if (llvm::isPowerOf2_64(std::abs(divisor))) {
+                unsigned shift = llvm::exactLog2_64(std::abs(divisor));
                 llvm::IRBuilder<> Builder(BO);
                 llvm::Value *ShiftResult;
 

--- a/llvm/compiler-course/llvm-ir/Shurigin_LLVM_IR_LAB2/Shurigin_LLVM_IR_LAB2.cpp
+++ b/llvm/compiler-course/llvm-ir/Shurigin_LLVM_IR_LAB2/Shurigin_LLVM_IR_LAB2.cpp
@@ -6,8 +6,6 @@
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Support/raw_ostream.h"
 
-using namespace llvm;
-
 namespace {
 
 static bool isPowerOfTwo(int64_t n) {
@@ -32,7 +30,7 @@ struct DivisionToShiftPass : PassInfoMixin<DivisionToShiftPass> {
     bool changed = false;
 
     for (auto &BB : F) {
-      std::vector<Instruction *> toReplace;
+      llvm::SmallVector<Instruction *> toReplace;
 
       for (auto &I : BB) {
         if (auto *BO = dyn_cast<BinaryOperator>(&I)) {

--- a/llvm/compiler-course/llvm-ir/Shurigin_LLVM_IR_LAB2/Shurigin_LLVM_IR_LAB2.cpp
+++ b/llvm/compiler-course/llvm-ir/Shurigin_LLVM_IR_LAB2/Shurigin_LLVM_IR_LAB2.cpp
@@ -5,6 +5,7 @@
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace {
 
@@ -25,24 +26,24 @@ static unsigned getLog2(int64_t n) {
   return log;
 }
 
-struct DivisionToShiftPass : PassInfoMixin<DivisionToShiftPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &) {
+struct DivisionToShiftPass : llvm::PassInfoMixin<DivisionToShiftPass> {
+  llvm::PreservedAnalyses run(llvm::Function &F, llvm::FunctionAnalysisManager &) {
     bool changed = false;
 
     for (auto &BB : F) {
-      llvm::SmallVector<Instruction *> toReplace;
+      llvm::SmallVector<llvm::Instruction *, 8> toReplace;
 
       for (auto &I : BB) {
-        if (auto *BO = dyn_cast<BinaryOperator>(&I)) {
-          if (BO->getOpcode() == Instruction::SDiv ||
-              BO->getOpcode() == Instruction::UDiv) {
-            if (auto *C = dyn_cast<ConstantInt>(BO->getOperand(1))) {
+        if (auto *BO = llvm::dyn_cast<llvm::BinaryOperator>(&I)) {
+          if (BO->getOpcode() == llvm::Instruction::SDiv ||
+              BO->getOpcode() == llvm::Instruction::UDiv) {
+            if (auto *C = llvm::dyn_cast<llvm::ConstantInt>(BO->getOperand(1))) {
               int64_t divisor = C->getSExtValue();
 
               if (divisor == 1) {
-                IRBuilder<> Builder(BO);
-                Value *Result = Builder.CreateAdd(
-                    BO->getOperand(0), ConstantInt::get(C->getType(), 0));
+                llvm::IRBuilder<> Builder(BO);
+                llvm::Value *Result = Builder.CreateAdd(
+                    BO->getOperand(0), llvm::ConstantInt::get(C->getType(), 0));
                 BO->replaceAllUsesWith(Result);
                 toReplace.push_back(BO);
                 changed = true;
@@ -51,20 +52,20 @@ struct DivisionToShiftPass : PassInfoMixin<DivisionToShiftPass> {
 
               if (isPowerOfTwo(std::abs(divisor))) {
                 unsigned shift = getLog2(std::abs(divisor));
-                IRBuilder<> Builder(BO);
-                Value *ShiftResult;
+                llvm::IRBuilder<> Builder(BO);
+                llvm::Value *ShiftResult;
 
-                if (BO->getOpcode() == Instruction::SDiv) {
+                if (BO->getOpcode() == llvm::Instruction::SDiv) {
                   ShiftResult = Builder.CreateAShr(
-                      BO->getOperand(0), ConstantInt::get(C->getType(), shift));
+                      BO->getOperand(0), llvm::ConstantInt::get(C->getType(), shift));
                 } else {
                   ShiftResult = Builder.CreateLShr(
-                      BO->getOperand(0), ConstantInt::get(C->getType(), shift));
+                      BO->getOperand(0), llvm::ConstantInt::get(C->getType(), shift));
                 }
 
                 if (divisor < 0) {
                   ShiftResult = Builder.CreateSub(
-                      ConstantInt::get(C->getType(), 0), ShiftResult);
+                      llvm::ConstantInt::get(C->getType(), 0), ShiftResult);
                 }
 
                 BO->replaceAllUsesWith(ShiftResult);
@@ -81,7 +82,7 @@ struct DivisionToShiftPass : PassInfoMixin<DivisionToShiftPass> {
       }
     }
 
-    return changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+    return changed ? llvm::PreservedAnalyses::none() : llvm::PreservedAnalyses::all();
   }
 
   static bool isRequired() { return true; }
@@ -90,10 +91,10 @@ struct DivisionToShiftPass : PassInfoMixin<DivisionToShiftPass> {
 
 llvm::PassPluginLibraryInfo getDivToShiftPluginInfo() {
   return {LLVM_PLUGIN_API_VERSION, "DivisionToShiftPass", "v1.0",
-          [](PassBuilder &PB) {
+          [](llvm::PassBuilder &PB) {
             PB.registerPipelineParsingCallback(
-                [](StringRef Name, FunctionPassManager &FPM,
-                   ArrayRef<PassBuilder::PipelineElement>) -> bool {
+                [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
+                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) -> bool {
                   if (Name == "div2shift") {
                     FPM.addPass(DivisionToShiftPass());
                     return true;

--- a/llvm/compiler-course/llvm-ir/Shurigin_LLVM_IR_LAB2/Shurigin_LLVM_IR_LAB2.cpp
+++ b/llvm/compiler-course/llvm-ir/Shurigin_LLVM_IR_LAB2/Shurigin_LLVM_IR_LAB2.cpp
@@ -59,11 +59,11 @@ struct DivisionToShiftPass : llvm::PassInfoMixin<DivisionToShiftPass> {
 
                 if (BO->getOpcode() == llvm::Instruction::SDiv) {
                   ShiftResult = Builder.CreateAShr(
-                      BO->getOperand(0), 
+                      BO->getOperand(0),
                       llvm::ConstantInt::get(C->getType(), shift));
                 } else {
                   ShiftResult = Builder.CreateLShr(
-                      BO->getOperand(0), 
+                      BO->getOperand(0),
                       llvm::ConstantInt::get(C->getType(), shift));
                 }
 
@@ -86,7 +86,7 @@ struct DivisionToShiftPass : llvm::PassInfoMixin<DivisionToShiftPass> {
       }
     }
 
-    return changed ? llvm::PreservedAnalyses::none() 
+    return changed ? llvm::PreservedAnalyses::none()
                    : llvm::PreservedAnalyses::all();
   }
 

--- a/llvm/test/compiler-course/Shurigin_LLVM_IR_LAB2/test_llvm_ir.ll
+++ b/llvm/test/compiler-course/Shurigin_LLVM_IR_LAB2/test_llvm_ir.ll
@@ -56,3 +56,52 @@ define i32 @f15(i32 %value) {
   %div = sdiv i32 %value, 33  
   ret i32 %div
 }
+
+define i32 @u1(i32 %value) {
+; CHECK: @u1
+; CHECK-NEXT: lshr i32 %value, 3
+  %div = udiv i32 %value, 8
+  ret i32 %div
+}
+
+define i32 @u2(i32 %value) {
+; CHECK: @u2
+; CHECK-NEXT: lshr i32 %value, 1
+  %div = udiv i32 %value, 2
+  ret i32 %div
+}
+
+define i32 @u3(i32 %value) {
+; CHECK: @u3
+; CHECK-NEXT: udiv i32 %value, 3
+  %div = udiv i32 %value, 3
+  ret i32 %div
+}
+
+define i32 @u4(i32 %value) {
+; CHECK: @u4
+; CHECK-NEXT: lshr i32 %value, 10
+  %div = udiv i32 %value, 1024
+  ret i32 %div
+}
+
+define i32 @u6(i32 %value) {
+; CHECK: @u6
+; CHECK-NEXT: add i32 %value, 0
+  %div = udiv i32 %value, 1
+  ret i32 %div
+}
+
+define i32 @u7(i32 %value) {
+; CHECK: @u7
+; CHECK-NEXT: lshr i32 %value, 30
+  %div = udiv i32 %value, 1073741824  ; 2^30
+  ret i32 %div
+}
+
+define i32 @u8(i32 %value) {
+; CHECK: @u8
+; CHECK-NEXT: udiv i32 %value, 33
+  %div = udiv i32 %value, 33  
+  ret i32 %div
+}

--- a/llvm/test/compiler-course/Shurigin_LLVM_IR_LAB2/test_llvm_ir.ll
+++ b/llvm/test/compiler-course/Shurigin_LLVM_IR_LAB2/test_llvm_ir.ll
@@ -1,6 +1,5 @@
 ; RUN: opt -load-pass-plugin %llvmshlibdir/LLVM_IR_LAB2_Shurigin_FIIT1_LLVM_IR%pluginext -passes=div2shift -S %s | FileCheck %s
 
-; Базовые тесты - деление на степени двойки
 define i32 @f1(i32 %value) {
 ; CHECK: @f1
 ; CHECK-NEXT: ashr i32 %value, 3
@@ -15,7 +14,6 @@ define i32 @f2(i32 %value) {
   ret i32 %div
 }
 
-; Деление на не-степень двойки - не должно меняться
 define i32 @f3(i32 %value) {
 ; CHECK: @f3
 ; CHECK-NEXT: sdiv i32 %value, 3
@@ -23,7 +21,6 @@ define i32 @f3(i32 %value) {
   ret i32 %div
 }
 
-; Большие степени двойки
 define i32 @f4(i32 %value) {
 ; CHECK: @f4
 ; CHECK-NEXT: ashr i32 %value, 10
@@ -31,7 +28,6 @@ define i32 @f4(i32 %value) {
   ret i32 %div
 }
 
-; Отрицательный делитель, степень двойки
 define i32 @f5(i32 %value) {
 ; CHECK: @f5
 ; CHECK-NEXT: ashr i32 %value, 2
@@ -40,7 +36,6 @@ define i32 @f5(i32 %value) {
   ret i32 %div
 }
 
-; Деление на 1 - не должно создавать сдвиг
 define i32 @f6(i32 %value) {
 ; CHECK: @f6
 ; CHECK-NEXT: add i32 %value, 0
@@ -48,7 +43,6 @@ define i32 @f6(i32 %value) {
   ret i32 %div
 }
 
-; Проверка максимальной степени двойки
 define i32 @f14(i32 %value) {
 ; CHECK: @f14
 ; CHECK-NEXT: ashr i32 %value, 30
@@ -56,10 +50,9 @@ define i32 @f14(i32 %value) {
   ret i32 %div
 }
 
-; Проверяем точность, что деление на число, близкое к степени двойки, не меняется
 define i32 @f15(i32 %value) {
 ; CHECK: @f15
 ; CHECK-NEXT: sdiv i32 %value, 33
-  %div = sdiv i32 %value, 33  ; не степень двойки (близко к 32 = 2^5)
+  %div = sdiv i32 %value, 33  
   ret i32 %div
 }

--- a/llvm/test/compiler-course/Shurigin_LLVM_IR_LAB2/test_llvm_ir.ll
+++ b/llvm/test/compiler-course/Shurigin_LLVM_IR_LAB2/test_llvm_ir.ll
@@ -1,0 +1,65 @@
+; RUN: opt -load-pass-plugin %llvmshlibdir/LLVM_IR_LAB2_Shurigin_FIIT1_LLVM_IR%pluginext -passes=div2shift -S %s | FileCheck %s
+
+; Базовые тесты - деление на степени двойки
+define i32 @f1(i32 %value) {
+; CHECK: @f1
+; CHECK-NEXT: ashr i32 %value, 3
+  %div = sdiv i32 %value, 8
+  ret i32 %div
+}
+
+define i32 @f2(i32 %value) {
+; CHECK: @f2
+; CHECK-NEXT: ashr i32 %value, 1
+  %div = sdiv i32 %value, 2
+  ret i32 %div
+}
+
+; Деление на не-степень двойки - не должно меняться
+define i32 @f3(i32 %value) {
+; CHECK: @f3
+; CHECK-NEXT: sdiv i32 %value, 3
+  %div = sdiv i32 %value, 3
+  ret i32 %div
+}
+
+; Большие степени двойки
+define i32 @f4(i32 %value) {
+; CHECK: @f4
+; CHECK-NEXT: ashr i32 %value, 10
+  %div = sdiv i32 %value, 1024
+  ret i32 %div
+}
+
+; Отрицательный делитель, степень двойки
+define i32 @f5(i32 %value) {
+; CHECK: @f5
+; CHECK-NEXT: ashr i32 %value, 2
+; CHECK-NEXT: sub i32 0, %
+  %div = sdiv i32 %value, -4
+  ret i32 %div
+}
+
+; Деление на 1 - не должно создавать сдвиг
+define i32 @f6(i32 %value) {
+; CHECK: @f6
+; CHECK-NEXT: add i32 %value, 0
+  %div = sdiv i32 %value, 1
+  ret i32 %div
+}
+
+; Проверка максимальной степени двойки
+define i32 @f14(i32 %value) {
+; CHECK: @f14
+; CHECK-NEXT: ashr i32 %value, 30
+  %div = sdiv i32 %value, 1073741824  ; 2^30
+  ret i32 %div
+}
+
+; Проверяем точность, что деление на число, близкое к степени двойки, не меняется
+define i32 @f15(i32 %value) {
+; CHECK: @f15
+; CHECK-NEXT: sdiv i32 %value, 33
+  %div = sdiv i32 %value, 33  ; не степень двойки (близко к 32 = 2^5)
+  ret i32 %div
+}


### PR DESCRIPTION
Этот LLVM-пасс оптимизирует деление на степень двойки, заменяя его на битовые сдвиги.

**Как работает:**
1. Проверяет, является ли делитель степенью двойки (isPowerOfTwo).
2. Заменяет x / 2^n на сдвиг вправо (AShr для знакового, LShr для беззнакового).
3. Если делитель равен 1, операция заменяется сложением. 
4. Если делитель отрицательный, инвертирует знак результата.
5. Удаляет исходное деление.

**Результат**: более быстрый код за счёт замены деления на сдвиги.