### PR TITLE
Соловьев Алексей. Лабораторная работа 2: LLVM IR. Вариант 4.

### DIFF
--- a/llvm/compiler-course/llvm-ir/solovev_a/CMakeLists.txt
+++ b/llvm/compiler-course/llvm-ir/solovev_a/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(Title "Lab_2_llvm_ir")
+set(Student "Solovev_a")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_LLVM_IR")
+
+if (NOT WIN32 AND NOT CYGWIN)
+    file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+    add_llvm_pass_plugin(${TARGET_NAME} ${SOURCES}
+        DEPENDS
+        intrinsics_gen
+        BUILDTREE_ONLY
+    )
+    set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)
+endif()

--- a/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
+++ b/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
@@ -9,60 +9,66 @@
 
 namespace {
 
-    class DivToShiftPass : public llvm::PassInfoMixin<DivToShiftPass> {
-    public:
-        llvm::PreservedAnalyses run(llvm::Function& F, llvm::FunctionAnalysisManager& FAM) {
-            bool changed = false;
-            for (auto& BB : F) {
-                for (auto& I : llvm::make_early_inc_range(BB)) {
-                    if (auto* SDiv = llvm::dyn_cast<llvm::BinaryOperator>(&I)) {
-                        if (SDiv->getOpcode() == llvm::Instruction::SDiv) {
-                            if (auto* ConstInt = llvm::dyn_cast<llvm::ConstantInt>(SDiv->getOperand(1))) {
-                                int64_t divisor = ConstInt->getSExtValue();
-                                llvm::IRBuilder<> Builder(SDiv);
-                                if (divisor == 1 || divisor == -1) {
-                                    llvm::Value* NewVal = Builder.CreateAdd(SDiv->getOperand(0),
-                                        llvm::ConstantInt::get(SDiv->getType(), 0), "add_zero");
-                                    if (divisor == -1) {
-                                        NewVal = Builder.CreateNeg(NewVal, "neg_tmp");
-                                    }
-                                    SDiv->replaceAllUsesWith(NewVal);
-                                    SDiv->eraseFromParent();
-                                    changed = true;
-                                    continue;
-                                }
-                                if (divisor != 0 && (abs(divisor) & (abs(divisor) - 1)) == 0) {
-                                    int shiftAmount = llvm::Log2_64(abs(divisor));
-                                    llvm::Value* Shifted = Builder.CreateAShr(SDiv->getOperand(0), shiftAmount, "sh_tmp");
-                                    if (divisor < 0) {
-                                        Shifted = Builder.CreateNeg(Shifted, "neg_tmp");
-                                    }
-                                    SDiv->replaceAllUsesWith(Shifted);
-                                    SDiv->eraseFromParent();
-                                    changed = true;
-                                }
-                            }
-                        }
-                    }
+class DivToShiftPass : public llvm::PassInfoMixin<DivToShiftPass> {
+public:
+  llvm::PreservedAnalyses run(llvm::Function& F,
+                              llvm::FunctionAnalysisManager& FAM) {
+    bool changed = false;
+    for (auto& BB : F) {
+      for (auto& I : llvm::make_early_inc_range(BB)) {
+        if (auto *SDiv = llvm::dyn_cast<llvm::BinaryOperator>(&I)) {
+          if (SDiv->getOpcode() == llvm::Instruction::SDiv) {
+            if (auto *ConstInt =
+                    llvm::dyn_cast<llvm::ConstantInt>(SDiv->getOperand(1))) {
+              int64_t divisor = ConstInt->getSExtValue();
+              llvm::IRBuilder<> Builder(SDiv);
+              if (divisor == 1 || divisor == -1) {
+                llvm::Value *NewVal = Builder.CreateAdd(
+                    SDiv->getOperand(0),
+                    llvm::ConstantInt::get(SDiv->getType(), 0), "add_zero");
+                if (divisor == -1) {
+                  NewVal = Builder.CreateNeg(NewVal, "neg_tmp");
                 }
+                SDiv->replaceAllUsesWith(NewVal);
+                SDiv->eraseFromParent();
+                changed = true;
+                continue;
+              } 
+              if (divisor != 0 && (abs(divisor) & (abs(divisor) - 1)) == 0) {
+                int shiftAmount = llvm::Log2_64(abs(divisor));
+                llvm::Value *Shifted = Builder.CreateAShr(
+                    SDiv->getOperand(0), shiftAmount, "sh_tmp");
+                if (divisor < 0) {
+                  Shifted = Builder.CreateNeg(Shifted, "neg_tmp");
+                }
+                SDiv->replaceAllUsesWith(Shifted);
+                SDiv->eraseFromParent();
+                changed = true;
+              }
             }
-            return changed ? llvm::PreservedAnalyses::none() : llvm::PreservedAnalyses::all();
+          }
         }
-    };
+      }
+    }
+    return changed ? llvm::PreservedAnalyses::none()
+                   : llvm::PreservedAnalyses::all();
+  }
+};
 
 } // namespace
 
-extern "C" llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK llvmGetPassPluginInfo() {
-    return { LLVM_PLUGIN_API_VERSION, "DivToShiftPass", "v0.4",
-              [](llvm::PassBuilder& PB) {
-                  PB.registerPipelineParsingCallback(
-                      [](llvm::StringRef Name, llvm::FunctionPassManager& FPM, llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
-                          if (Name == "div-to-shift") {
-                              FPM.addPass(DivToShiftPass());
-                              return true;
-                          }
-                          return false;
-                      });
-              } };
+extern "C" llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
+llvmGetPassPluginInfo() {
+  return { LLVM_PLUGIN_API_VERSION, "DivToShiftPass", "v0.4",
+           [](llvm::PassBuilder& PB) {
+             PB.registerPipelineParsingCallback(
+                 [](llvm::StringRef Name, llvm::FunctionPassManager& FPM,
+                    llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
+                   if (Name == "div-to-shift") {
+                     FPM.addPass(DivToShiftPass());
+                     return true;
+                   }
+                   return false;
+                 });
+           }};
 }
-

--- a/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
+++ b/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
@@ -17,20 +17,17 @@ public:
     for (auto &BB : F) {
       for (auto &I : llvm::make_early_inc_range(BB)) {
         if (auto *Div = llvm::dyn_cast<llvm::BinaryOperator>(&I)) {
-          if (Div->getOpcode() == llvm::Instruction::SDiv) {
-            if (auto *ConstInt =
-                    llvm::dyn_cast<llvm::ConstantInt>(Div->getOperand(1))) {
-              int64_t divisor = ConstInt->getSExtValue();
+          bool isSigned = Div->getOpcode() == llvm::Instruction::SDiv;
+          bool isUnsigned = Div->getOpcode() == llvm::Instruction::UDiv;
+          if (isSigned || isUnsigned) {
+            if (auto *ConstInt = llvm::dyn_cast<llvm::ConstantInt>(Div->getOperand(1))) {
+              int64_t divisor = isSigned ? ConstInt->getSExtValue() : ConstInt->getZExtValue();
               llvm::IRBuilder<> Builder(Div);
-              if (divisor == 1 || divisor == -1) {
-                llvm::Value *NewVal;
-                if (divisor == 1) {
-                  NewVal = Builder.CreateAdd(
-                      Div->getOperand(0),
-                      llvm::ConstantInt::get(Div->getType(), 0), "add_zero");
-                } else {
-                  NewVal = Builder.CreateNeg(Div->getOperand(0), "neg_tmp");
-                }
+              llvm::Value *Dividend = Div->getOperand(0);                                
+              if (divisor == 1 || (isSigned && divisor == -1)) {
+                llvm::Value *NewVal = (divisor == 1) ?
+                Builder.CreateAdd(Dividend, llvm::ConstantInt::get(Div->getType(), 0), "add_zero") :
+                Builder.CreateNeg(Dividend, "neg_tmp");
                 Div->replaceAllUsesWith(NewVal);
                 Div->eraseFromParent();
                 changed = true;
@@ -38,35 +35,12 @@ public:
               }
               if (divisor != 0 && (abs(divisor) & (abs(divisor) - 1)) == 0) {
                 int shiftAmount = llvm::Log2_64(abs(divisor));
-                llvm::Value *Shifted = Builder.CreateAShr(
-                    Div->getOperand(0), shiftAmount, "sh_tmp");
-                if (divisor < 0) {
-                  Shifted = Builder.CreateNeg(Shifted, "neg_tmp");
+                llvm::Value *Shifted = isSigned ?
+                Builder.CreateAShr(Dividend, shiftAmount, "sh_tmp") :
+                Builder.CreateLShr(Dividend, shiftAmount, "lsh_tmp");
+                if (isSigned && divisor < 0) {
+                Shifted = Builder.CreateNeg(Shifted, "neg_tmp");
                 }
-                Div->replaceAllUsesWith(Shifted);
-                Div->eraseFromParent();
-                changed = true;
-              }
-            }
-          }
-          if (Div->getOpcode() == llvm::Instruction::UDiv) {
-            if (auto *ConstInt =
-                    llvm::dyn_cast<llvm::ConstantInt>(Div->getOperand(1))) {
-              uint64_t divisor = ConstInt->getZExtValue();
-              llvm::IRBuilder<> Builder(Div);
-              if (divisor == 1) {
-                llvm::Value *NewVal = Builder.CreateAdd(
-                    Div->getOperand(0),
-                    llvm::ConstantInt::get(Div->getType(), 0), "add_zero");
-                Div->replaceAllUsesWith(NewVal);
-                Div->eraseFromParent();
-                changed = true;
-                continue;
-              }
-              if (divisor != 0 && (divisor & (divisor - 1)) == 0) {
-                int shiftAmount = llvm::Log2_64(divisor);
-                llvm::Value *Shifted = Builder.CreateLShr(
-                    Div->getOperand(0), shiftAmount, "lsh_tmp");
                 Div->replaceAllUsesWith(Shifted);
                 Div->eraseFromParent();
                 changed = true;
@@ -85,16 +59,16 @@ public:
 
 extern "C" llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
 llvmGetPassPluginInfo() {
-  return {LLVM_PLUGIN_API_VERSION, "DivToShiftPass", "v1.0",
-          [](llvm::PassBuilder &PB) {
-            PB.registerPipelineParsingCallback(
-                [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
-                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
-                  if (Name == "div-to-shift") {
-                    FPM.addPass(DivToShiftPass());
-                    return true;
-                  }
-                  return false;
-                });
-          }};
+    return {LLVM_PLUGIN_API_VERSION, "DivToShiftPass", "v1.0",
+            [](llvm::PassBuilder &PB) {
+              PB.registerPipelineParsingCallback(
+                  [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
+                     llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
+                    if (Name == "div-to-shift") {
+                      FPM.addPass(DivToShiftPass());
+                      return true;
+                    }
+                    return false;
+                  });
+            }};
 }

--- a/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
+++ b/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
@@ -16,33 +16,58 @@ public:
     bool changed = false;
     for (auto &BB : F) {
       for (auto &I : llvm::make_early_inc_range(BB)) {
-        if (auto *SDiv = llvm::dyn_cast<llvm::BinaryOperator>(&I)) {
-          if (SDiv->getOpcode() == llvm::Instruction::SDiv) {
+        if (auto *Div = llvm::dyn_cast<llvm::BinaryOperator>(&I)) {
+          if (Div->getOpcode() == llvm::Instruction::SDiv) {
             if (auto *ConstInt =
-                    llvm::dyn_cast<llvm::ConstantInt>(SDiv->getOperand(1))) {
+                    llvm::dyn_cast<llvm::ConstantInt>(Div->getOperand(1))) {
               int64_t divisor = ConstInt->getSExtValue();
-              llvm::IRBuilder<> Builder(SDiv);
+              llvm::IRBuilder<> Builder(Div);  
               if (divisor == 1 || divisor == -1) {
-                llvm::Value *NewVal = Builder.CreateAdd(
-                    SDiv->getOperand(0),
-                    llvm::ConstantInt::get(SDiv->getType(), 0), "add_zero");
-                if (divisor == -1) {
-                  NewVal = Builder.CreateNeg(NewVal, "neg_tmp");
+                llvm::Value *NewVal;
+                if (divisor == 1) { 
+                  NewVal = Builder.CreateAdd(
+                  Div->getOperand(0),
+                  llvm::ConstantInt::get(Div->getType(), 0), "add_zero");
+                } else {
+                  NewVal = Builder.CreateNeg(Div->getOperand(0), "neg_tmp");
                 }
-                SDiv->replaceAllUsesWith(NewVal);
-                SDiv->eraseFromParent();
+                Div->replaceAllUsesWith(NewVal);
+                Div->eraseFromParent();
                 changed = true;
                 continue;
-              }
+              }   
               if (divisor != 0 && (abs(divisor) & (abs(divisor) - 1)) == 0) {
                 int shiftAmount = llvm::Log2_64(abs(divisor));
                 llvm::Value *Shifted = Builder.CreateAShr(
-                    SDiv->getOperand(0), shiftAmount, "sh_tmp");
+                Div->getOperand(0), shiftAmount, "sh_tmp");
                 if (divisor < 0) {
                   Shifted = Builder.CreateNeg(Shifted, "neg_tmp");
                 }
-                SDiv->replaceAllUsesWith(Shifted);
-                SDiv->eraseFromParent();
+                Div->replaceAllUsesWith(Shifted);
+                Div->eraseFromParent();
+                changed = true;
+              }
+            }
+          }                    
+          if (Div->getOpcode() == llvm::Instruction::UDiv) {
+            if (auto *ConstInt = llvm::dyn_cast<llvm::ConstantInt>(Div->getOperand(1))) {
+              uint64_t divisor = ConstInt->getZExtValue();
+              llvm::IRBuilder<> Builder(Div);                               
+              if (divisor == 1) {
+                llvm::Value* NewVal = Builder.CreateAdd(
+                Div->getOperand(0),
+                llvm::ConstantInt::get(Div->getType(), 0), "add_zero");
+                Div->replaceAllUsesWith(NewVal);
+                Div->eraseFromParent();
+                changed = true;
+                continue;
+              }
+              if (divisor != 0 && (divisor & (divisor - 1)) == 0) {
+                int shiftAmount = llvm::Log2_64(divisor);
+                llvm::Value* Shifted = Builder.CreateLShr(
+                Div->getOperand(0), shiftAmount, "lsh_tmp");
+                Div->replaceAllUsesWith(Shifted);
+                Div->eraseFromParent();
                 changed = true;
               }
             }
@@ -59,16 +84,16 @@ public:
 
 extern "C" llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
 llvmGetPassPluginInfo() {
-  return {LLVM_PLUGIN_API_VERSION, "DivToShiftPass", "v0.4",
-          [](llvm::PassBuilder &PB) {
-            PB.registerPipelineParsingCallback(
-                [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
-                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
-                  if (Name == "div-to-shift") {
-                    FPM.addPass(DivToShiftPass());
-                    return true;
-                  }
-                  return false;
-                });
-          }};
+  return { LLVM_PLUGIN_API_VERSION, "DivToShiftPass", "v1.0",
+           [](llvm::PassBuilder& PB) {
+             PB.registerPipelineParsingCallback(
+                 [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
+                    llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
+                   if (Name == "div-to-shift") {
+                     FPM.addPass(DivToShiftPass());
+                     return true;
+                   }
+                   return false;
+                 });
+           }};
 }

--- a/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
+++ b/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
@@ -28,10 +28,7 @@ public:
               llvm::Value *Dividend = Div->getOperand(0);
               if (divisor == 1 || (isSigned && divisor == -1)) {
                 llvm::Value *NewVal =
-                    (divisor == 1) ? Builder.CreateAdd(Dividend,
-                                                       llvm::ConstantInt::get(
-                                                           Div->getType(), 0),
-                                                       "add_zero")
+                    (divisor == 1) ? Dividend
                                    : Builder.CreateNeg(Dividend, "neg_tmp");
                 Div->replaceAllUsesWith(NewVal);
                 Div->eraseFromParent();

--- a/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
+++ b/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
@@ -20,14 +20,19 @@ public:
           bool isSigned = Div->getOpcode() == llvm::Instruction::SDiv;
           bool isUnsigned = Div->getOpcode() == llvm::Instruction::UDiv;
           if (isSigned || isUnsigned) {
-            if (auto *ConstInt = llvm::dyn_cast<llvm::ConstantInt>(Div->getOperand(1))) {
-              int64_t divisor = isSigned ? ConstInt->getSExtValue() : ConstInt->getZExtValue();
+            if (auto *ConstInt =
+                    llvm::dyn_cast<llvm::ConstantInt>(Div->getOperand(1))) {
+              int64_t divisor = isSigned ? ConstInt->getSExtValue()
+                                         : ConstInt->getZExtValue();
               llvm::IRBuilder<> Builder(Div);
-              llvm::Value *Dividend = Div->getOperand(0);                                
+              llvm::Value *Dividend = Div->getOperand(0);
               if (divisor == 1 || (isSigned && divisor == -1)) {
-                llvm::Value *NewVal = (divisor == 1) ?
-                Builder.CreateAdd(Dividend, llvm::ConstantInt::get(Div->getType(), 0), "add_zero") :
-                Builder.CreateNeg(Dividend, "neg_tmp");
+                llvm::Value *NewVal =
+                    (divisor == 1) ? Builder.CreateAdd(Dividend,
+                                                       llvm::ConstantInt::get(
+                                                           Div->getType(), 0),
+                                                       "add_zero")
+                                   : Builder.CreateNeg(Dividend, "neg_tmp");
                 Div->replaceAllUsesWith(NewVal);
                 Div->eraseFromParent();
                 changed = true;
@@ -35,11 +40,12 @@ public:
               }
               if (divisor != 0 && (abs(divisor) & (abs(divisor) - 1)) == 0) {
                 int shiftAmount = llvm::Log2_64(abs(divisor));
-                llvm::Value *Shifted = isSigned ?
-                Builder.CreateAShr(Dividend, shiftAmount, "sh_tmp") :
-                Builder.CreateLShr(Dividend, shiftAmount, "lsh_tmp");
+                llvm::Value *Shifted =
+                    isSigned 
+                        ? Builder.CreateAShr(Dividend, shiftAmount, "sh_tmp") 
+                        : Builder.CreateLShr(Dividend, shiftAmount, "lsh_tmp");
                 if (isSigned && divisor < 0) {
-                Shifted = Builder.CreateNeg(Shifted, "neg_tmp");
+                  Shifted = Builder.CreateNeg(Shifted, "neg_tmp");
                 }
                 Div->replaceAllUsesWith(Shifted);
                 Div->eraseFromParent();
@@ -59,16 +65,16 @@ public:
 
 extern "C" llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
 llvmGetPassPluginInfo() {
-    return {LLVM_PLUGIN_API_VERSION, "DivToShiftPass", "v1.0",
-            [](llvm::PassBuilder &PB) {
-              PB.registerPipelineParsingCallback(
-                  [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
-                     llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
-                    if (Name == "div-to-shift") {
-                      FPM.addPass(DivToShiftPass());
-                      return true;
-                    }
-                    return false;
-                  });
-            }};
+return {LLVM_PLUGIN_API_VERSION, "DivToShiftPass", "v1.0",
+        [](llvm::PassBuilder &PB) {
+          PB.registerPipelineParsingCallback(
+              [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
+                 llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
+                if (Name == "div-to-shift") {
+                  FPM.addPass(DivToShiftPass());
+                  return true;
+                }
+                return false;
+              });
+        }};
 }

--- a/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
+++ b/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
@@ -1,0 +1,68 @@
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+
+    class DivToShiftPass : public llvm::PassInfoMixin<DivToShiftPass> {
+    public:
+        llvm::PreservedAnalyses run(llvm::Function& F, llvm::FunctionAnalysisManager& FAM) {
+            bool changed = false;
+            for (auto& BB : F) {
+                for (auto& I : llvm::make_early_inc_range(BB)) {
+                    if (auto* SDiv = llvm::dyn_cast<llvm::BinaryOperator>(&I)) {
+                        if (SDiv->getOpcode() == llvm::Instruction::SDiv) {
+                            if (auto* ConstInt = llvm::dyn_cast<llvm::ConstantInt>(SDiv->getOperand(1))) {
+                                int64_t divisor = ConstInt->getSExtValue();
+                                llvm::IRBuilder<> Builder(SDiv);
+                                if (divisor == 1 || divisor == -1) {
+                                    llvm::Value* NewVal = Builder.CreateAdd(SDiv->getOperand(0),
+                                        llvm::ConstantInt::get(SDiv->getType(), 0), "add_zero");
+                                    if (divisor == -1) {
+                                        NewVal = Builder.CreateNeg(NewVal, "neg_tmp");
+                                    }
+                                    SDiv->replaceAllUsesWith(NewVal);
+                                    SDiv->eraseFromParent();
+                                    changed = true;
+                                    continue;
+                                }
+                                if (divisor != 0 && (abs(divisor) & (abs(divisor) - 1)) == 0) {
+                                    int shiftAmount = llvm::Log2_64(abs(divisor));
+                                    llvm::Value* Shifted = Builder.CreateAShr(SDiv->getOperand(0), shiftAmount, "sh_tmp");
+                                    if (divisor < 0) {
+                                        Shifted = Builder.CreateNeg(Shifted, "neg_tmp");
+                                    }
+                                    SDiv->replaceAllUsesWith(Shifted);
+                                    SDiv->eraseFromParent();
+                                    changed = true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            return changed ? llvm::PreservedAnalyses::none() : llvm::PreservedAnalyses::all();
+        }
+    };
+
+} // namespace
+
+extern "C" llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK llvmGetPassPluginInfo() {
+    return { LLVM_PLUGIN_API_VERSION, "DivToShiftPass", "v0.4",
+              [](llvm::PassBuilder& PB) {
+                  PB.registerPipelineParsingCallback(
+                      [](llvm::StringRef Name, llvm::FunctionPassManager& FPM, llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
+                          if (Name == "div-to-shift") {
+                              FPM.addPass(DivToShiftPass());
+                              return true;
+                          }
+                          return false;
+                      });
+              } };
+}
+

--- a/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
+++ b/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
@@ -41,8 +41,8 @@ public:
               if (divisor != 0 && (abs(divisor) & (abs(divisor) - 1)) == 0) {
                 int shiftAmount = llvm::Log2_64(abs(divisor));
                 llvm::Value *Shifted =
-                    isSigned 
-                        ? Builder.CreateAShr(Dividend, shiftAmount, "sh_tmp") 
+                    isSigned
+                        ? Builder.CreateAShr(Dividend, shiftAmount, "sh_tmp")
                         : Builder.CreateLShr(Dividend, shiftAmount, "lsh_tmp");
                 if (isSigned && divisor < 0) {
                   Shifted = Builder.CreateNeg(Shifted, "neg_tmp");
@@ -65,16 +65,16 @@ public:
 
 extern "C" llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
 llvmGetPassPluginInfo() {
-return {LLVM_PLUGIN_API_VERSION, "DivToShiftPass", "v1.0",
-        [](llvm::PassBuilder &PB) {
-          PB.registerPipelineParsingCallback(
-              [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
-                 llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
-                if (Name == "div-to-shift") {
-                  FPM.addPass(DivToShiftPass());
-                  return true;
-                }
-                return false;
-              });
-        }};
+  return {LLVM_PLUGIN_API_VERSION, "DivToShiftPass", "v1.0",
+          [](llvm::PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
+                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
+                  if (Name == "div-to-shift") {
+                    FPM.addPass(DivToShiftPass());
+                    return true;
+                  }
+                  return false;
+                });
+          }};
 }

--- a/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
+++ b/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
@@ -21,13 +21,13 @@ public:
             if (auto *ConstInt =
                     llvm::dyn_cast<llvm::ConstantInt>(Div->getOperand(1))) {
               int64_t divisor = ConstInt->getSExtValue();
-              llvm::IRBuilder<> Builder(Div);  
+              llvm::IRBuilder<> Builder(Div);
               if (divisor == 1 || divisor == -1) {
                 llvm::Value *NewVal;
-                if (divisor == 1) { 
+                if (divisor == 1) {
                   NewVal = Builder.CreateAdd(
-                  Div->getOperand(0),
-                  llvm::ConstantInt::get(Div->getType(), 0), "add_zero");
+                      Div->getOperand(0),
+                      llvm::ConstantInt::get(Div->getType(), 0), "add_zero");
                 } else {
                   NewVal = Builder.CreateNeg(Div->getOperand(0), "neg_tmp");
                 }
@@ -35,11 +35,11 @@ public:
                 Div->eraseFromParent();
                 changed = true;
                 continue;
-              }   
+              }
               if (divisor != 0 && (abs(divisor) & (abs(divisor) - 1)) == 0) {
                 int shiftAmount = llvm::Log2_64(abs(divisor));
                 llvm::Value *Shifted = Builder.CreateAShr(
-                Div->getOperand(0), shiftAmount, "sh_tmp");
+                    Div->getOperand(0), shiftAmount, "sh_tmp");
                 if (divisor < 0) {
                   Shifted = Builder.CreateNeg(Shifted, "neg_tmp");
                 }
@@ -48,15 +48,16 @@ public:
                 changed = true;
               }
             }
-          }                    
+          }
           if (Div->getOpcode() == llvm::Instruction::UDiv) {
-            if (auto *ConstInt = llvm::dyn_cast<llvm::ConstantInt>(Div->getOperand(1))) {
+            if (auto *ConstInt =
+                    llvm::dyn_cast<llvm::ConstantInt>(Div->getOperand(1))) {
               uint64_t divisor = ConstInt->getZExtValue();
-              llvm::IRBuilder<> Builder(Div);                               
+              llvm::IRBuilder<> Builder(Div);
               if (divisor == 1) {
-                llvm::Value* NewVal = Builder.CreateAdd(
-                Div->getOperand(0),
-                llvm::ConstantInt::get(Div->getType(), 0), "add_zero");
+                llvm::Value *NewVal = Builder.CreateAdd(
+                    Div->getOperand(0),
+                    llvm::ConstantInt::get(Div->getType(), 0), "add_zero");
                 Div->replaceAllUsesWith(NewVal);
                 Div->eraseFromParent();
                 changed = true;
@@ -64,8 +65,8 @@ public:
               }
               if (divisor != 0 && (divisor & (divisor - 1)) == 0) {
                 int shiftAmount = llvm::Log2_64(divisor);
-                llvm::Value* Shifted = Builder.CreateLShr(
-                Div->getOperand(0), shiftAmount, "lsh_tmp");
+                llvm::Value *Shifted = Builder.CreateLShr(
+                    Div->getOperand(0), shiftAmount, "lsh_tmp");
                 Div->replaceAllUsesWith(Shifted);
                 Div->eraseFromParent();
                 changed = true;
@@ -84,16 +85,16 @@ public:
 
 extern "C" llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
 llvmGetPassPluginInfo() {
-  return { LLVM_PLUGIN_API_VERSION, "DivToShiftPass", "v1.0",
-           [](llvm::PassBuilder& PB) {
-             PB.registerPipelineParsingCallback(
-                 [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
-                    llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
-                   if (Name == "div-to-shift") {
-                     FPM.addPass(DivToShiftPass());
-                     return true;
-                   }
-                   return false;
-                 });
-           }};
+  return {LLVM_PLUGIN_API_VERSION, "DivToShiftPass", "v1.0",
+          [](llvm::PassBuilder& PB) {
+            PB.registerPipelineParsingCallback(
+                [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
+                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
+                  if (Name == "div-to-shift") {
+                    FPM.addPass(DivToShiftPass());
+                    return true;
+                  }
+                  return false;
+                });
+          }};
 }

--- a/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
+++ b/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
@@ -60,9 +60,9 @@ public:
 extern "C" llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
 llvmGetPassPluginInfo() {
   return {LLVM_PLUGIN_API_VERSION, "DivToShiftPass", "v0.4",
-          [](llvm::PassBuilder& PB) {
+          [](llvm::PassBuilder &PB) {
             PB.registerPipelineParsingCallback(
-                [](llvm::StringRef Name, llvm::FunctionPassManager& FPM,
+                [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
                    llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
                   if (Name == "div-to-shift") {
                     FPM.addPass(DivToShiftPass());

--- a/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
+++ b/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
@@ -86,7 +86,7 @@ public:
 extern "C" llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
 llvmGetPassPluginInfo() {
   return {LLVM_PLUGIN_API_VERSION, "DivToShiftPass", "v1.0",
-          [](llvm::PassBuilder& PB) {
+          [](llvm::PassBuilder &PB) {
             PB.registerPipelineParsingCallback(
                 [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
                    llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {

--- a/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
+++ b/llvm/compiler-course/llvm-ir/solovev_a/solovev_a.cpp
@@ -11,11 +11,11 @@ namespace {
 
 class DivToShiftPass : public llvm::PassInfoMixin<DivToShiftPass> {
 public:
-  llvm::PreservedAnalyses run(llvm::Function& F,
-                              llvm::FunctionAnalysisManager& FAM) {
+  llvm::PreservedAnalyses run(llvm::Function &F,
+                              llvm::FunctionAnalysisManager &FAM) {
     bool changed = false;
-    for (auto& BB : F) {
-      for (auto& I : llvm::make_early_inc_range(BB)) {
+    for (auto &BB : F) {
+      for (auto &I : llvm::make_early_inc_range(BB)) {
         if (auto *SDiv = llvm::dyn_cast<llvm::BinaryOperator>(&I)) {
           if (SDiv->getOpcode() == llvm::Instruction::SDiv) {
             if (auto *ConstInt =
@@ -33,7 +33,7 @@ public:
                 SDiv->eraseFromParent();
                 changed = true;
                 continue;
-              } 
+              }
               if (divisor != 0 && (abs(divisor) & (abs(divisor) - 1)) == 0) {
                 int shiftAmount = llvm::Log2_64(abs(divisor));
                 llvm::Value *Shifted = Builder.CreateAShr(
@@ -59,16 +59,16 @@ public:
 
 extern "C" llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
 llvmGetPassPluginInfo() {
-  return { LLVM_PLUGIN_API_VERSION, "DivToShiftPass", "v0.4",
-           [](llvm::PassBuilder& PB) {
-             PB.registerPipelineParsingCallback(
-                 [](llvm::StringRef Name, llvm::FunctionPassManager& FPM,
-                    llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
-                   if (Name == "div-to-shift") {
-                     FPM.addPass(DivToShiftPass());
-                     return true;
-                   }
-                   return false;
-                 });
-           }};
+  return {LLVM_PLUGIN_API_VERSION, "DivToShiftPass", "v0.4",
+          [](llvm::PassBuilder& PB) {
+            PB.registerPipelineParsingCallback(
+                [](llvm::StringRef Name, llvm::FunctionPassManager& FPM,
+                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
+                  if (Name == "div-to-shift") {
+                    FPM.addPass(DivToShiftPass());
+                    return true;
+                  }
+                  return false;
+                });
+          }};
 }

--- a/llvm/test/compiler-course/solovev_a_test/test_llvm_ir.ll
+++ b/llvm/test/compiler-course/solovev_a_test/test_llvm_ir.ll
@@ -2,7 +2,7 @@
 
 define i32 @test1(i32 %value) {
 ; CHECK-LABEL: @test1
-; CHECK: ashr i32 %value, 3
+; CHECK-NEXT: ashr i32 %value, 3
 ; CHECK-NEXT: ashr i32 %value, 5
   %div1 = sdiv i32 %value, 8
   %div2 = sdiv i32 %value, 32
@@ -12,7 +12,7 @@ define i32 @test1(i32 %value) {
 
 define i32 @test2(i32 %value) {
 ; CHECK-LABEL: @test2
-; CHECK: ashr i32 %value, 2
+; CHECK-NEXT: ashr i32 %value, 2
 ; CHECK-NEXT: ashr i32 %value, 4
 ; CHECK-NEXT: sub i32 0, 
   %div1 = sdiv i32 %value, 4
@@ -24,17 +24,26 @@ define i32 @test2(i32 %value) {
 
 define i32 @test3(i32 %value) {
 ; CHECK-LABEL: @test3
-; CHECK: add i32 %value, 0
+; CHECK-NEXT: add i32 %value, 0
   %div = sdiv i32 %value, 1
   ret i32 %div
 }
 
 define i32 @test4(i32 %value) {
 ; CHECK-LABEL: @test4
-; CHECK: ashr i32 %value, 6
+; CHECK-NEXT: ashr i32 %value, 6
 ; CHECK-NEXT: ashr i32 %value, 1
   %div1 = sdiv i32 %value, 64
   %div2 = sdiv i32 %value, 2
   %result = sub i32 %div2, %div1
+  ret i32 %result
+}
+define i32 @test_udiv1(i32 %value) {
+; CHECK-LABEL: @test_udiv1
+; CHECK-NEXT: lshr i32 %value, 3
+; CHECK-NEXT: lshr i32 %value, 5
+  %div1 = udiv i32 %value, 8
+  %div2 = udiv i32 %value, 32
+  %result = add i32 %div1, %div2
   ret i32 %result
 }

--- a/llvm/test/compiler-course/solovev_a_test/test_llvm_ir.ll
+++ b/llvm/test/compiler-course/solovev_a_test/test_llvm_ir.ll
@@ -24,7 +24,7 @@ define i32 @test2(i32 %value) {
 
 define i32 @test3(i32 %value) {
 ; CHECK-LABEL: @test3
-; CHECK-NEXT: add i32 %value, 0
+; CHECK-NEXT: ret i32 %value
   %div = sdiv i32 %value, 1
   ret i32 %div
 }

--- a/llvm/test/compiler-course/solovev_a_test/test_llvm_ir.ll
+++ b/llvm/test/compiler-course/solovev_a_test/test_llvm_ir.ll
@@ -1,0 +1,40 @@
+; RUN: opt -load-pass-plugin %llvmshlibdir/Lab_2_llvm_ir_Solovev_a_FIIT1_LLVM_IR%pluginext -passes=div-to-shift -S %s | FileCheck %s
+
+define i32 @test1(i32 %value) {
+; CHECK-LABEL: @test1
+; CHECK: ashr i32 %value, 3
+; CHECK-NEXT: ashr i32 %value, 5
+  %div1 = sdiv i32 %value, 8
+  %div2 = sdiv i32 %value, 32
+  %result = add i32 %div1, %div2
+  ret i32 %result
+}
+
+define i32 @test2(i32 %value) {
+; CHECK-LABEL: @test2
+; CHECK: ashr i32 %value, 2
+; CHECK-NEXT: ashr i32 %value, 4
+; CHECK-NEXT: sub i32 0, 
+  %div1 = sdiv i32 %value, 4
+  %div2 = sdiv i32 %value, -16 
+  %neg_div2 = sub i32 0, %div2
+  %result = sub i32 %div1, %neg_div2
+  ret i32 %result
+}
+
+define i32 @test3(i32 %value) {
+; CHECK-LABEL: @test3
+; CHECK: add i32 %value, 0
+  %div = sdiv i32 %value, 1
+  ret i32 %div
+}
+
+define i32 @test4(i32 %value) {
+; CHECK-LABEL: @test4
+; CHECK: ashr i32 %value, 6
+; CHECK-NEXT: ashr i32 %value, 1
+  %div1 = sdiv i32 %value, 64
+  %div2 = sdiv i32 %value, 2
+  %result = sub i32 %div2, %div1
+  ret i32 %result
+}


### PR DESCRIPTION
Этот LLVM-пасс оптимизирует операции целочисленного деления, заменяя деление на степень двойки на эквивалентную операцию побитового сдвига. Пасс ищет инструкции деления (SDiv) в функции и проверяет, является ли делитель степенью двойки (положительной или отрицательной). В случае, если делитель равен 1 или -1, происходит замена на простую операцию сложения с нулём или её отрицание для -1. Если делитель — степень двойки, то деление заменяется на побитовый сдвиг вправо (AShr) на количество бит, равное логарифму по основанию 2 от абсолютного значения делителя.