### PR TITLE
Кудряшова Ирина. Лабораторная работа 2: LLVM IR. Вариант 3.

### DIFF
--- a/llvm/compiler-course/llvm-ir/kudryashova_i_add_replace/CMakeLists.txt
+++ b/llvm/compiler-course/llvm-ir/kudryashova_i_add_replace/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(Title "AddReplacePass")
+set(Student "Kudryashova_Irina")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_LLVM_IR")
+
+if (NOT WIN32 AND NOT CYGWIN)
+    file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+    add_llvm_pass_plugin(${TARGET_NAME} ${SOURCES}
+        DEPENDS
+        intrinsics_gen
+        BUILDTREE_ONLY
+    )
+    set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)
+endif()

--- a/llvm/compiler-course/llvm-ir/kudryashova_i_add_replace/addReplacePass.cpp
+++ b/llvm/compiler-course/llvm-ir/kudryashova_i_add_replace/addReplacePass.cpp
@@ -25,7 +25,7 @@ struct AddReplacePass : llvm::PassInfoMixin<AddReplacePass> {
         continue;
       }
       for (llvm::BasicBlock &BB : F) {
-        std::vector<llvm::BinaryOperator *> ToReplace;
+        llvm::SmallVector<llvm::BinaryOperator *> ToReplace;
 
         for (llvm::Instruction &I : BB) {
           if (auto *BinOp = llvm::dyn_cast<llvm::BinaryOperator>(&I)) {

--- a/llvm/compiler-course/llvm-ir/kudryashova_i_add_replace/addReplacePass.cpp
+++ b/llvm/compiler-course/llvm-ir/kudryashova_i_add_replace/addReplacePass.cpp
@@ -1,0 +1,75 @@
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+struct AddReplacePass : llvm::PassInfoMixin<AddReplacePass> {
+  llvm::PreservedAnalyses run(llvm::Module &Mod,
+                              llvm::ModuleAnalysisManager &) {
+    bool Changed = false;
+
+    llvm::Function *AddFunc = Mod.getFunction("add");
+    if (!AddFunc || AddFunc->arg_size() != 2) {
+      return llvm::PreservedAnalyses::all();
+    }
+
+    llvm::Type *Arg0Type = AddFunc->getArg(0)->getType();
+    llvm::Type *Arg1Type = AddFunc->getArg(1)->getType();
+
+    for (llvm::Function &F : Mod) {
+      if (&F == AddFunc) {
+        continue;
+      }
+      for (llvm::BasicBlock &BB : F) {
+        std::vector<llvm::BinaryOperator *> ToReplace;
+
+        for (llvm::Instruction &I : BB) {
+          if (auto *BinOp = llvm::dyn_cast<llvm::BinaryOperator>(&I)) {
+            if (BinOp->getOpcode() == llvm::Instruction::Add) {
+              llvm::Value *Op0 = BinOp->getOperand(0);
+              llvm::Value *Op1 = BinOp->getOperand(1);
+              if (Op0->getType() == Arg0Type && Op1->getType() == Arg1Type) {
+                ToReplace.push_back(BinOp);
+              }
+            }
+          }
+        }
+
+        for (auto *BinOp : ToReplace) {
+          llvm::IRBuilder<> Builder(BinOp);
+          llvm::Value *Args[] = {BinOp->getOperand(0), BinOp->getOperand(1)};
+          llvm::CallInst *Call = Builder.CreateCall(AddFunc, Args);
+          BinOp->replaceAllUsesWith(Call);
+          BinOp->eraseFromParent();
+          Changed = true;
+        }
+      }
+    }
+
+    return Changed ? llvm::PreservedAnalyses::none()
+                   : llvm::PreservedAnalyses::all();
+  }
+
+  static bool isRequired() { return true; }
+};
+} // namespace
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "AddReplacePass", "0.1",
+          [](llvm::PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](llvm::StringRef Name, llvm::ModulePassManager &MPM,
+                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) -> bool {
+                  if (Name == "AddReplacePass") {
+                    MPM.addPass(AddReplacePass{});
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}

--- a/llvm/test/compiler-course/kudryashova_i_add_replace/litTestKudryashova.ll
+++ b/llvm/test/compiler-course/kudryashova_i_add_replace/litTestKudryashova.ll
@@ -21,3 +21,13 @@ define i64 @bar(i64 %x, i64 %y) {
   %sum = add i64 %x, %y
   ret i64 %sum
 }
+
+; RUN: opt -load-pass-plugin %llvmshlibdir/AddReplacePass_Kudryashova_Irina_FIIT3_LLVM_IR%pluginext \
+; RUN: -passes="AddReplacePass" -S %s | FileCheck %s
+
+; CHECK-LABEL: @far
+; CHECK: add i64 %x, %y
+define i64 @far(i64 %x, i64 %y) {
+  %sum = add i64 %x, %y
+  ret i64 %sum
+}

--- a/llvm/test/compiler-course/kudryashova_i_add_replace/litTestKudryashova.ll
+++ b/llvm/test/compiler-course/kudryashova_i_add_replace/litTestKudryashova.ll
@@ -1,0 +1,23 @@
+; RUN: opt -load-pass-plugin %llvmshlibdir/AddReplacePass_Kudryashova_Irina_FIIT3_LLVM_IR%pluginext \
+; RUN: -passes="AddReplacePass" -S %s | FileCheck %s
+
+; CHECK-LABEL: @add
+; CHECK: add i32 %a, %b
+define i32 @add(i32 %a, i32 %b) {
+  %result = add i32 %a, %b
+  ret i32 %result
+}
+
+; CHECK-LABEL: @foo
+; CHECK: call i32 @add(i32 %x, i32 %y)
+define i32 @foo(i32 %x, i32 %y) {
+  %sum = add i32 %x, %y
+  ret i32 %sum
+}
+
+; CHECK-LABEL: @bar
+; CHECK: add i64 %x, %y
+define i64 @bar(i64 %x, i64 %y) {
+  %sum = add i64 %x, %y
+  ret i64 %sum
+}

--- a/llvm/test/compiler-course/kudryashova_i_add_replace/litTestKudryashova.ll
+++ b/llvm/test/compiler-course/kudryashova_i_add_replace/litTestKudryashova.ll
@@ -1,6 +1,8 @@
-; RUN: opt -load-pass-plugin %llvmshlibdir/AddReplacePass_Kudryashova_Irina_FIIT3_LLVM_IR%pluginext \
-; RUN: -passes="AddReplacePass" -S %s | FileCheck %s
+; RUN: split-file %s %t
+; RUN: opt -load-pass-plugin %llvmshlibdir/AddReplacePass_Kudryashova_Irina_FIIT3_LLVM_IR%pluginext -passes="AddReplacePass" -S %t/a.ll | FileCheck %t/a.ll
+; RUN: opt -load-pass-plugin %llvmshlibdir/AddReplacePass_Kudryashova_Irina_FIIT3_LLVM_IR%pluginext -passes="AddReplacePass" -S %t/b.ll | FileCheck %t/b.ll
 
+;--- a.ll
 ; CHECK-LABEL: @add
 ; CHECK: add i32 %a, %b
 define i32 @add(i32 %a, i32 %b) {
@@ -22,9 +24,7 @@ define i64 @bar(i64 %x, i64 %y) {
   ret i64 %sum
 }
 
-; RUN: opt -load-pass-plugin %llvmshlibdir/AddReplacePass_Kudryashova_Irina_FIIT3_LLVM_IR%pluginext \
-; RUN: -passes="AddReplacePass" -S %s | FileCheck %s
-
+;--- b.ll
 ; CHECK-LABEL: @far
 ; CHECK: add i64 %x, %y
 define i64 @far(i64 %x, i64 %y) {


### PR DESCRIPTION
Совершаем проход по всем функциям в модуле и проверяем, не является ли инструкция самой инструкцией add, на которую мы и планируем заменятm. Для каждой функции проходим по базовым блокам и инструкциям. Далее для каждой инструкции типа add получим её аргументы и их типы. Затем найдём функцию "add" в модуле и проверим, что у функции "add" ровно два аргумента, типы которых совпадают с операндами. Если всё верно, заменить add на call @add.