### PR TITLE
Миронов Арсений. 3822Б1ФИ1. Лабораторная работа 2. Вариант 3.

### DIFF
--- a/llvm/compiler-course/llvm-ir/mironov_a_lab2/Add_Pass.cpp
+++ b/llvm/compiler-course/llvm-ir/mironov_a_lab2/Add_Pass.cpp
@@ -1,10 +1,10 @@
 #include "llvm/IR/Function.h"
-#include "llvm/IR/Instructions.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/IR/Module.h"
 
 using namespace std;
 using namespace llvm;
@@ -15,16 +15,16 @@ struct Add_Pass : llvm::PassInfoMixin<Add_Pass> {
                               llvm::ModuleAnalysisManager &) {
 
     pair<Type *, Type *> add_types;
-    Function * add_func_ptr = nullptr;
+    Function *add_func_ptr = nullptr;
     bool none = 0;
 
     // store all overloads
     for (auto &func : module) {
 
-      if (func.getName() != "add") { 
+      if (func.getName() != "add") {
         continue;
       }
-      
+
       FunctionType *funcType = func.getFunctionType();
       if (funcType->getNumParams() == 2) {
         add_types = {funcType->getParamType(0), funcType->getParamType(1)};
@@ -32,7 +32,7 @@ struct Add_Pass : llvm::PassInfoMixin<Add_Pass> {
         break;
       }
     }
-    if (add_func_ptr == nullptr){
+    if (add_func_ptr == nullptr) {
       return PreservedAnalyses::all();
     }
 
@@ -42,28 +42,30 @@ struct Add_Pass : llvm::PassInfoMixin<Add_Pass> {
       if (&func == add_func_ptr) {
         continue;
       }
-  
+
       for (auto &op : func) {
-        for (auto it = op.begin(); it != op.end(); ) {
+        for (auto it = op.begin(); it != op.end();) {
           auto &inst = *it++;
-          if (isa<BinaryOperator>(inst) && inst.getOpcode() == Instruction::Add) {
+          if (isa<BinaryOperator>(inst) &&
+              inst.getOpcode() == Instruction::Add) {
             Type *left_type = inst.getOperand(0)->getType();
             Type *right_type = inst.getOperand(1)->getType();
             pair<Type *, Type *> par = {left_type, right_type};
 
             if (par == add_types) {
               IRBuilder<> builder(&inst);
-              Value *call = builder.CreateCall(add_func_ptr, {inst.getOperand(0), inst.getOperand(1)});
+              Value *call = builder.CreateCall(
+                  add_func_ptr, {inst.getOperand(0), inst.getOperand(1)});
               inst.replaceAllUsesWith(call);
               inst.eraseFromParent();
-              none=true;
+              none = true;
             }
           }
         }
       }
     }
 
-    if (none){
+    if (none) {
       return PreservedAnalyses::none();
     }
     return PreservedAnalyses::all();

--- a/llvm/compiler-course/llvm-ir/mironov_a_lab2/Add_Pass.cpp
+++ b/llvm/compiler-course/llvm-ir/mironov_a_lab2/Add_Pass.cpp
@@ -6,16 +6,13 @@
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Support/raw_ostream.h"
 
-using namespace std;
-using namespace llvm;
-
 namespace {
 struct Add_Pass : llvm::PassInfoMixin<Add_Pass> {
   llvm::PreservedAnalyses run(llvm::Module &module,
                               llvm::ModuleAnalysisManager &) {
 
-    pair<Type *, Type *> add_types;
-    Function *add_func_ptr = nullptr;
+    std::pair<llvm::Type *, llvm::Type *> add_types;
+    llvm::Function *add_func_ptr = nullptr;
     bool none = 0;
 
     // store all overloads
@@ -25,7 +22,7 @@ struct Add_Pass : llvm::PassInfoMixin<Add_Pass> {
         continue;
       }
 
-      FunctionType *funcType = func.getFunctionType();
+      llvm::FunctionType *funcType = func.getFunctionType();
       if (funcType->getNumParams() == 2) {
         add_types = {funcType->getParamType(0), funcType->getParamType(1)};
         add_func_ptr = &func;
@@ -33,7 +30,7 @@ struct Add_Pass : llvm::PassInfoMixin<Add_Pass> {
       }
     }
     if (add_func_ptr == nullptr) {
-      return PreservedAnalyses::all();
+      return llvm::PreservedAnalyses::all();
     }
 
     // check all add operators
@@ -46,15 +43,15 @@ struct Add_Pass : llvm::PassInfoMixin<Add_Pass> {
       for (auto &op : func) {
         for (auto it = op.begin(); it != op.end();) {
           auto &inst = *it++;
-          if (isa<BinaryOperator>(inst) &&
-              inst.getOpcode() == Instruction::Add) {
-            Type *left_type = inst.getOperand(0)->getType();
-            Type *right_type = inst.getOperand(1)->getType();
-            pair<Type *, Type *> par = {left_type, right_type};
+          if (llvm::isa<llvm::BinaryOperator>(inst) &&
+              inst.getOpcode() == llvm::Instruction::Add) {
+            llvm::Type *left_type = inst.getOperand(0)->getType();
+            llvm::Type *right_type = inst.getOperand(1)->getType();
+            std::pair<llvm::Type *, llvm::Type *> par = {left_type, right_type};
 
             if (par == add_types) {
-              IRBuilder<> builder(&inst);
-              Value *call = builder.CreateCall(
+              llvm::IRBuilder<> builder(&inst);
+              llvm::Value *call = builder.CreateCall(
                   add_func_ptr, {inst.getOperand(0), inst.getOperand(1)});
               inst.replaceAllUsesWith(call);
               inst.eraseFromParent();
@@ -66,9 +63,9 @@ struct Add_Pass : llvm::PassInfoMixin<Add_Pass> {
     }
 
     if (none) {
-      return PreservedAnalyses::none();
+      return llvm::PreservedAnalyses::none();
     }
-    return PreservedAnalyses::all();
+    return llvm::PreservedAnalyses::all();
   }
 
   static bool isRequired() { return true; }

--- a/llvm/compiler-course/llvm-ir/mironov_a_lab2/Add_Pass.cpp
+++ b/llvm/compiler-course/llvm-ir/mironov_a_lab2/Add_Pass.cpp
@@ -1,0 +1,90 @@
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/IR/Module.h"
+
+using namespace std;
+using namespace llvm;
+
+namespace {
+struct Add_Pass : llvm::PassInfoMixin<Add_Pass> {
+  llvm::PreservedAnalyses run(llvm::Module &module,
+                              llvm::ModuleAnalysisManager &) {
+
+    pair<Type *, Type *> add_types;
+    Function * add_func_ptr = nullptr;
+    bool none = 0;
+
+    // store all overloads
+    for (auto &func : module) {
+
+      if (func.getName() != "add") { 
+        continue;
+      }
+      
+      FunctionType *funcType = func.getFunctionType();
+      if (funcType->getNumParams() == 2) {
+        add_types = {funcType->getParamType(0), funcType->getParamType(1)};
+        add_func_ptr = &func;
+        break;
+      }
+    }
+    if (add_func_ptr == nullptr){
+      return PreservedAnalyses::all();
+    }
+
+    // check all add operators
+    for (auto &func : module) {
+
+      if (&func == add_func_ptr) {
+        continue;
+      }
+  
+      for (auto &op : func) {
+        for (auto it = op.begin(); it != op.end(); ) {
+          auto &inst = *it++;
+          if (isa<BinaryOperator>(inst) && inst.getOpcode() == Instruction::Add) {
+            Type *left_type = inst.getOperand(0)->getType();
+            Type *right_type = inst.getOperand(1)->getType();
+            pair<Type *, Type *> par = {left_type, right_type};
+
+            if (par == add_types) {
+              IRBuilder<> builder(&inst);
+              Value *call = builder.CreateCall(add_func_ptr, {inst.getOperand(0), inst.getOperand(1)});
+              inst.replaceAllUsesWith(call);
+              inst.eraseFromParent();
+              none=true;
+            }
+          }
+        }
+      }
+    }
+
+    if (none){
+      return PreservedAnalyses::none();
+    }
+    return PreservedAnalyses::all();
+  }
+
+  static bool isRequired() { return true; }
+};
+} // namespace
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "Add_Pass", "0.1",
+          [](llvm::PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](llvm::StringRef name, llvm::ModulePassManager &FPM,
+                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) -> bool {
+                  if (name == "Add_Pass") {
+                    FPM.addPass(Add_Pass{});
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}

--- a/llvm/compiler-course/llvm-ir/mironov_a_lab2/CMakeLists.txt
+++ b/llvm/compiler-course/llvm-ir/mironov_a_lab2/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(Title "Add_Pass")
+set(Student "Mironov_Arseniy")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_LLVM_IR")
+
+if (NOT WIN32 AND NOT CYGWIN)
+    file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+    add_llvm_pass_plugin(${TARGET_NAME} ${SOURCES}
+        DEPENDS
+        intrinsics_gen
+        BUILDTREE_ONLY
+    )
+    set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)
+endif()

--- a/llvm/test/compiler-course/mironov_a_lab2/test.ll
+++ b/llvm/test/compiler-course/mironov_a_lab2/test.ll
@@ -1,0 +1,33 @@
+; RUN: opt -load-pass-plugin %llvmshlibdir/Add_Pass_Mironov_Arseniy_FIIT1_LLVM_IR%pluginext\
+; RUN: -passes=Add_Pass -S %s 2>&1 | FileCheck %s -dump-input=always
+
+
+; CHECK: define i32 @add(i32 %a, i32 %b)
+; CHECK: %result = add i32 %a, %b
+; CHECK: ret i32 %result
+
+; CHECK: define i32 @test_case1(i32 %x, i32 %y)
+; CHECK: %1 = call i32 @add(i32 %x, i32 %y)
+; CHECK: ret i32 %1
+
+; CHECK: define i32 @test_case2(i32 %x, i32 %y, i32 %z)
+; CHECK: %1 = call i32 @add(i32 %x, i32 %y)
+; CHECK: %2 = call i32 @add(i32 %1, i32 %z)
+; CHECK: ret i32 %2
+
+
+define i32 @add(i32 %a, i32 %b) {
+    %result = add i32 %a, %b
+    ret i32 %result
+}
+
+define i32 @test_case1(i32 %x, i32 %y) {
+    %sum = add i32 %x, %y
+    ret i32 %sum
+}
+
+define i32 @test_case2(i32 %x, i32 %y, i32 %z) {
+    %res1 = add i32 %x, %y
+    %res2 = add i32 %res1, %z
+    ret i32 %res2
+}

--- a/llvm/test/compiler-course/mironov_a_lab2/test.ll
+++ b/llvm/test/compiler-course/mironov_a_lab2/test.ll
@@ -2,19 +2,21 @@
 ; RUN: -passes=Add_Pass -S %s 2>&1 | FileCheck %s -dump-input=always
 
 
-; CHECK: define i32 @add(i32 %a, i32 %b)
-; CHECK: %result = add i32 %a, %b
-; CHECK: ret i32 %result
+; CHECK-LABEL: define i32 @add(i32 %a, i32 %b)
+; CHECK-NEXT: %result = add i32 %a, %b
+; CHECK-NEXT: ret i32 %result
 
-; CHECK: define i32 @test_case1(i32 %x, i32 %y)
-; CHECK: %1 = call i32 @add(i32 %x, i32 %y)
-; CHECK: ret i32 %1
+; CHECK-LABEL: define i32 @test_case1(i32 %x, i32 %y)
+; CHECK-NEXT: %1 = call i32 @add(i32 %x, i32 %y)
+; CHECK-NEXT: ret i32 %1
+; CHECK-NOT: %sum = add i32 %x, %y
 
-; CHECK: define i32 @test_case2(i32 %x, i32 %y, i32 %z)
-; CHECK: %1 = call i32 @add(i32 %x, i32 %y)
-; CHECK: %2 = call i32 @add(i32 %1, i32 %z)
-; CHECK: ret i32 %2
-
+; CHECK-LABEL: define i32 @test_case2(i32 %x, i32 %y, i32 %z)
+; CHECK-NEXT: %1 = call i32 @add(i32 %x, i32 %y)
+; CHECK-NEXT: %2 = call i32 @add(i32 %1, i32 %z)
+; CHECK-NEXT: ret i32 %2
+; CHECK-NOT: %res1 = add i32 %x, %y
+; CHECK-NOT: %res2 = add i32 %res1, %z
 
 define i32 @add(i32 %a, i32 %b) {
     %result = add i32 %a, %b

--- a/llvm/test/compiler-course/mironov_a_lab2/test1.ll
+++ b/llvm/test/compiler-course/mironov_a_lab2/test1.ll
@@ -1,0 +1,11 @@
+; RUN: opt -load-pass-plugin %llvmshlibdir/Add_Pass_Mironov_Arseniy_FIIT1_LLVM_IR%pluginext\
+; RUN: -passes=Add_Pass -S %s 2>&1 | FileCheck %s -dump-input=always
+
+; CHECK-LABEL: define i32 @test_case1(i32 %x, i32 %y)
+; CHECK-NEXT: %sum = add i32 %x, %y
+; CHECK-NEXT: ret i32 %sum
+
+define i32 @test_case1(i32 %x, i32 %y) {
+    %sum = add i32 %x, %y
+    ret i32 %sum
+}


### PR DESCRIPTION
## Добавление LLVM-пасса для замены инструкций сложения на вызовы функции add с соответствующими типами аргументов

Данный пасс для LLVM анализирует модуль и ищет инструкции сложения (add). Если в модуле присутствует функция add, принимающая два аргумента с типами, совпадающими с типами операндов инструкции сложения, то эта инструкция заменяется на вызов соответствующей функции.

Пасс выполняет следующие действия:

- Проверяет наличие функции add в модуле.
- Проходит по всем функциям, исключая саму функцию add, и ищет бинарные операторы сложения.
- При обнаружении таких операторов, если их операнды соответствуют типам аргументов функции add, они заменяются на вызов этой функции.
- Если функция add не найдена или типы не совпадают, исходная инструкция остается без изменений.
