### PR TITLE
Шкуринская Елена. Лабораторная работа 2: LLVM IR. Вариант 4.

### DIFF
--- a/llvm/compiler-course/llvm-ir/shkurinskaya_e_llvm/BinShift.cpp
+++ b/llvm/compiler-course/llvm-ir/shkurinskaya_e_llvm/BinShift.cpp
@@ -11,96 +11,108 @@ namespace {
 
 class BinShiftPass : public llvm::PassInfoMixin<BinShiftPass> {
 public:
-    llvm::PreservedAnalyses run(llvm::Function &F, llvm::FunctionAnalysisManager &) {
-        bool Modified = false;
+  llvm::PreservedAnalyses run(llvm::Function &F,
+                              llvm::FunctionAnalysisManager &) {
+    bool Modified = false;
 
-        for (auto &BB : F) {
-            llvm::SmallVector<llvm::Instruction *, 16> WorkList;
+    for (auto &BB : F) {
+      llvm::SmallVector<llvm::Instruction *, 16> WorkList;
 
-            for (auto &I : BB) {
-                if (auto *Div = llvm::dyn_cast<llvm::BinaryOperator>(&I)) {
-                    if (Div->getOpcode() == llvm::Instruction::SDiv || Div->getOpcode() == llvm::Instruction::UDiv) {
-                        WorkList.push_back(Div);
-                    }
-                }
-            }
-
-            for (auto *DivInst : WorkList) {
-                if (processDivision(DivInst)) {
-                    Modified = true;
-                }
-            }
+      for (auto &I : BB) {
+        if (auto *Div = llvm::dyn_cast<llvm::BinaryOperator>(&I)) {
+          if (Div->getOpcode() == llvm::Instruction::SDiv ||
+              Div->getOpcode() == llvm::Instruction::UDiv) {
+            WorkList.push_back(Div);
+          }
         }
+      }
 
-        return Modified ? llvm::PreservedAnalyses::none() : llvm::PreservedAnalyses::all();
+      for (auto *DivInst : WorkList) {
+        if (processDivision(DivInst)) {
+          Modified = true;
+        }
+      }
     }
+
+    return Modified ? llvm::PreservedAnalyses::none()
+                    : llvm::PreservedAnalyses::all();
+  }
 
 private:
-    bool processDivision(llvm::Instruction *Div) {
-        llvm::IRBuilder<> Builder(Div);
+  bool processDivision(llvm::Instruction *Div) {
+    llvm::IRBuilder<> Builder(Div);
 
-        auto *Dividend = Div->getOperand(0);
-        auto *DivisorOp = Div->getOperand(1);
-        
-        auto IsSigned = Div->getOpcode() == llvm::Instruction::SDiv;
+    auto *Dividend = Div->getOperand(0);
+    auto *DivisorOp = Div->getOperand(1);
 
-        if (auto *ConstInt = llvm::dyn_cast<llvm::ConstantInt>(DivisorOp)) {
-            int64_t DivisorValue = IsSigned ? ConstInt->getSExtValue() : ConstInt->getZExtValue();
+    auto IsSigned = Div->getOpcode() == llvm::Instruction::SDiv;
 
-            if (DivisorValue == 1) {
-                Div->replaceAllUsesWith(Dividend);
-                Div->eraseFromParent();
-                return true;
-            }
-            
-            if (IsSigned && DivisorValue == -1) {
-                auto *NegVal = Builder.CreateNeg(Dividend, "negation_tmp");
-                Div->replaceAllUsesWith(NegVal);
-                Div->eraseFromParent();
-                return true;
-            }
+    if (auto *ConstInt = llvm::dyn_cast<llvm::ConstantInt>(DivisorOp)) {
+      int64_t DivisorValue =
+          IsSigned ? ConstInt->getSExtValue() : ConstInt->getZExtValue();
 
-            if (isPowerOfTwo(DivisorValue)) {
-                replaceDivisionWithShift(Div, Dividend, DivisorValue, IsSigned, Builder);
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    bool isPowerOfTwo(int64_t Value) {
-        return Value > 0 && (Value & (Value - 1)) == 0;
-    }
-
-    void replaceDivisionWithShift(llvm::Instruction *Div, llvm::Value *Dividend, int64_t DivisorValue, bool IsSigned, llvm::IRBuilder<> &Builder) {
-        unsigned ShiftAmount = llvm::Log2_64(DivisorValue);
-        llvm::Value *ShiftedValue = nullptr;
-
-        if (IsSigned) {
-            ShiftedValue = Builder.CreateAShr(Dividend, llvm::ConstantInt::get(Div->getType(), ShiftAmount), "signed_shift");
-        } else {
-            ShiftedValue = Builder.CreateLShr(Dividend, llvm::ConstantInt::get(Div->getType(), ShiftAmount), "unsigned_shift");
-        }
-
-        Div->replaceAllUsesWith(ShiftedValue);
+      if (DivisorValue == 1) {
+        Div->replaceAllUsesWith(Dividend);
         Div->eraseFromParent();
+        return true;
+      }
+
+      if (IsSigned && DivisorValue == -1) {
+        auto *NegVal = Builder.CreateNeg(Dividend, "negation_tmp");
+        Div->replaceAllUsesWith(NegVal);
+        Div->eraseFromParent();
+        return true;
+      }
+
+      if (isPowerOfTwo(DivisorValue)) {
+        replaceDivisionWithShift(Div, Dividend, DivisorValue, IsSigned,
+                                 Builder);
+        return true;
+      }
     }
+
+    return false;
+  }
+
+  bool isPowerOfTwo(int64_t Value) {
+    return Value > 0 && (Value & (Value - 1)) == 0;
+  }
+
+  void replaceDivisionWithShift(llvm::Instruction *Div, llvm::Value *Dividend,
+                                int64_t DivisorValue, bool IsSigned,
+                                llvm::IRBuilder<> &Builder) {
+    unsigned ShiftAmount = llvm::Log2_64(DivisorValue);
+    llvm::Value *ShiftedValue = nullptr;
+
+    if (IsSigned) {
+      ShiftedValue = Builder.CreateAShr(
+          Dividend, llvm::ConstantInt::get(Div->getType(), ShiftAmount),
+          "signed_shift");
+    } else {
+      ShiftedValue = Builder.CreateLShr(
+          Dividend, llvm::ConstantInt::get(Div->getType(), ShiftAmount),
+          "unsigned_shift");
+    }
+
+    Div->replaceAllUsesWith(ShiftedValue);
+    Div->eraseFromParent();
+  }
 };
 
 } // namespace
 
-extern "C" llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK llvmGetPassPluginInfo() {
-    return {LLVM_PLUGIN_API_VERSION, "BinShiftPass", "1.0",
-            [](llvm::PassBuilder &PB) {
-                PB.registerPipelineParsingCallback(
-                    [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
-                       llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
-                    if (Name == "bin-shift") {
-                        FPM.addPass(BinShiftPass());
-                        return true;
-                    }
-                    return false;
+extern "C" llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
+llvmGetPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "BinShiftPass", "1.0",
+          [](llvm::PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
+                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
+                  if (Name == "bin-shift") {
+                    FPM.addPass(BinShiftPass());
+                    return true;
+                  }
+                  return false;
                 });
-            }};
+          }};
 }

--- a/llvm/compiler-course/llvm-ir/shkurinskaya_e_llvm/BinShift.cpp
+++ b/llvm/compiler-course/llvm-ir/shkurinskaya_e_llvm/BinShift.cpp
@@ -1,0 +1,106 @@
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+
+class BinShiftPass : public llvm::PassInfoMixin<BinShiftPass> {
+public:
+    llvm::PreservedAnalyses run(llvm::Function &F, llvm::FunctionAnalysisManager &) {
+        bool Modified = false;
+
+        for (auto &BB : F) {
+            llvm::SmallVector<llvm::Instruction *, 16> WorkList;
+
+            for (auto &I : BB) {
+                if (auto *Div = llvm::dyn_cast<llvm::BinaryOperator>(&I)) {
+                    if (Div->getOpcode() == llvm::Instruction::SDiv || Div->getOpcode() == llvm::Instruction::UDiv) {
+                        WorkList.push_back(Div);
+                    }
+                }
+            }
+
+            for (auto *DivInst : WorkList) {
+                if (processDivision(DivInst)) {
+                    Modified = true;
+                }
+            }
+        }
+
+        return Modified ? llvm::PreservedAnalyses::none() : llvm::PreservedAnalyses::all();
+    }
+
+private:
+    bool processDivision(llvm::Instruction *Div) {
+        llvm::IRBuilder<> Builder(Div);
+
+        auto *Dividend = Div->getOperand(0);
+        auto *DivisorOp = Div->getOperand(1);
+        
+        auto IsSigned = Div->getOpcode() == llvm::Instruction::SDiv;
+
+        if (auto *ConstInt = llvm::dyn_cast<llvm::ConstantInt>(DivisorOp)) {
+            int64_t DivisorValue = IsSigned ? ConstInt->getSExtValue() : ConstInt->getZExtValue();
+
+            if (DivisorValue == 1) {
+                Div->replaceAllUsesWith(Dividend);
+                Div->eraseFromParent();
+                return true;
+            }
+            
+            if (IsSigned && DivisorValue == -1) {
+                auto *NegVal = Builder.CreateNeg(Dividend, "negation_tmp");
+                Div->replaceAllUsesWith(NegVal);
+                Div->eraseFromParent();
+                return true;
+            }
+
+            if (isPowerOfTwo(DivisorValue)) {
+                replaceDivisionWithShift(Div, Dividend, DivisorValue, IsSigned, Builder);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    bool isPowerOfTwo(int64_t Value) {
+        return Value > 0 && (Value & (Value - 1)) == 0;
+    }
+
+    void replaceDivisionWithShift(llvm::Instruction *Div, llvm::Value *Dividend, int64_t DivisorValue, bool IsSigned, llvm::IRBuilder<> &Builder) {
+        unsigned ShiftAmount = llvm::Log2_64(DivisorValue);
+        llvm::Value *ShiftedValue = nullptr;
+
+        if (IsSigned) {
+            ShiftedValue = Builder.CreateAShr(Dividend, llvm::ConstantInt::get(Div->getType(), ShiftAmount), "signed_shift");
+        } else {
+            ShiftedValue = Builder.CreateLShr(Dividend, llvm::ConstantInt::get(Div->getType(), ShiftAmount), "unsigned_shift");
+        }
+
+        Div->replaceAllUsesWith(ShiftedValue);
+        Div->eraseFromParent();
+    }
+};
+
+} // namespace
+
+extern "C" llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK llvmGetPassPluginInfo() {
+    return {LLVM_PLUGIN_API_VERSION, "BinShiftPass", "1.0",
+            [](llvm::PassBuilder &PB) {
+                PB.registerPipelineParsingCallback(
+                    [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
+                       llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
+                    if (Name == "bin-shift") {
+                        FPM.addPass(BinShiftPass());
+                        return true;
+                    }
+                    return false;
+                });
+            }};
+}

--- a/llvm/compiler-course/llvm-ir/shkurinskaya_e_llvm/BinShift.cpp
+++ b/llvm/compiler-course/llvm-ir/shkurinskaya_e_llvm/BinShift.cpp
@@ -3,6 +3,7 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/PatternMatch.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Support/raw_ostream.h"
@@ -47,31 +48,53 @@ private:
 
     auto IsSigned = Div->getOpcode() == llvm::Instruction::SDiv;
 
-    if (auto *ConstInt = llvm::dyn_cast<llvm::ConstantInt>(DivisorOp)) {
-      int64_t DivisorValue =
-          IsSigned ? ConstInt->getSExtValue() : ConstInt->getZExtValue();
+    int64_t DivisorValue = getConstantValue(DivisorOp);
 
+    if (DivisorValue == 1 || DivisorValue == -1) {
       if (DivisorValue == 1) {
         Div->replaceAllUsesWith(Dividend);
-        Div->eraseFromParent();
-        return true;
-      }
-
-      if (IsSigned && DivisorValue == -1) {
+      } else {
         auto *NegVal = Builder.CreateNeg(Dividend, "negation_tmp");
         Div->replaceAllUsesWith(NegVal);
-        Div->eraseFromParent();
-        return true;
       }
+      Div->eraseFromParent();
+      return true;
+    }
 
-      if (isPowerOfTwo(DivisorValue)) {
-        replaceDivisionWithShift(Div, Dividend, DivisorValue, IsSigned,
-                                 Builder);
-        return true;
+    int64_t AbsDivisorValue = std::abs(DivisorValue);
+
+    if (isPowerOfTwo(AbsDivisorValue)) {
+      if (DivisorValue < 0) {
+        Dividend = Builder.CreateNeg(Dividend, "negation_tmp");
+      }
+      replaceDivisionWithShift(Div, Dividend, AbsDivisorValue, IsSigned,
+                               Builder);
+      return true;
+    }
+
+    return false; // Non-constant divisors pass through unchanged.
+  }
+
+  int64_t getConstantValue(llvm::Value *Val) {
+    if (auto *ConstInt = llvm::dyn_cast<llvm::ConstantInt>(Val)) {
+      return ConstInt->getSExtValue();
+    }
+
+    if (auto *Instr = llvm::dyn_cast<llvm::Instruction>(Val)) {
+      if (Instr->getOpcode() == llvm::Instruction::Mul) {
+        auto *Op1 = Instr->getOperand(0);
+        auto *Op2 = Instr->getOperand(1);
+
+        int64_t Op1Val = getConstantValue(Op1);
+        int64_t Op2Val = getConstantValue(Op2);
+
+        if (Op1Val != 0 && Op2Val != 0) {
+          return Op1Val * Op2Val;
+        }
       }
     }
 
-    return false;
+    return 0; // Return 0 if not a constant value.
   }
 
   bool isPowerOfTwo(int64_t Value) {

--- a/llvm/compiler-course/llvm-ir/shkurinskaya_e_llvm/CMakeLists.txt
+++ b/llvm/compiler-course/llvm-ir/shkurinskaya_e_llvm/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(Title "BinShiftPass")
+set(Student "Shkurinskaya_Elena")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_LLVM_IR")
+
+if (NOT WIN32 AND NOT CYGWIN)
+    file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+    add_llvm_pass_plugin(${TARGET_NAME} ${SOURCES}
+        DEPENDS
+        intrinsics_gen
+        BUILDTREE_ONLY
+    )
+    set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)
+endif()

--- a/llvm/test/compiler-course/shkurinskaya_e_llvm/test.ll
+++ b/llvm/test/compiler-course/shkurinskaya_e_llvm/test.ll
@@ -1,0 +1,56 @@
+; RUN: opt -load-pass-plugin %llvmshlibdir/BinShiftPass_Shkurinskaya_Elena_FIIT2_LLVM_IR%pluginext -passes=bin-shift -S %s | FileCheck %s
+
+define i32 @test_sdiv_power_of_two(i32 %x) {
+; CHECK-LABEL: @test_sdiv_power_of_two
+; CHECK-NEXT: ashr i32 %x, 3
+  %div = sdiv i32 %x, 8
+  ret i32 %div
+}
+
+define i32 @test_udiv_power_of_two(i32 %x) {
+; CHECK-LABEL: @test_udiv_power_of_two
+; CHECK-NEXT: lshr i32 %x, 4
+  %div = udiv i32 %x, 16
+  ret i32 %div
+}
+
+define i32 @test_sdiv_sub_one(i32 %x) {
+; CHECK-LABEL: @test_sdiv_sub_one
+; CHECK-NEXT: sub i32 0, %x
+  %div = sdiv i32 %x, -1
+  ret i32 %div
+}
+
+define i32 @test_sdiv_one(i32 %x) {
+; CHECK-LABEL: @test_sdiv_one
+; CHECK-NEXT: ret i32 %x
+  %div = sdiv i32 %x, 1
+  ret i32 %div
+}
+
+define i32 @test_udiv_one(i32 %x) {
+; CHECK-LABEL: @test_udiv_one
+; CHECK-NEXT: ret i32 %x
+  %div = udiv i32 %x, 1
+  ret i32 %div
+}
+
+define i32 @test_no_optimization(i32 %x) {
+; CHECK-LABEL: @test_no_optimization
+; CHECK-NEXT: sdiv i32 %x, 5
+  %div = sdiv i32 %x, 5
+  ret i32 %div
+}
+
+define i32 @test_mixed(i32 %x) {
+; CHECK-LABEL: @test_mixed
+; CHECK-NEXT: ashr i32 %x, 2
+; CHECK-NEXT: sdiv i32 %x, 3
+; CHECK-NEXT: lshr i32 %x, 5
+  %div1 = sdiv i32 %x, 4
+  %div2 = sdiv i32 %x, 3
+  %div3 = udiv i32 %x, 32
+  %result = add i32 %div1, %div2
+  %result2 = add i32 %result, %div3
+  ret i32 %result2
+}

--- a/llvm/test/compiler-course/shkurinskaya_e_llvm/test.ll
+++ b/llvm/test/compiler-course/shkurinskaya_e_llvm/test.ll
@@ -54,3 +54,59 @@ define i32 @test_mixed(i32 %x) {
   %result2 = add i32 %result, %div3
   ret i32 %result2
 }
+
+define i8 @test_sdiv_i8(i8 %x) {
+; CHECK-LABEL: @test_sdiv_i8
+; CHECK-NEXT: ashr i8 %x, 1
+  %div = sdiv i8 %x, 2
+  ret i8 %div
+}
+
+define i8 @test_udiv_i8(i8 %x) {
+; CHECK-LABEL: @test_udiv_i8
+; CHECK-NEXT: lshr i8 %x, 1
+  %div = udiv i8 %x, 2
+  ret i8 %div
+}
+
+define i16 @test_sdiv_i16(i16 %x) {
+; CHECK-LABEL: @test_sdiv_i16
+; CHECK-NEXT: ashr i16 %x, 2
+  %div = sdiv i16 %x, 4
+  ret i16 %div
+}
+
+define i16 @test_udiv_i16(i16 %x) {
+; CHECK-LABEL: @test_udiv_i16
+; CHECK-NEXT: lshr i16 %x, 2
+  %div = udiv i16 %x, 4
+  ret i16 %div
+}
+
+define i64 @test_sdiv_i64(i64 %x) {
+; CHECK-LABEL: @test_sdiv_i64
+; CHECK-NEXT: ashr i64 %x, 3
+  %div = sdiv i64 %x, 8
+  ret i64 %div
+}
+
+define i64 @test_udiv_i64(i64 %x) {
+; CHECK-LABEL: @test_udiv_i64
+; CHECK-NEXT: lshr i64 %x, 3
+  %div = udiv i64 %x, 8
+  ret i64 %div
+}
+
+define i128 @test_sdiv_i128(i128 %x) {
+; CHECK-LABEL: @test_sdiv_i128
+; CHECK-NEXT: ashr i128 %x, 4
+  %div = sdiv i128 %x, 16
+  ret i128 %div
+}
+
+define i128 @test_udiv_i128(i128 %x) {
+; CHECK-LABEL: @test_udiv_i128
+; CHECK-NEXT: lshr i128 %x, 4
+  %div = udiv i128 %x, 16
+  ret i128 %div
+}

--- a/llvm/test/compiler-course/shkurinskaya_e_llvm/test.ll
+++ b/llvm/test/compiler-course/shkurinskaya_e_llvm/test.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -load-pass-plugin %llvmshlibdir/BinShiftPass_Shkurinskaya_Elena_FIIT2_LLVM_IR%pluginext -passes=bin-shift -S %s | FileCheck %s
+; RUN: opt -load-pass-plugin %llvmshlibdir/BinShiftPass_Shkurinskaya_Elena_FIIT2_LLVM_IR%pluginext -passes=bin-shift -S %s | FileCheck %s
 
 define i32 @test_sdiv_power_of_two(i32 %x) {
 ; CHECK-LABEL: @test_sdiv_power_of_two
@@ -109,4 +110,38 @@ define i128 @test_udiv_i128(i128 %x) {
 ; CHECK-NEXT: lshr i128 %x, 4
   %div = udiv i128 %x, 16
   ret i128 %div
+}
+
+define i32 @test_sdiv_negative_power_of_two(i32 %x) {
+; CHECK-LABEL: @test_sdiv_negative_power_of_two
+; CHECK-NEXT: sub i32 0, %x
+; CHECK-NEXT: ashr i32 %negation_tmp, 4
+  %div = sdiv i32 %x, -16
+  ret i32 %div
+}
+
+define i32 @test_non_constant_divisor(i32 %x, i32 %y) {
+; CHECK-LABEL: @test_non_constant_divisor
+; CHECK-NEXT: sdiv i32 %x, %y
+  %div = sdiv i32 %x, %y
+  ret i32 %div
+}
+
+define i32 @test_var_power_of_two(i32 %x) {
+; CHECK-LABEL: @test_var_power_of_two
+; CHECK-DAG: %y = mul i32 1, 8
+; CHECK-DAG: %unsigned_shift = lshr i32 %x, 3
+  %y = mul i32 1, 8
+  %div = udiv i32 %x, %y
+  ret i32 %div
+}
+
+define i32 @test_var_negative_power_of_two(i32 %x) {
+; CHECK-LABEL: @test_var_negative_power_of_two
+; CHECK-DAG: %y = mul i32 -1, 4
+; CHECK-DAG: %negation_tmp = sub i32 0, %x
+; CHECK-DAG: %signed_shift = ashr i32 %negation_tmp, 2
+  %y = mul i32 -1, 4
+  %div = sdiv i32 %x, %y
+  ret i32 %div
 }


### PR DESCRIPTION
Этот LLVM Pass оптимизирует операции деления (sdiv и udiv) на степени двойки и деление на -1 или 1, заменяя их на более эффективные операции. Pass проходит по всем функциям в программе и ищет инструкции деления (sdiv и udiv). Если делитель является степенью двойки (2^n), деление заменяется на побитовый сдвиг вправо: арифметический (ashr) для знаковых чисел и логический (lshr) для беззнаковых чисел. Деление на 1 заменяется на возврат исходного значения, а деление на -1 заменяется на операцию отрицания. Если деление не подходит под эти оптимизации, оно остаётся неизменным.