### PR TITLE
Суворов Дмитрий. Лабораторная работа 2. LLVM IR PASS. Вариант 4.

### DIFF
--- a/llvm/compiler-course/llvm-ir/suvorov_d_lab2_var4/CMakeLists.txt
+++ b/llvm/compiler-course/llvm-ir/suvorov_d_lab2_var4/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(Title "DivOptimizePass")
+set(Student "Suvorov_Dmitrii")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_LLVM_IR")
+
+if (NOT WIN32 AND NOT CYGWIN)
+    file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+    add_llvm_pass_plugin(${TARGET_NAME} ${SOURCES}
+        DEPENDS
+        intrinsics_gen
+        BUILDTREE_ONLY
+    )
+    set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)
+endif()

--- a/llvm/compiler-course/llvm-ir/suvorov_d_lab2_var4/div_optimize_pass.cpp
+++ b/llvm/compiler-course/llvm-ir/suvorov_d_lab2_var4/div_optimize_pass.cpp
@@ -1,0 +1,104 @@
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+
+bool optimizeDivision(llvm::Function &F) {
+  bool Changed = false;
+
+  for (auto &BB : F) {
+    llvm::SmallVector<llvm::Instruction *, 8> ToErase;
+
+    for (auto &I : BB) {
+      auto *BinOp = llvm::dyn_cast<llvm::BinaryOperator>(&I);
+      if (!BinOp || (BinOp->getOpcode() != llvm::Instruction::SDiv &&
+                     BinOp->getOpcode() != llvm::Instruction::UDiv))
+        continue;
+
+      auto *Const = llvm::dyn_cast<llvm::ConstantInt>(BinOp->getOperand(1));
+      if (!Const)
+        continue;
+
+      const llvm::APInt &DivisorValue = Const->getValue();
+
+      if (DivisorValue.isZero())
+        continue;
+
+      llvm::IRBuilder<> Builder(BinOp);
+      llvm::Value *Replacement = nullptr;
+
+      if (DivisorValue.isOne()) {
+        Replacement = BinOp->getOperand(0);
+      } else if (DivisorValue.isAllOnes()) {
+        Replacement = Builder.CreateNeg(BinOp->getOperand(0));
+      } else if (DivisorValue.abs().isPowerOf2()) {
+        uint64_t ShiftAmount = DivisorValue.abs().exactLogBase2();
+
+        llvm::Value *Shift = nullptr;
+
+        if (BinOp->getOpcode() == llvm::Instruction::SDiv)
+          Shift = Builder.CreateAShr(
+              BinOp->getOperand(0),
+              llvm::ConstantInt::get(Const->getType(), ShiftAmount));
+        else
+          Shift = Builder.CreateLShr(
+              BinOp->getOperand(0),
+              llvm::ConstantInt::get(Const->getType(), ShiftAmount));
+
+        if (DivisorValue.isNegative())
+          Replacement = Builder.CreateNeg(Shift);
+        else
+          Replacement = Shift;
+      }
+
+      if (Replacement) {
+        BinOp->replaceAllUsesWith(Replacement);
+        ToErase.push_back(BinOp);
+        Changed = true;
+      }
+    }
+
+    for (auto *I : ToErase)
+      I->eraseFromParent();
+  }
+
+  return Changed;
+}
+
+struct DivOptimizePass : llvm::PassInfoMixin<DivOptimizePass> {
+  llvm::PreservedAnalyses run(llvm::Function &F,
+                              llvm::FunctionAnalysisManager &) {
+    bool Changed = optimizeDivision(F);
+    return Changed ? llvm::PreservedAnalyses::none()
+                   : llvm::PreservedAnalyses::all();
+  }
+
+  static bool isRequired() { return true; }
+};
+
+} // namespace
+
+llvm::PassPluginLibraryInfo getDivOptimizePluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "DivOptimizePass", LLVM_VERSION_STRING,
+          [](llvm::PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
+                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
+                  if (Name == "div-optimize") {
+                    FPM.addPass(DivOptimizePass());
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return getDivOptimizePluginInfo();
+}

--- a/llvm/test/compiler-course/suvorov_d_div_optimize_pass/suvorov_d_div_optimize_test.ll
+++ b/llvm/test/compiler-course/suvorov_d_div_optimize_pass/suvorov_d_div_optimize_test.ll
@@ -1,0 +1,77 @@
+; RUN: opt -load-pass-plugin %llvmshlibdir/DivOptimizePass_Suvorov_Dmitrii_FIIT1_LLVM_IR%pluginext -passes=div-optimize -S %s | FileCheck %s
+
+define i32 @f_pos(i32 %value) {
+; CHECK: @f_pos
+; CHECK-NEXT: ashr i32 %value, 3
+  %div = sdiv i32 %value, 8
+  ret i32 %div
+}
+
+define i32 @f_neg(i32 %value) {
+; CHECK: @f_neg
+; CHECK-NEXT: ashr i32 %value, 2
+; CHECK-NEXT: sub i32 0, 
+  %div = sdiv i32 %value, -4
+  ret i32 %div
+}
+
+define i32 @f_zero(i32 %value) {
+; CHECK: @f_zero
+; CHECK-NEXT: sdiv i32 %value, 0
+  %div = sdiv i32 %value, 0
+  ret i32 %div
+}
+
+define i32 @f_one(i32 %value) {
+; CHECK: @f_one
+; CHECK-NOT: sdiv
+  %div = sdiv i32 %value, 1
+  ret i32 %div
+}
+
+define i32 @f_minus_one(i32 %value) {
+; CHECK: @f_minus_one
+; CHECK-NEXT: sub i32 0, %value
+  %div = sdiv i32 %value, -1
+  ret i32 %div
+}
+
+define i32 @f_non_power(i32 %value) {
+; CHECK: @f_non_power
+; CHECK-NEXT: sdiv i32 %value, 3
+  %div = sdiv i32 %value, 3
+  ret i32 %div
+}
+
+define i32 @f_seq(i32 %value) {
+; CHECK: @f_seq
+; CHECK-NEXT: ashr i32 %value, 2
+; CHECK-NEXT: sdiv i32 %value, 5
+; CHECK-NEXT: ashr i32 %value, 3
+; CHECK-NEXT: sub i32 0,
+  %a = sdiv i32 %value, 4
+  %b = sdiv i32 %value, 5
+  %c = sdiv i32 %value, -8
+  ret i32 %c
+}
+
+define i32 @u_pos(i32 %value) {
+; CHECK: @u_pos
+; CHECK-NEXT: lshr i32 %value, 3
+  %div = udiv i32 %value, 8
+  ret i32 %div
+}
+
+define i32 @u_non_power(i32 %value) {
+; CHECK: @u_non_power
+; CHECK-NEXT: udiv i32 %value, 3
+  %div = udiv i32 %value, 3
+  ret i32 %div
+}
+
+define i32 @u_one(i32 %value) {
+; CHECK: @u_one
+; CHECK-NOT: udiv
+  %div = udiv i32 %value, 1
+  ret i32 %div
+}

--- a/llvm/test/compiler-course/suvorov_d_div_optimize_pass/suvorov_d_div_optimize_test.ll
+++ b/llvm/test/compiler-course/suvorov_d_div_optimize_pass/suvorov_d_div_optimize_test.ll
@@ -1,14 +1,14 @@
 ; RUN: opt -load-pass-plugin %llvmshlibdir/DivOptimizePass_Suvorov_Dmitrii_FIIT1_LLVM_IR%pluginext -passes=div-optimize -S %s | FileCheck %s
 
 define i32 @f_pos(i32 %value) {
-; CHECK: @f_pos
+; CHECK-LABEL: @f_pos
 ; CHECK-NEXT: ashr i32 %value, 3
   %div = sdiv i32 %value, 8
   ret i32 %div
 }
 
 define i32 @f_neg(i32 %value) {
-; CHECK: @f_neg
+; CHECK-LABEL: @f_neg
 ; CHECK-NEXT: ashr i32 %value, 2
 ; CHECK-NEXT: sub i32 0, 
   %div = sdiv i32 %value, -4
@@ -16,35 +16,35 @@ define i32 @f_neg(i32 %value) {
 }
 
 define i32 @f_zero(i32 %value) {
-; CHECK: @f_zero
+; CHECK-LABEL: @f_zero
 ; CHECK-NEXT: sdiv i32 %value, 0
   %div = sdiv i32 %value, 0
   ret i32 %div
 }
 
 define i32 @f_one(i32 %value) {
-; CHECK: @f_one
+; CHECK-LABEL: @f_one
 ; CHECK-NOT: sdiv
   %div = sdiv i32 %value, 1
   ret i32 %div
 }
 
 define i32 @f_minus_one(i32 %value) {
-; CHECK: @f_minus_one
+; CHECK-LABEL: @f_minus_one
 ; CHECK-NEXT: sub i32 0, %value
   %div = sdiv i32 %value, -1
   ret i32 %div
 }
 
 define i32 @f_non_power(i32 %value) {
-; CHECK: @f_non_power
+; CHECK-LABEL: @f_non_power
 ; CHECK-NEXT: sdiv i32 %value, 3
   %div = sdiv i32 %value, 3
   ret i32 %div
 }
 
 define i32 @f_seq(i32 %value) {
-; CHECK: @f_seq
+; CHECK-LABEL: @f_seq
 ; CHECK-NEXT: ashr i32 %value, 2
 ; CHECK-NEXT: sdiv i32 %value, 5
 ; CHECK-NEXT: ashr i32 %value, 3
@@ -56,21 +56,21 @@ define i32 @f_seq(i32 %value) {
 }
 
 define i32 @u_pos(i32 %value) {
-; CHECK: @u_pos
+; CHECK-LABEL: @u_pos
 ; CHECK-NEXT: lshr i32 %value, 3
   %div = udiv i32 %value, 8
   ret i32 %div
 }
 
 define i32 @u_non_power(i32 %value) {
-; CHECK: @u_non_power
+; CHECK-LABEL: @u_non_power
 ; CHECK-NEXT: udiv i32 %value, 3
   %div = udiv i32 %value, 3
   ret i32 %div
 }
 
 define i32 @u_one(i32 %value) {
-; CHECK: @u_one
+; CHECK-LABEL: @u_one
 ; CHECK-NOT: udiv
   %div = udiv i32 %value, 1
   ret i32 %div

--- a/llvm/test/compiler-course/suvorov_d_div_optimize_pass/suvorov_d_div_optimize_test.ll
+++ b/llvm/test/compiler-course/suvorov_d_div_optimize_pass/suvorov_d_div_optimize_test.ll
@@ -1,77 +1,77 @@
 ; RUN: opt -load-pass-plugin %llvmshlibdir/DivOptimizePass_Suvorov_Dmitrii_FIIT1_LLVM_IR%pluginext -passes=div-optimize -S %s | FileCheck %s
 
-define i32 @f_pos(i32 %value) {
 ; CHECK-LABEL: @f_pos
 ; CHECK-NEXT: ashr i32 %value, 3
+define i32 @f_pos(i32 %value) {
   %div = sdiv i32 %value, 8
   ret i32 %div
 }
 
-define i32 @f_neg(i32 %value) {
 ; CHECK-LABEL: @f_neg
 ; CHECK-NEXT: ashr i32 %value, 2
 ; CHECK-NEXT: sub i32 0, 
+define i32 @f_neg(i32 %value) {
   %div = sdiv i32 %value, -4
   ret i32 %div
 }
 
-define i32 @f_zero(i32 %value) {
 ; CHECK-LABEL: @f_zero
 ; CHECK-NEXT: sdiv i32 %value, 0
+define i32 @f_zero(i32 %value) {
   %div = sdiv i32 %value, 0
   ret i32 %div
 }
 
-define i32 @f_one(i32 %value) {
 ; CHECK-LABEL: @f_one
 ; CHECK-NOT: sdiv
+define i32 @f_one(i32 %value) {
   %div = sdiv i32 %value, 1
   ret i32 %div
 }
 
-define i32 @f_minus_one(i32 %value) {
 ; CHECK-LABEL: @f_minus_one
 ; CHECK-NEXT: sub i32 0, %value
+define i32 @f_minus_one(i32 %value) {
   %div = sdiv i32 %value, -1
   ret i32 %div
 }
 
-define i32 @f_non_power(i32 %value) {
 ; CHECK-LABEL: @f_non_power
 ; CHECK-NEXT: sdiv i32 %value, 3
+define i32 @f_non_power(i32 %value) {
   %div = sdiv i32 %value, 3
   ret i32 %div
 }
 
-define i32 @f_seq(i32 %value) {
 ; CHECK-LABEL: @f_seq
 ; CHECK-NEXT: ashr i32 %value, 2
 ; CHECK-NEXT: sdiv i32 %value, 5
 ; CHECK-NEXT: ashr i32 %value, 3
 ; CHECK-NEXT: sub i32 0,
+define i32 @f_seq(i32 %value) {
   %a = sdiv i32 %value, 4
   %b = sdiv i32 %value, 5
   %c = sdiv i32 %value, -8
   ret i32 %c
 }
 
-define i32 @u_pos(i32 %value) {
 ; CHECK-LABEL: @u_pos
 ; CHECK-NEXT: lshr i32 %value, 3
+define i32 @u_pos(i32 %value) {
   %div = udiv i32 %value, 8
   ret i32 %div
 }
 
-define i32 @u_non_power(i32 %value) {
 ; CHECK-LABEL: @u_non_power
 ; CHECK-NEXT: udiv i32 %value, 3
+define i32 @u_non_power(i32 %value) {
   %div = udiv i32 %value, 3
   ret i32 %div
 }
 
-define i32 @u_one(i32 %value) {
 ; CHECK-LABEL: @u_one
 ; CHECK-NOT: udiv
+define i32 @u_one(i32 %value) {
   %div = udiv i32 %value, 1
   ret i32 %div
 }


### PR DESCRIPTION
Был реализован LLVM IR pass, который оптимизирует операции деления на степени двойки, заменяя их на сдвиги. Он также обрабатывает несколько специальных случаев, включая деление на 1, -1 и 0. 
Если делитель является степенью двойки, то операция деления заменяется на сдвиг вправо на логарифм делителя по основанию 2.
Для знаковых делений используется арифметический сдвиг (AShr), для беззнаковых — логический сдвиг (LShr).
Если делитель равен 1, операция деления заменяется на возвращение делимого.
Если делитель равен -1, операция деления заменяется на отрицание делимого.