### PR TITLE
Созонов Илья. Лабораторная работа 2. LLVM IR. Вариант 1.

### DIFF
--- a/llvm/compiler-course/llvm-ir/sozonov_i_llvm_fmuladd/CMakeLists.txt
+++ b/llvm/compiler-course/llvm-ir/sozonov_i_llvm_fmuladd/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(Title "FmulFaddPass")
+set(Student "Sozonov_Ilya")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_LLVM_IR")
+
+if (NOT WIN32 AND NOT CYGWIN)
+    file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+    add_llvm_pass_plugin(${TARGET_NAME} ${SOURCES}
+        DEPENDS
+        intrinsics_gen
+        BUILDTREE_ONLY
+    )
+    set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)
+endif()

--- a/llvm/compiler-course/llvm-ir/sozonov_i_llvm_fmuladd/FmulFaddPass.cpp
+++ b/llvm/compiler-course/llvm-ir/sozonov_i_llvm_fmuladd/FmulFaddPass.cpp
@@ -1,0 +1,87 @@
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstrTypes.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+struct FmulFaddPass : llvm::PassInfoMixin<FmulFaddPass> {
+  llvm::PreservedAnalyses run(llvm::Function &func,
+                              llvm::FunctionAnalysisManager &) {
+    bool isModified = false;
+    llvm::SmallVector<llvm::Instruction *, 4> instructionsToRemove;
+
+    for (llvm::BasicBlock &BB : func) {
+      for (llvm::Instruction &I : llvm::make_early_inc_range(BB)) {
+        if (I.getOpcode() != llvm::Instruction::FAdd)
+          continue;
+
+        llvm::Value *Op1 = I.getOperand(0);
+        llvm::Value *Op2 = I.getOperand(1);
+
+        llvm::Instruction *MulInst = nullptr;
+        llvm::Value *A = nullptr, *B = nullptr, *C = nullptr;
+
+        if (auto *Mul = llvm::dyn_cast<llvm::Instruction>(Op1)) {
+          if (Mul->getOpcode() == llvm::Instruction::FMul) {
+            A = Mul->getOperand(0);
+            B = Mul->getOperand(1);
+            C = Op2;
+            MulInst = Mul;
+          }
+        }
+
+        if (!MulInst) {
+          if (auto *Mul = llvm::dyn_cast<llvm::Instruction>(Op2)) {
+            if (Mul->getOpcode() == llvm::Instruction::FMul) {
+              A = Mul->getOperand(0);
+              B = Mul->getOperand(1);
+              C = Op1;
+              MulInst = Mul;
+            }
+          }
+        }
+
+        if (MulInst) {
+          llvm::IRBuilder<> builder(&I);
+          llvm::Function *FmaFunc = llvm::Intrinsic::getDeclaration(
+              func.getParent(), llvm::Intrinsic::fmuladd, I.getType());
+
+          llvm::Value *Fma = builder.CreateCall(FmaFunc, {A, B, C});
+          I.replaceAllUsesWith(Fma);
+          instructionsToRemove.push_back(&I);
+          instructionsToRemove.push_back(MulInst);
+          isModified = true;
+        }
+      }
+    }
+
+    for (llvm::Instruction *I : instructionsToRemove)
+      I->eraseFromParent();
+
+    return isModified ? llvm::PreservedAnalyses::none()
+                      : llvm::PreservedAnalyses::all();
+  }
+
+  static bool isRequired() { return true; }
+};
+} // namespace
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "FmulFaddPass", "0.1",
+          [](llvm::PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](llvm::StringRef name, llvm::FunctionPassManager &FPM,
+                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) -> bool {
+                  if (name == "FmulFaddPass") {
+                    FPM.addPass(FmulFaddPass{});
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}

--- a/llvm/compiler-course/llvm-ir/sozonov_i_llvm_fmuladd/FmulFaddPass.cpp
+++ b/llvm/compiler-course/llvm-ir/sozonov_i_llvm_fmuladd/FmulFaddPass.cpp
@@ -40,18 +40,18 @@ struct FmulFaddPass : llvm::PassInfoMixin<FmulFaddPass> {
         }
 
         if (MulInst) {
+          if (!MulInst->hasOneUse())
+            continue;
+
           llvm::IRBuilder<> builder(&I);
           llvm::Function *FmaFunc = llvm::Intrinsic::getDeclaration(
               func.getParent(), llvm::Intrinsic::fmuladd, I.getType());
-        
+
           llvm::Value *Fma = builder.CreateCall(FmaFunc, {A, B, C});
           I.replaceAllUsesWith(Fma);
           instructionsToRemove.push_back(&I);
-        
-          if (MulInst->hasOneUse()) {
-            instructionsToRemove.push_back(MulInst);
-          }
-        
+          instructionsToRemove.push_back(MulInst);
+
           isModified = true;
         }
       }

--- a/llvm/compiler-course/llvm-ir/sozonov_i_llvm_fmuladd/FmulFaddPass.cpp
+++ b/llvm/compiler-course/llvm-ir/sozonov_i_llvm_fmuladd/FmulFaddPass.cpp
@@ -25,22 +25,16 @@ struct FmulFaddPass : llvm::PassInfoMixin<FmulFaddPass> {
         llvm::Instruction *MulInst = nullptr;
         llvm::Value *A = nullptr, *B = nullptr, *C = nullptr;
 
-        if (auto *Mul = llvm::dyn_cast<llvm::Instruction>(Op1)) {
-          if (Mul->getOpcode() == llvm::Instruction::FMul) {
-            A = Mul->getOperand(0);
-            B = Mul->getOperand(1);
-            C = Op2;
-            MulInst = Mul;
-          }
-        }
+        llvm::Value *Operands[2] = {Op1, Op2};
 
-        if (!MulInst) {
-          if (auto *Mul = llvm::dyn_cast<llvm::Instruction>(Op2)) {
+        for (int i = 0; i < 2; ++i) {
+          if (auto *Mul = llvm::dyn_cast<llvm::Instruction>(Operands[i])) {
             if (Mul->getOpcode() == llvm::Instruction::FMul) {
               A = Mul->getOperand(0);
               B = Mul->getOperand(1);
-              C = Op1;
+              C = Operands[1 - i];
               MulInst = Mul;
+              break;
             }
           }
         }
@@ -49,11 +43,15 @@ struct FmulFaddPass : llvm::PassInfoMixin<FmulFaddPass> {
           llvm::IRBuilder<> builder(&I);
           llvm::Function *FmaFunc = llvm::Intrinsic::getDeclaration(
               func.getParent(), llvm::Intrinsic::fmuladd, I.getType());
-
+        
           llvm::Value *Fma = builder.CreateCall(FmaFunc, {A, B, C});
           I.replaceAllUsesWith(Fma);
           instructionsToRemove.push_back(&I);
-          instructionsToRemove.push_back(MulInst);
+        
+          if (MulInst->hasOneUse()) {
+            instructionsToRemove.push_back(MulInst);
+          }
+        
           isModified = true;
         }
       }

--- a/llvm/test/compiler-course/sozonov_i_llvm_fmuladd/lit_test_llvm_ir_.ll
+++ b/llvm/test/compiler-course/sozonov_i_llvm_fmuladd/lit_test_llvm_ir_.ll
@@ -1,0 +1,41 @@
+; RUN: opt -load-pass-plugin %llvmshlibdir/FmulFaddPass_Sozonov_Ilya_FIIT3_LLVM_IR%pluginext -passes=FmulFaddPass -S %s | FileCheck %s
+
+; Test 1: (a * b) + c - should be replaced with llvm.fmuladd(a, b, c)
+; CHECK-LABEL: @mul_add_direct
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+; CHECK-NEXT: ret float %0
+
+define float @mul_add_direct(float %a, float %b, float %c) {
+entry:
+  %mul = fmul float %a, %b
+  %add = fadd float %mul, %c
+  ret float %add
+}
+
+; Test 2: c + (a * b) - should also be replaced with llvm.fmuladd(a, b, c)
+; CHECK-LABEL: @add_commuted_mul
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+; CHECK-NEXT: ret float %0
+
+define float @add_commuted_mul(float %a, float %b, float %c) {
+entry:
+  %mul = fmul float %a, %b
+  %add = fadd float %c, %mul
+  ret float %add
+}
+
+; Test 3: non-pattern input - should NOT be replaced
+; CHECK-LABEL: @no_pattern
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %add = fadd float %c, %b
+; CHECK-NEXT: %mul = fmul float %a, %add
+; CHECK-NEXT: ret float %mul
+
+define float @no_pattern(float %a, float %b, float %c) {
+entry:
+  %add = fadd float %c, %b
+  %mul = fmul float %a, %add
+  ret float %mul
+}

--- a/llvm/test/compiler-course/sozonov_i_llvm_fmuladd/lit_test_llvm_ir_.ll
+++ b/llvm/test/compiler-course/sozonov_i_llvm_fmuladd/lit_test_llvm_ir_.ll
@@ -1,12 +1,11 @@
 ; RUN: opt -load-pass-plugin %llvmshlibdir/FmulFaddPass_Sozonov_Ilya_FIIT3_LLVM_IR%pluginext -passes=FmulFaddPass -S %s | FileCheck %s
 
 ; Test 1: (a * b) + c - should be replaced with llvm.fmuladd(a, b, c)
-; CHECK-LABEL: @mul_add_direct
+; CHECK-LABEL: @fmul_fadd_ab_c
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT: %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
 ; CHECK-NEXT: ret float %0
-
-define float @mul_add_direct(float %a, float %b, float %c) {
+define float @fmul_fadd_ab_c(float %a, float %b, float %c) {
 entry:
   %mul = fmul float %a, %b
   %add = fadd float %mul, %c
@@ -14,28 +13,112 @@ entry:
 }
 
 ; Test 2: c + (a * b) - should also be replaced with llvm.fmuladd(a, b, c)
-; CHECK-LABEL: @add_commuted_mul
+; CHECK-LABEL: @fadd_c_fmul_ab
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT: %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
 ; CHECK-NEXT: ret float %0
-
-define float @add_commuted_mul(float %a, float %b, float %c) {
+define float @fadd_c_fmul_ab(float %a, float %b, float %c) {
 entry:
   %mul = fmul float %a, %b
   %add = fadd float %c, %mul
   ret float %add
 }
 
-; Test 3: non-pattern input - should NOT be replaced
-; CHECK-LABEL: @no_pattern
+; Test 3: (c + b) * a - addition first (no matching pattern)
+; CHECK-LABEL: @no_match_fadd_then_fmul
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT: %add = fadd float %c, %b
 ; CHECK-NEXT: %mul = fmul float %a, %add
 ; CHECK-NEXT: ret float %mul
-
-define float @no_pattern(float %a, float %b, float %c) {
+define float @no_match_fadd_then_fmul(float %a, float %b, float %c) {
 entry:
   %add = fadd float %c, %b
   %mul = fmul float %a, %add
   ret float %mul
+}
+
+; Test 4: (a + b) * c — addition comes first (should not match)
+; CHECK-LABEL: @no_match_add_then_mul
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %add = fadd float %a, %b
+; CHECK-NEXT: %mul = fmul float %add, %c
+; CHECK-NEXT: ret float %mul
+define float @no_match_add_then_mul(float %a, float %b, float %c) {
+entry:
+  %add = fadd float %a, %b
+  %mul = fmul float %add, %c
+  ret float %mul
+}
+
+; Test 5: (a * a) + a - same operand used in multiple places (should still replace)
+; CHECK-LABEL: @fmul_fadd_reuse
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %0 = call float @llvm.fmuladd.f32(float %a, float %a, float %a)
+; CHECK-NEXT: ret float %0
+define float @fmul_fadd_reuse(float %a) {
+entry:
+  %mul = fmul float %a, %a
+  %add = fadd float %mul, %a
+  ret float %add
+}
+
+; Test 6: ((a * b) + c) + d - nested expression (should replace inner only)
+; CHECK-LABEL: @nested_fmul_fadd_then_add
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+; CHECK-NEXT: %add2 = fadd float %0, %d
+; CHECK-NEXT: ret float %add2
+define float @nested_fmul_fadd_then_add(float %a, float %b, float %c, float %d) {
+entry:
+  %mul = fmul float %a, %b
+  %add1 = fadd float %mul, %c
+  %add2 = fadd float %add1, %d
+  ret float %add2
+}
+
+; Test 7: (a * b) + c — double precision (should replace)
+; CHECK-LABEL: @fmul_fadd_double
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %0 = call double @llvm.fmuladd.f64(double %a, double %b, double %c)
+; CHECK-NEXT: ret double %0
+define double @fmul_fadd_double(double %a, double %b, double %c) {
+entry:
+  %mul = fmul double %a, %b
+  %add = fadd double %mul, %c
+  ret double %add
+}
+
+; Test 8: (2.0 * a) + 1.0 - used constants (should replace)
+; CHECK-LABEL: @fmul_fadd_with_constants
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %0 = call float @llvm.fmuladd.f32(float 2.000000e+00, float %a, float 1.000000e+00)
+; CHECK-NEXT: ret float %0
+define float @fmul_fadd_with_constants(float %a) {
+entry:
+  %mul = fmul float 2.0, %a
+  %add = fadd float %mul, 1.0
+  ret float %add
+}
+
+; Test 9: (x * x) + y - one operand used multiple times (should replace)
+; CHECK-LABEL: @fmul_fadd_duplicate_operand
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %0 = call float @llvm.fmuladd.f32(float %x, float %x, float %y)
+; CHECK-NEXT: ret float %0
+define float @fmul_fadd_duplicate_operand(float %x, float %y) {
+entry:
+  %mul = fmul float %x, %x
+  %add = fadd float %mul, %y
+  ret float %add
+}
+
+; Test 10: already fused with llvm.fmuladd
+; CHECK-LABEL: @already_fused_fmuladd
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %fma = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+; CHECK-NEXT: ret float %fma
+define float @already_fused_fmuladd(float %a, float %b, float %c) {
+entry:
+  %fma = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+  ret float %fma
 }

--- a/llvm/test/compiler-course/sozonov_i_llvm_fmuladd/lit_test_llvm_ir_.ll
+++ b/llvm/test/compiler-course/sozonov_i_llvm_fmuladd/lit_test_llvm_ir_.ll
@@ -24,7 +24,7 @@ entry:
   ret float %add
 }
 
-; Test 3: (c + b) * a - addition first (no matching pattern)
+; Test 3: a * (c + b) - addition first (no matching pattern)
 ; CHECK-LABEL: @no_match_fadd_then_fmul
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT: %add = fadd float %c, %b
@@ -112,7 +112,23 @@ entry:
   ret float %add
 }
 
-; Test 10: already fused with llvm.fmuladd
+; Test 10: (x = a * b; y = x + c; return x + y) - use of intermediate result
+; CHECK-LABEL: @fmul_used_multiple_times
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %mul = fmul float %a, %b
+; CHECK-NEXT: %add = fadd float %mul, %c
+; CHECK-NEXT: %add2 = fadd float %mul, %add
+; CHECK-NEXT: ret float %add2
+
+define float @fmul_used_multiple_times(float %a, float %b, float %c) {
+entry:
+  %mul = fmul float %a, %b
+  %add = fadd float %mul, %c
+  %add2 = fadd float %mul, %add
+  ret float %add2
+}
+
+; Test 11: already fused with llvm.fmuladd
 ; CHECK-LABEL: @already_fused_fmuladd
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT: %fma = call float @llvm.fmuladd.f32(float %a, float %b, float %c)

--- a/llvm/test/compiler-course/sozonov_i_llvm_fmuladd/lit_test_llvm_ir_.ll
+++ b/llvm/test/compiler-course/sozonov_i_llvm_fmuladd/lit_test_llvm_ir_.ll
@@ -119,7 +119,6 @@ entry:
 ; CHECK-NEXT: %add = fadd float %mul, %c
 ; CHECK-NEXT: %add2 = fadd float %mul, %add
 ; CHECK-NEXT: ret float %add2
-
 define float @fmul_used_multiple_times(float %a, float %b, float %c) {
 entry:
   %mul = fmul float %a, %b


### PR DESCRIPTION
This LLVM plugin performs an optimization that replaces expressions of the form `(a * b) + c (or c + (a * b))` with the intrinsic function `llvm.fmuladd(a, b, c)` in the Intermediate Representation (IR) of a program. This enables efficient use of the FMA (Fused Multiply-Add) instruction, which combines multiplication and addition into a single operation, potentially improving performance on architectures that support FMA.

1. **Traversal of Instructions in a Function:** The plugin traverses all functions in the module and looks for fadd (floating-point addition) instructions. For each such instruction, it checks if one of its operands is a multiplication (FMul).

2. **Replacement with llvm.fmuladd:** When an expression matching the pattern `(a * b) + c `or `c + (a * b)` is found, it is replaced with the call to the intrinsic function `llvm.fmuladd(a, b, c)`, which efficiently combines multiplication and addition in a single instruction.

3. **Removing Redundant Instructions:** After replacing the expression, the plugin removes the old fadd and fmul instructions, as they are no longer needed.

4. **Returning the Result:** If modifications were made, the plugin returns `llvm::PreservedAnalyses::none()`. If no changes were made, it returns `llvm::PreservedAnalyses::all()`.