### PR TITLE
Хованский Дмитрий.  Лабораторная работа 2. LLVM IR. Вариант 3.

### DIFF
--- a/llvm/compiler-course/llvm-ir/khovansky_d_lab2/CMakeLists.txt
+++ b/llvm/compiler-course/llvm-ir/khovansky_d_lab2/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(Title "AddReplacer")
+set(Student "Khovansky_Dmitry")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_LLVM_IR")
+
+if (NOT WIN32 AND NOT CYGWIN)
+    file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+    add_llvm_pass_plugin(${TARGET_NAME} ${SOURCES}
+        DEPENDS
+        intrinsics_gen
+        BUILDTREE_ONLY
+    )
+    set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)
+endif()

--- a/llvm/compiler-course/llvm-ir/khovansky_d_lab2/khovansky_d_lab2.cpp
+++ b/llvm/compiler-course/llvm-ir/khovansky_d_lab2/khovansky_d_lab2.cpp
@@ -1,16 +1,19 @@
-#include "llvm/IR/Module.h"
+
 #include "llvm/IR/Function.h"
-#include "llvm/IR/Instructions.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
-#include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Transforms/Utils/BasicBlockUtils.h"
 
 namespace {
 
-struct ReplaceAddInstructionPass : llvm::PassInfoMixin<ReplaceAddInstructionPass> {
-  llvm::PreservedAnalyses run(llvm::Function &Func, llvm::FunctionAnalysisManager &) {
+struct ReplaceAddInstructionPass
+    : llvm::PassInfoMixin<ReplaceAddInstructionPass> {
+  llvm::PreservedAnalyses run(llvm::Function &Func,
+                              llvm::FunctionAnalysisManager &) {
     llvm::Module *Mod = Func.getParent();
 
     if (!Mod) {
@@ -33,7 +36,8 @@ struct ReplaceAddInstructionPass : llvm::PassInfoMixin<ReplaceAddInstructionPass
 
     for (llvm::BasicBlock &Block : Func) {
       for (llvm::Instruction &Inst : Block) {
-        llvm::BinaryOperator *BinOp = llvm::dyn_cast<llvm::BinaryOperator>(&Inst);
+        llvm::BinaryOperator *BinOp =
+            llvm::dyn_cast<llvm::BinaryOperator>(&Inst);
 
         if (!BinOp || BinOp->getOpcode() != llvm::Instruction::Add) {
           continue;
@@ -58,7 +62,7 @@ struct ReplaceAddInstructionPass : llvm::PassInfoMixin<ReplaceAddInstructionPass
         if (AddFuncType->getParamType(0) == LeftType &&
             AddFuncType->getParamType(1) == RightType &&
             AddFuncType->getReturnType() == ResultType) {
-            ToReplace.push_back(BinOp);
+          ToReplace.push_back(BinOp);
         }
       }
     }
@@ -72,7 +76,8 @@ struct ReplaceAddInstructionPass : llvm::PassInfoMixin<ReplaceAddInstructionPass
       llvm::Value *Arg1 = OldAdd->getOperand(0);
       llvm::Value *Arg2 = OldAdd->getOperand(1);
 
-      llvm::CallInst *Call = Builder.CreateCall(AddFunc, {Arg1, Arg2}, OldAdd->getName());
+      llvm::CallInst *Call =
+          Builder.CreateCall(AddFunc, {Arg1, Arg2}, OldAdd->getName());
 
       OldAdd->replaceAllUsesWith(Call);
       OldAdd->eraseFromParent();

--- a/llvm/compiler-course/llvm-ir/khovansky_d_lab2/khovansky_d_lab2.cpp
+++ b/llvm/compiler-course/llvm-ir/khovansky_d_lab2/khovansky_d_lab2.cpp
@@ -33,6 +33,8 @@ struct ReplaceAddInstructionPass
 
     llvm::SmallVector<llvm::Instruction *, 8> ToReplace;
 
+    llvm::FunctionType *AddFuncType = AddFunc->getFunctionType();
+
     for (llvm::BasicBlock &Block : Func) {
       for (llvm::Instruction &Inst : Block) {
         llvm::BinaryOperator *BinOp =
@@ -51,12 +53,6 @@ struct ReplaceAddInstructionPass
         llvm::Type *LeftType = BinOp->getOperand(0)->getType();
         llvm::Type *RightType = BinOp->getOperand(1)->getType();
         llvm::Type *ResultType = BinOp->getType();
-
-        llvm::FunctionType *AddFuncType = AddFunc->getFunctionType();
-
-        if (AddFuncType->getNumParams() != 2) {
-          continue;
-        }
 
         if (AddFuncType->getParamType(0) == LeftType &&
             AddFuncType->getParamType(1) == RightType &&

--- a/llvm/compiler-course/llvm-ir/khovansky_d_lab2/khovansky_d_lab2.cpp
+++ b/llvm/compiler-course/llvm-ir/khovansky_d_lab2/khovansky_d_lab2.cpp
@@ -1,0 +1,103 @@
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Transforms/Utils/BasicBlockUtils.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+
+struct ReplaceAddInstructionPass : llvm::PassInfoMixin<ReplaceAddInstructionPass> {
+  llvm::PreservedAnalyses run(llvm::Function &Func, llvm::FunctionAnalysisManager &) {
+    llvm::Module *Mod = Func.getParent();
+
+    if (!Mod) {
+      return llvm::PreservedAnalyses::all();
+    }
+
+    llvm::Function *AddFunc = Mod->getFunction("add");
+
+    // проверка на названия типа "__add"
+    if (!AddFunc || AddFunc == &Func || AddFunc->getName() != "add") {
+      return llvm::PreservedAnalyses::all();
+    }
+
+    // проверка на сигнатуру - не vararg и два аргумента
+    if (AddFunc->arg_size() != 2 || AddFunc->isVarArg()) {
+      return llvm::PreservedAnalyses::all();
+    }
+
+    llvm::SmallVector<llvm::Instruction *, 8> ToReplace;
+
+    for (llvm::BasicBlock &Block : Func) {
+      for (llvm::Instruction &Inst : Block) {
+        llvm::BinaryOperator *BinOp = llvm::dyn_cast<llvm::BinaryOperator>(&Inst);
+
+        if (!BinOp || BinOp->getOpcode() != llvm::Instruction::Add) {
+          continue;
+        }
+
+        // вызов функции в этом случае менее эффективен, чем встроенная операция
+        if (llvm::isa<llvm::Constant>(BinOp->getOperand(0)) ||
+            llvm::isa<llvm::Constant>(BinOp->getOperand(1))) {
+          continue;
+        }
+
+        llvm::Type *LeftType = BinOp->getOperand(0)->getType();
+        llvm::Type *RightType = BinOp->getOperand(1)->getType();
+        llvm::Type *ResultType = BinOp->getType();
+
+        llvm::FunctionType *AddFuncType = AddFunc->getFunctionType();
+
+        if (AddFuncType->getNumParams() != 2) {
+          continue;
+        }
+
+        if (AddFuncType->getParamType(0) == LeftType &&
+            AddFuncType->getParamType(1) == RightType &&
+            AddFuncType->getReturnType() == ResultType) {
+            ToReplace.push_back(BinOp);
+        }
+      }
+    }
+
+    if (ToReplace.empty()) {
+      return llvm::PreservedAnalyses::all();
+    }
+
+    for (llvm::Instruction *OldAdd : ToReplace) {
+      llvm::IRBuilder<> Builder(OldAdd);
+      llvm::Value *Arg1 = OldAdd->getOperand(0);
+      llvm::Value *Arg2 = OldAdd->getOperand(1);
+
+      llvm::CallInst *Call = Builder.CreateCall(AddFunc, {Arg1, Arg2}, OldAdd->getName());
+
+      OldAdd->replaceAllUsesWith(Call);
+      OldAdd->eraseFromParent();
+    }
+
+    return llvm::PreservedAnalyses::none();
+  }
+
+  static bool isRequired() { return true; }
+};
+
+} // namespace
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "ReplaceAddInstructionPass", "0.1",
+          [](llvm::PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](llvm::StringRef name, llvm::FunctionPassManager &FPM,
+                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) -> bool {
+                  if (name == "AddReplacer") {
+                    FPM.addPass(ReplaceAddInstructionPass{});
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}

--- a/llvm/compiler-course/llvm-ir/khovansky_d_lab2/khovansky_d_lab2.cpp
+++ b/llvm/compiler-course/llvm-ir/khovansky_d_lab2/khovansky_d_lab2.cpp
@@ -22,7 +22,6 @@ struct ReplaceAddInstructionPass
 
     llvm::Function *AddFunc = Mod->getFunction("add");
 
-    // проверка на названия типа "__add"
     if (!AddFunc || AddFunc == &Func || AddFunc->getName() != "add") {
       return llvm::PreservedAnalyses::all();
     }

--- a/llvm/compiler-course/llvm-ir/khovansky_d_lab2/khovansky_d_lab2.cpp
+++ b/llvm/compiler-course/llvm-ir/khovansky_d_lab2/khovansky_d_lab2.cpp
@@ -26,7 +26,7 @@ struct ReplaceAddInstructionPass
       return llvm::PreservedAnalyses::all();
     }
 
-    // проверка на сигнатуру - не vararg и два аргумента
+    // проверка на сигнатуру: не vararg и два аргумента
     if (AddFunc->arg_size() != 2 || AddFunc->isVarArg()) {
       return llvm::PreservedAnalyses::all();
     }

--- a/llvm/test/compiler-course/khovansky_d_lab2/test_llvm_ir.ll
+++ b/llvm/test/compiler-course/khovansky_d_lab2/test_llvm_ir.ll
@@ -1,0 +1,67 @@
+; RUN: opt -load-pass-plugin %llvmshlibdir/AddReplacer_Khovansky_Dmitry_FIIT2_LLVM_IR%pluginext\
+; RUN: -passes=AddReplacer -S %s | FileCheck %s
+
+; === сама функция add ===
+; CHECK-LABEL: define i32 @add(
+; CHECK:       entry:
+; CHECK:       %result = add i32 %a, %b
+; CHECK:       ret i32 %result
+define i32 @add(i32 %a, i32 %b) {
+entry:
+  %result = add i32 %a, %b
+  ret i32 %result
+}
+
+; === Test 1: Заменяется add на вызов @add ===
+; CHECK-LABEL: define i32 @should_replace(
+; CHECK:       entry:
+; CHECK:       call i32 @add(i32 %x, i32 %y)
+; CHECK:       ret i32
+; CHECK-NOT:   add i32 %x, %y
+define i32 @should_replace(i32 %x, i32 %y) {
+entry:
+  %sum = add i32 %x, %y
+  ret i32 %sum
+}
+
+; === Test 2: используется именно @add, а не его сигнатура ===
+; CHECK-LABEL: define i32 @wrong_sig_user(
+; CHECK:       entry:
+; CHECK:       call i32 @add(i32 %x, i32 %y)
+; CHECK-NOT:   call i64 @add_wrong_sig
+define i64 @add_wrong_sig(i64 %a, i64 %b) {
+entry:
+  %r = add i64 %a, %b
+  ret i64 %r
+}
+
+define i32 @wrong_sig_user(i32 %x, i32 %y) {
+entry:
+  %sum = add i32 %x, %y
+  ret i32 %sum
+}
+
+
+; === Test 3: проверка константы ===
+; CHECK-LABEL: define i32 @const_operand(
+; CHECK:       entry:
+; CHECK:       add i32 %x, 42
+; CHECK:       ret i32
+; CHECK-NOT:   add i32 %x, %y
+define i32 @const_operand(i32 %x) {
+entry:
+  %sum = add i32 %x, 42
+  ret i32 %sum
+}
+
+; === Test 4: проверка fadd ===
+; CHECK-LABEL: define double @double_add(
+; CHECK:       entry:
+; CHECK:       fadd double %a, %b
+; CHECK:       ret double
+; CHECK-NOT:   add i32 %x, %y
+define double @double_add(double %a, double %b) {
+entry:
+  %sum = fadd double %a, %b
+  ret double %sum
+}

--- a/llvm/test/compiler-course/khovansky_d_lab2/test_llvm_ir.ll
+++ b/llvm/test/compiler-course/khovansky_d_lab2/test_llvm_ir.ll
@@ -3,9 +3,9 @@
 
 ; === сама функция add ===
 ; CHECK-LABEL: define i32 @add(
-; CHECK:       entry:
-; CHECK:       %result = add i32 %a, %b
-; CHECK:       ret i32 %result
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:  %result = add i32 %a, %b
+; CHECK-NEXT:  ret i32 %result
 define i32 @add(i32 %a, i32 %b) {
 entry:
   %result = add i32 %a, %b
@@ -14,9 +14,9 @@ entry:
 
 ; === Test 1: Заменяется add на вызов @add ===
 ; CHECK-LABEL: define i32 @should_replace(
-; CHECK:       entry:
-; CHECK:       call i32 @add(i32 %x, i32 %y)
-; CHECK:       ret i32
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:  call i32 @add(i32 %x, i32 %y)
+; CHECK-NEXT:  ret i32
 ; CHECK-NOT:   add i32 %x, %y
 define i32 @should_replace(i32 %x, i32 %y) {
 entry:
@@ -26,8 +26,8 @@ entry:
 
 ; === Test 2: используется именно @add, а не его сигнатура ===
 ; CHECK-LABEL: define i32 @wrong_sig_user(
-; CHECK:       entry:
-; CHECK:       call i32 @add(i32 %x, i32 %y)
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:  call i32 @add(i32 %x, i32 %y)
 ; CHECK-NOT:   call i64 @add_wrong_sig
 define i64 @add_wrong_sig(i64 %a, i64 %b) {
 entry:
@@ -44,9 +44,9 @@ entry:
 
 ; === Test 3: проверка константы ===
 ; CHECK-LABEL: define i32 @const_operand(
-; CHECK:       entry:
-; CHECK:       add i32 %x, 42
-; CHECK:       ret i32
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:  add i32 %x, 42
+; CHECK-NEXT:  ret i32
 ; CHECK-NOT:   call i32 @add(i32 %x, 42)
 define i32 @const_operand(i32 %x) {
 entry:
@@ -56,9 +56,9 @@ entry:
 
 ; === Test 4: проверка fadd ===
 ; CHECK-LABEL: define double @double_add(
-; CHECK:       entry:
-; CHECK:       fadd double %a, %b
-; CHECK:       ret double
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:  fadd double %a, %b
+; CHECK-NEXT:  ret double
 ; CHECK-NOT:   call i32 @add(i32 %a, i32 %b)
 define double @double_add(double %a, double %b) {
 entry:

--- a/llvm/test/compiler-course/khovansky_d_lab2/test_llvm_ir.ll
+++ b/llvm/test/compiler-course/khovansky_d_lab2/test_llvm_ir.ll
@@ -47,7 +47,7 @@ entry:
 ; CHECK:       entry:
 ; CHECK:       add i32 %x, 42
 ; CHECK:       ret i32
-; CHECK-NOT:   add i32 %x, %y
+; CHECK-NOT:   call i32 @add(i32 %x, 42)
 define i32 @const_operand(i32 %x) {
 entry:
   %sum = add i32 %x, 42
@@ -59,7 +59,7 @@ entry:
 ; CHECK:       entry:
 ; CHECK:       fadd double %a, %b
 ; CHECK:       ret double
-; CHECK-NOT:   add i32 %x, %y
+; CHECK-NOT:   call i32 @add(i32 %a, i32 %b)
 define double @double_add(double %a, double %b) {
 entry:
   %sum = fadd double %a, %b

--- a/llvm/test/compiler-course/khovansky_d_lab2/test_llvm_ir1.ll
+++ b/llvm/test/compiler-course/khovansky_d_lab2/test_llvm_ir1.ll
@@ -1,0 +1,22 @@
+; RUN: opt -load-pass-plugin %llvmshlibdir/AddReplacer_Khovansky_Dmitry_FIIT2_LLVM_IR%pluginext\
+; RUN: -passes=AddReplacer -S %s | FileCheck %s
+
+; === Test 5: user's add function with 3 arguments ===
+; CHECK-LABEL: define i32 @test_three_args(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:  add i32 %x, %y
+; CHECK-NEXT:  ret i32
+; CHECK-NOT:   call i32 @add(i32 %x, i32 %y)
+
+define i32 @add(i32 %a, i32 %b, i32 %c) {
+entry:
+  %sum = add i32 %a, %b
+  %sum2 = add i32 %sum, %c
+  ret i32 %sum2
+}
+
+define i32 @test_three_args(i32 %x, i32 %y) {
+entry:
+  %sum = add i32 %x, %y
+  ret i32 %sum
+}


### PR DESCRIPTION
Пасс ищет инструкции add и заменяет их на вызов функции @add, если:

1. Функция @add существует ;

2. Сигнатура @add совпадает с типами операндов и результатом инструкции;

3. Оба операнда не являются константами;

4. Обрабатываемая функция — не сама @add.

Так обеспечивается замена add на вызов @add(i32, i32) только при корректном совпадении типов.