### PR TITLE
Хованский Дмитрий. Лабораторная работа 1. Clang AST. Вариант 3.

### DIFF
--- a/clang/compiler-course/khovansky_d_lab1/CMakeLists.txt
+++ b/clang/compiler-course/khovansky_d_lab1/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "ImplicitConvPlugin")
+set(Student "Khovansky_Dmitry")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
+++ b/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
@@ -38,7 +38,8 @@ class ImplicitConvVisitor final
   }
 
 public:
-  explicit ImplicitConvVisitor(clang::ASTContext *astcontext) : context(astcontext) {}
+  explicit ImplicitConvVisitor(clang::ASTContext *astcontext) :
+      context(astcontext) {}
 
   bool VisitFunctionDecl(clang::FunctionDecl *func) {
     current_function = func->getNameInfo().getName().getAsString();

--- a/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
+++ b/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
@@ -1,0 +1,141 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+#include <map>
+#include <string>
+#include <vector>
+
+namespace {
+
+class ImplicitConvVisitor final
+    : public clang::RecursiveASTVisitor<ImplicitConvVisitor> {
+
+  void handleTypeConversion(const clang::QualType &fromType,
+                            const clang::QualType &toType) {
+    std::string fromTypeStr = fromType.getAsString();
+    std::string toTypeStr = toType.getAsString();
+
+    // ради читаемости
+    fromTypeStr = (fromTypeStr == "_Bool") ? "bool" : fromTypeStr;
+    toTypeStr = (toTypeStr == "_Bool") ? "bool" : toTypeStr;
+
+    if (fromTypeStr == toTypeStr)
+      return;
+
+    std::string conversion = fromTypeStr + " -> " + toTypeStr;
+    auto &convList = conversions[currentFunction];
+
+    for (auto &entry : convList) {
+      if (entry.first == conversion) {
+        entry.second++;
+        return;
+      }
+    }
+
+    convList.push_back({conversion, 1});
+  }
+
+public:
+  explicit ImplicitConvVisitor(clang::ASTContext *context) : Context(context) {}
+
+  bool VisitFunctionDecl(clang::FunctionDecl *func) {
+    currentFunction = func->getNameInfo().getName().getAsString();
+    if (conversions.find(currentFunction) == conversions.end()) {
+      functionOrder.push_back(currentFunction);
+    }
+    return true;
+  }
+
+  bool VisitCXXConstructExpr(clang::CXXConstructExpr *expr) {
+    if (expr->getNumArgs() == 1) {
+      clang::QualType fromType = expr->getArg(0)->getType();
+      clang::QualType toType = expr->getType();
+      handleTypeConversion(fromType, toType);
+    }
+    return true;
+  }
+
+  bool VisitImplicitCastExpr(clang::ImplicitCastExpr *cast) {
+    switch (cast->getCastKind()) {
+      case clang::CK_NoOp:
+      case clang::CK_LValueToRValue:
+      case clang::CK_FunctionToPointerDecay:
+      case clang::CK_ArrayToPointerDecay:
+        return true;
+      default:
+        break;
+    }    
+
+    clang::QualType fromType = cast->getSubExpr()->getType();
+    clang::QualType toType = cast->getType();
+    handleTypeConversion(fromType, toType);
+    return true;
+  }
+
+  bool VisitVarDecl(clang::VarDecl *varDecl) {
+    if (!currentFunction.empty()) return true;
+
+    clang::QualType fromType = varDecl->getType();
+    clang::QualType toType = varDecl->getType();
+
+    handleTypeConversion(fromType, toType);
+    return true;
+  }
+
+  void printResults() {
+    auto &os = llvm::outs();
+
+    os << "In global scope:\n";
+    for (const auto &[c1, c2] : conversions["global_scope"]) {
+      os << "  " << c1 << ": " << c2 << "\n";
+    }
+
+    for (const auto &funcName : functionOrder) {
+      os << "Function: " << funcName << "\n";
+      for (const auto &[c1, c2] : conversions[funcName]) {
+        os << "  " << c1 << ": " << c2 << "\n";
+      }
+      os << "\n";
+    }
+  }
+
+private:
+  clang::ASTContext *Context;
+  std::string currentFunction = "global_scope";
+  std::vector<std::string> functionOrder;
+  std::map<std::string, std::vector<std::pair<std::string, int>>> conversions;
+};
+
+class ConversionConsumer final : public clang::ASTConsumer {
+public:
+  explicit ConversionConsumer(clang::ASTContext *context) : Visitor(context) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    Visitor.TraverseDecl(context.getTranslationUnitDecl());
+    Visitor.printResults();
+  }
+
+private:
+  ImplicitConvVisitor Visitor;
+};
+
+class ConversionAction final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    return std::make_unique<ConversionConsumer>(&ci.getASTContext());
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+};
+
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<ConversionAction>
+    X("ImplicitConvPlugin",
+      "Output the number of implicit conversions in the entire file, including global scope");

--- a/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
+++ b/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+// NOLINTBEGIN(readability-identifier-naming)
 namespace {
 
 class ImplicitConvVisitor final
@@ -141,3 +142,5 @@ public:
 static clang::FrontendPluginRegistry::Add<ConversionAction>
     X("ImplicitConvPlugin", "Output the number of implicit conversions in the "
                             "entire file, including global scope");
+// NOLINTEND(readability-identifier-naming)
+

--- a/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
+++ b/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
@@ -66,7 +66,7 @@ public:
       return true;
     default:
       break;
-    }    
+    }
 
     clang::QualType fromType = cast->getSubExpr()->getType();
     clang::QualType toType = cast->getType();

--- a/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
+++ b/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
@@ -12,7 +12,7 @@ namespace {
 class ImplicitConvVisitor final
     : public clang::RecursiveASTVisitor<ImplicitConvVisitor> {
 
-  void handleTypeConversion(const clang::QualType &fromType,
+  void HandleTypeConversion(const clang::QualType &fromType,
                             const clang::QualType &toType) {
     std::string fromTypeStr = fromType.getAsString();
     std::string toTypeStr = toType.getAsString();
@@ -52,7 +52,7 @@ public:
     if (expr->getNumArgs() == 1) {
       clang::QualType fromType = expr->getArg(0)->getType();
       clang::QualType toType = expr->getType();
-      handleTypeConversion(fromType, toType);
+      HandleTypeConversion(fromType, toType);
     }
     return true;
   }
@@ -70,7 +70,7 @@ public:
 
     clang::QualType fromType = cast->getSubExpr()->getType();
     clang::QualType toType = cast->getType();
-    handleTypeConversion(fromType, toType);
+    HandleTypeConversion(fromType, toType);
     return true;
   }
 
@@ -80,7 +80,7 @@ public:
     clang::QualType fromType = varDecl->getType();
     clang::QualType toType = varDecl->getType();
 
-    handleTypeConversion(fromType, toType);
+    HandleTypeConversion(fromType, toType);
     return true;
   }
 

--- a/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
+++ b/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
@@ -12,47 +12,47 @@ namespace {
 class ImplicitConvVisitor final
     : public clang::RecursiveASTVisitor<ImplicitConvVisitor> {
 
-  void HandleTypeConversion(const clang::QualType &fromType,
-                            const clang::QualType &toType) {
-    std::string fromTypeStr = fromType.getAsString();
-    std::string toTypeStr = toType.getAsString();
+  void HandleTypeConversion(const clang::QualType &from_type,
+                            const clang::QualType &to_type) {
+    std::string from_type_str = from_type.getAsString();
+    std::string to_type_str = to_type.getAsString();
 
     // ради читаемости
-    fromTypeStr = (fromTypeStr == "_Bool") ? "bool" : fromTypeStr;
-    toTypeStr = (toTypeStr == "_Bool") ? "bool" : toTypeStr;
+    from_type_str = (from_type_str == "_Bool") ? "bool" : from_type_str;
+    to_type_str = (to_type_str == "_Bool") ? "bool" : to_type_str;
 
-    if (fromTypeStr == toTypeStr)
+    if (from_type_str == to_type_str)
       return;
 
-    std::string conversion = fromTypeStr + " -> " + toTypeStr;
-    auto &convList = conversions[currentFunction];
+    std::string conversion = from_type_str + " -> " + to_type_str;
+    auto &conv_list = conversions[current_function];
 
-    for (auto &entry : convList) {
+    for (auto &entry : conv_list) {
       if (entry.first == conversion) {
         entry.second++;
         return;
       }
     }
 
-    convList.push_back({conversion, 1});
+    conv_list.push_back({conversion, 1});
   }
 
 public:
-  explicit ImplicitConvVisitor(clang::ASTContext *context) : Context(context) {}
+  explicit ImplicitConvVisitor(clang::ASTContext *astcontext) : context(astcontext) {}
 
   bool VisitFunctionDecl(clang::FunctionDecl *func) {
-    currentFunction = func->getNameInfo().getName().getAsString();
-    if (conversions.find(currentFunction) == conversions.end()) {
-      functionOrder.push_back(currentFunction);
+    current_function = func->getNameInfo().getName().getAsString();
+    if (conversions.find(current_function) == conversions.end()) {
+      function_order.push_back(current_function);
     }
     return true;
   }
 
   bool VisitCXXConstructExpr(clang::CXXConstructExpr *expr) {
     if (expr->getNumArgs() == 1) {
-      clang::QualType fromType = expr->getArg(0)->getType();
-      clang::QualType toType = expr->getType();
-      HandleTypeConversion(fromType, toType);
+      clang::QualType from_type = expr->getArg(0)->getType();
+      clang::QualType to_type = expr->getType();
+      HandleTypeConversion(from_type, to_type);
     }
     return true;
   }
@@ -68,20 +68,20 @@ public:
       break;
     }
 
-    clang::QualType fromType = cast->getSubExpr()->getType();
-    clang::QualType toType = cast->getType();
-    HandleTypeConversion(fromType, toType);
+    clang::QualType from_type = cast->getSubExpr()->getType();
+    clang::QualType to_type = cast->getType();
+    HandleTypeConversion(from_type, to_type);
     return true;
   }
 
   bool VisitVarDecl(clang::VarDecl *varDecl) {
-    if (!currentFunction.empty())
+    if (!current_function.empty())
       return true;
 
-    clang::QualType fromType = varDecl->getType();
-    clang::QualType toType = varDecl->getType();
+    clang::QualType from_type = varDecl->getType();
+    clang::QualType to_type = varDecl->getType();
 
-    HandleTypeConversion(fromType, toType);
+    HandleTypeConversion(from_type, to_type);
     return true;
   }
 
@@ -93,9 +93,9 @@ public:
       os << "  " << c1 << ": " << c2 << "\n";
     }
 
-    for (const auto &funcName : functionOrder) {
-      os << "Function: " << funcName << "\n";
-      for (const auto &[c1, c2] : conversions[funcName]) {
+    for (const auto &func_name : function_order) {
+      os << "Function: " << func_name << "\n";
+      for (const auto &[c1, c2] : conversions[func_name]) {
         os << "  " << c1 << ": " << c2 << "\n";
       }
       os << "\n";
@@ -103,9 +103,9 @@ public:
   }
 
 private:
-  clang::ASTContext *Context;
-  std::string currentFunction = "global_scope";
-  std::vector<std::string> functionOrder;
+  clang::ASTContext *context;
+  std::string current_function = "global_scope";
+  std::vector<std::string> function_order;
   std::map<std::string, std::vector<std::pair<std::string, int>>> conversions;
 };
 

--- a/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
+++ b/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
@@ -12,8 +12,8 @@ namespace {
 class ImplicitConvVisitor final
     : public clang::RecursiveASTVisitor<ImplicitConvVisitor> {
 
-  void HandleTypeConversion(const clang::QualType &from_type,
-                            const clang::QualType &to_type) {
+  void HandleTypeConversion(const clang::QualType &from_type, // NOLINT
+                            const clang::QualType &to_type) { // NOLINT
     std::string from_type_str = from_type.getAsString();
     std::string to_type_str = to_type.getAsString();
 
@@ -41,7 +41,7 @@ public:
   explicit ImplicitConvVisitor(clang::ASTContext *astcontext)
       : context(astcontext) {}
 
-  bool VisitFunctionDecl(clang::FunctionDecl *func) {
+  bool VisitFunctionDecl(clang::FunctionDecl *func) { // NOLINT
     current_function = func->getNameInfo().getName().getAsString();
     if (conversions.find(current_function) == conversions.end()) {
       function_order.push_back(current_function);
@@ -49,7 +49,7 @@ public:
     return true;
   }
 
-  bool VisitCXXConstructExpr(clang::CXXConstructExpr *expr) {
+  bool VisitCXXConstructExpr(clang::CXXConstructExpr *expr) { // NOLINT
     if (expr->getNumArgs() == 1) {
       clang::QualType from_type = expr->getArg(0)->getType();
       clang::QualType to_type = expr->getType();
@@ -58,7 +58,7 @@ public:
     return true;
   }
 
-  bool VisitImplicitCastExpr(clang::ImplicitCastExpr *cast) {
+  bool VisitImplicitCastExpr(clang::ImplicitCastExpr *cast) { // NOLINT
     switch (cast->getCastKind()) {
     case clang::CK_NoOp:
     case clang::CK_LValueToRValue:
@@ -75,7 +75,7 @@ public:
     return true;
   }
 
-  bool VisitVarDecl(clang::VarDecl *varDecl) {
+  bool VisitVarDecl(clang::VarDecl *varDecl) { // NOLINT
     if (!current_function.empty())
       return true;
 
@@ -86,7 +86,7 @@ public:
     return true;
   }
 
-  void PrintResults() {
+  void PrintResults() { // NOLINT
     auto &os = llvm::outs();
 
     os << "In global scope:\n";
@@ -141,4 +141,3 @@ public:
 static clang::FrontendPluginRegistry::Add<ConversionAction>
     X("ImplicitConvPlugin", "Output the number of implicit conversions in the "
                             "entire file, including global scope");
-

--- a/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
+++ b/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
@@ -7,7 +7,6 @@
 #include <string>
 #include <vector>
 
-// NOLINTBEGIN(readability-identifier-naming)
 namespace {
 
 class ImplicitConvVisitor final
@@ -142,5 +141,4 @@ public:
 static clang::FrontendPluginRegistry::Add<ConversionAction>
     X("ImplicitConvPlugin", "Output the number of implicit conversions in the "
                             "entire file, including global scope");
-// NOLINTEND(readability-identifier-naming)
 

--- a/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
+++ b/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
@@ -59,13 +59,13 @@ public:
 
   bool VisitImplicitCastExpr(clang::ImplicitCastExpr *cast) {
     switch (cast->getCastKind()) {
-      case clang::CK_NoOp:
-      case clang::CK_LValueToRValue:
-      case clang::CK_FunctionToPointerDecay:
-      case clang::CK_ArrayToPointerDecay:
-        return true;
-      default:
-        break;
+    case clang::CK_NoOp:
+    case clang::CK_LValueToRValue:
+    case clang::CK_FunctionToPointerDecay:
+    case clang::CK_ArrayToPointerDecay:
+      return true;
+    default:
+      break;
     }    
 
     clang::QualType fromType = cast->getSubExpr()->getType();
@@ -75,7 +75,8 @@ public:
   }
 
   bool VisitVarDecl(clang::VarDecl *varDecl) {
-    if (!currentFunction.empty()) return true;
+    if (!currentFunction.empty())
+      return true;
 
     clang::QualType fromType = varDecl->getType();
     clang::QualType toType = varDecl->getType();
@@ -84,7 +85,7 @@ public:
     return true;
   }
 
-  void printResults() {
+  void PrintResults() {
     auto &os = llvm::outs();
 
     os << "In global scope:\n";
@@ -114,7 +115,7 @@ public:
 
   void HandleTranslationUnit(clang::ASTContext &context) override {
     Visitor.TraverseDecl(context.getTranslationUnitDecl());
-    Visitor.printResults();
+    Visitor.PrintResults();
   }
 
 private:
@@ -137,5 +138,5 @@ public:
 } // namespace
 
 static clang::FrontendPluginRegistry::Add<ConversionAction>
-    X("ImplicitConvPlugin",
-      "Output the number of implicit conversions in the entire file, including global scope");
+    X("ImplicitConvPlugin", "Output the number of implicit conversions in the "
+                            "entire file, including global scope");

--- a/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
+++ b/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
@@ -12,54 +12,53 @@ namespace {
 class ImplicitConvVisitor final
     : public clang::RecursiveASTVisitor<ImplicitConvVisitor> {
 
-  void HandleTypeConversion(const clang::QualType &from_type, // NOLINT
-                            const clang::QualType &to_type) { // NOLINT
-    std::string from_type_str = from_type.getAsString();
-    std::string to_type_str = to_type.getAsString();
+  void HandleTypeConversion(const clang::QualType &FromType,
+                            const clang::QualType &ToType) {
+    std::string FromTypeStr = FromType.getAsString();
+    std::string ToTypeStr = ToType.getAsString();
 
     // ради читаемости
-    from_type_str = (from_type_str == "_Bool") ? "bool" : from_type_str;
-    to_type_str = (to_type_str == "_Bool") ? "bool" : to_type_str;
+    FromTypeStr = (FromTypeStr == "_Bool") ? "bool" : FromTypeStr;
+    ToTypeStr = (ToTypeStr == "_Bool") ? "bool" : ToTypeStr;
 
-    if (from_type_str == to_type_str)
+    if (FromTypeStr == ToTypeStr)
       return;
 
-    std::string conversion = from_type_str + " -> " + to_type_str;
-    auto &conv_list = conversions[current_function];
+    std::string Conversion = FromTypeStr + " -> " + ToTypeStr;
+    auto &ConvList = Conversions[CurrentFunction];
 
-    for (auto &entry : conv_list) {
-      if (entry.first == conversion) {
+    for (auto &entry : ConvList) {
+      if (entry.first == Conversion) {
         entry.second++;
         return;
       }
     }
 
-    conv_list.push_back({conversion, 1});
+    ConvList.push_back({Conversion, 1});
   }
 
 public:
-  explicit ImplicitConvVisitor(clang::ASTContext *astcontext)
-      : context(astcontext) {}
+  explicit ImplicitConvVisitor(clang::ASTContext *Context) : Context(Context) {}
 
-  bool VisitFunctionDecl(clang::FunctionDecl *func) { // NOLINT
-    current_function = func->getNameInfo().getName().getAsString();
-    if (conversions.find(current_function) == conversions.end()) {
-      function_order.push_back(current_function);
+  bool VisitFunctionDecl(clang::FunctionDecl *Func) {
+    CurrentFunction = Func->getNameInfo().getName().getAsString();
+    if (Conversions.find(CurrentFunction) == Conversions.end()) {
+      FunctionOrder.push_back(CurrentFunction);
     }
     return true;
   }
 
-  bool VisitCXXConstructExpr(clang::CXXConstructExpr *expr) { // NOLINT
-    if (expr->getNumArgs() == 1) {
-      clang::QualType from_type = expr->getArg(0)->getType();
-      clang::QualType to_type = expr->getType();
-      HandleTypeConversion(from_type, to_type);
+  bool VisitCXXConstructExpr(clang::CXXConstructExpr *Expr) {
+    if (Expr->getNumArgs() == 1) {
+      clang::QualType FromType = Expr->getArg(0)->getType();
+      clang::QualType ToType = Expr->getType();
+      HandleTypeConversion(FromType, ToType);
     }
     return true;
   }
 
-  bool VisitImplicitCastExpr(clang::ImplicitCastExpr *cast) { // NOLINT
-    switch (cast->getCastKind()) {
+  bool VisitImplicitCastExpr(clang::ImplicitCastExpr *Cast) {
+    switch (Cast->getCastKind()) {
     case clang::CK_NoOp:
     case clang::CK_LValueToRValue:
     case clang::CK_FunctionToPointerDecay:
@@ -69,54 +68,54 @@ public:
       break;
     }
 
-    clang::QualType from_type = cast->getSubExpr()->getType();
-    clang::QualType to_type = cast->getType();
-    HandleTypeConversion(from_type, to_type);
+    clang::QualType FromType = Cast->getSubExpr()->getType();
+    clang::QualType ToType = Cast->getType();
+    HandleTypeConversion(FromType, ToType);
     return true;
   }
 
-  bool VisitVarDecl(clang::VarDecl *varDecl) { // NOLINT
-    if (!current_function.empty())
+  bool VisitVarDecl(clang::VarDecl *VarDecl) {
+    if (!CurrentFunction.empty())
       return true;
 
-    clang::QualType from_type = varDecl->getType();
-    clang::QualType to_type = varDecl->getType();
+    clang::QualType FromType = VarDecl->getType();
+    clang::QualType ToType = VarDecl->getType();
 
-    HandleTypeConversion(from_type, to_type);
+    HandleTypeConversion(FromType, ToType);
     return true;
   }
 
-  void PrintResults() { // NOLINT
-    auto &os = llvm::outs();
+  void printResults() {
+    auto &Os = llvm::outs();
 
-    os << "In global scope:\n";
-    for (const auto &[c1, c2] : conversions["global_scope"]) {
-      os << "  " << c1 << ": " << c2 << "\n";
+    Os << "In global scope:\n";
+    for (const auto &[c1, c2] : Conversions["global_scope"]) {
+      Os << "  " << c1 << ": " << c2 << "\n";
     }
 
-    for (const auto &func_name : function_order) {
-      os << "Function: " << func_name << "\n";
-      for (const auto &[c1, c2] : conversions[func_name]) {
-        os << "  " << c1 << ": " << c2 << "\n";
+    for (const auto &funcName : FunctionOrder) {
+      Os << "Function: " << funcName << "\n";
+      for (const auto &[c1, c2] : Conversions[funcName]) {
+        Os << "  " << c1 << ": " << c2 << "\n";
       }
-      os << "\n";
+      Os << "\n";
     }
   }
 
 private:
-  clang::ASTContext *context;
-  std::string current_function = "global_scope";
-  std::vector<std::string> function_order;
-  std::map<std::string, std::vector<std::pair<std::string, int>>> conversions;
+  clang::ASTContext *Context;
+  std::string CurrentFunction = "global_scope";
+  std::vector<std::string> FunctionOrder;
+  std::map<std::string, std::vector<std::pair<std::string, int>>> Conversions;
 };
 
 class ConversionConsumer final : public clang::ASTConsumer {
 public:
-  explicit ConversionConsumer(clang::ASTContext *context) : Visitor(context) {}
+  explicit ConversionConsumer(clang::ASTContext *Context) : Visitor(Context) {}
 
-  void HandleTranslationUnit(clang::ASTContext &context) override {
-    Visitor.TraverseDecl(context.getTranslationUnitDecl());
-    Visitor.PrintResults();
+  void HandleTranslationUnit(clang::ASTContext &Context) override {
+    Visitor.TraverseDecl(Context.getTranslationUnitDecl());
+    Visitor.printResults();
   }
 
 private:
@@ -126,12 +125,12 @@ private:
 class ConversionAction final : public clang::PluginASTAction {
 public:
   std::unique_ptr<clang::ASTConsumer>
-  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
-    return std::make_unique<ConversionConsumer>(&ci.getASTContext());
+  CreateASTConsumer(clang::CompilerInstance &Ci, llvm::StringRef) override {
+    return std::make_unique<ConversionConsumer>(&Ci.getASTContext());
   }
 
-  bool ParseArgs(const clang::CompilerInstance &ci,
-                 const std::vector<std::string> &args) override {
+  bool ParseArgs(const clang::CompilerInstance &Ci,
+                 const std::vector<std::string> &Args) override {
     return true;
   }
 };
@@ -139,5 +138,5 @@ public:
 } // namespace
 
 static clang::FrontendPluginRegistry::Add<ConversionAction>
-    X("ImplicitConvPlugin", "Output the number of implicit conversions in the "
+    X("ImplicitConvPlugin", "Output the number of implicit Conversions in the "
                             "entire file, including global scope");

--- a/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
+++ b/clang/compiler-course/khovansky_d_lab1/khovansky_d_lab1.cpp
@@ -38,8 +38,8 @@ class ImplicitConvVisitor final
   }
 
 public:
-  explicit ImplicitConvVisitor(clang::ASTContext *astcontext) :
-      context(astcontext) {}
+  explicit ImplicitConvVisitor(clang::ASTContext *astcontext)
+      : context(astcontext) {}
 
   bool VisitFunctionDecl(clang::FunctionDecl *func) {
     current_function = func->getNameInfo().getName().getAsString();

--- a/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
+++ b/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -load %llvmshlibdir/ImplicitConvPlugin_Khovansky_Dmitry_FIIT2_ClangAST%pluginext -plugin ImplicitConvPlugin -fsyntax-only %s 2>&1 | FileCheck %s
 
+// NOLINTBEGIN
 // Проверка глобального скоупа
 // CHECK: In global scope:
 // CHECK-NEXT: int -> double: 1
@@ -67,4 +68,6 @@ void pointer_test() {
   char* p = nullptr;
   void* vp = p;
 }
+// NOLINTEND
+
 

--- a/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
+++ b/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1 -load %llvmshlibdir/ImplicitConvPlugin_Khovansky_Dmitry_FIIT2_ClangAST%pluginext -plugin ImplicitConvPlugin -fsyntax-only %s 2>&1 | FileCheck %s
 
-// NOLINTBEGIN
 // Проверка глобального скоупа
 // CHECK: In global scope:
 // CHECK-NEXT: int -> double: 1
@@ -68,6 +67,5 @@ void pointer_test() {
   char* p = nullptr;
   void* vp = p;
 }
-// NOLINTEND
 
 

--- a/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
+++ b/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
@@ -63,11 +63,11 @@ bool make_bool() {
 // CHECK-NEXT: nullptr_t -> char *: 1
 // CHECK-NEXT: char * -> void *: 1
 
-// NOLINTBEGIN
-
 void pointer_test() {
   char* p = nullptr;
   void* vp = p;
 }
+
+// NOLINTBEGIN
 // NOLINTEND
 

--- a/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
+++ b/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
@@ -1,0 +1,69 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/ImplicitConvPlugin_Khovansky_Dmitry_FIIT2_ClangAST%pluginext -plugin ImplicitConvPlugin -fsyntax-only %s 2>&1 | FileCheck %s
+
+// Проверка глобального скоупа
+// CHECK: In global scope:
+// CHECK-NEXT: int -> double: 1
+double global_var = 42;
+
+// Проверка задач варианта
+// CHECK: Function: sum
+// CHECK-NEXT: float -> double: 1
+// CHECK-NEXT: int -> float: 1
+
+// CHECK: Function: mul
+// CHECK-NEXT: double -> int: 1
+// CHECK-NEXT: float -> double: 1
+// CHECK-NEXT: float -> int: 1
+
+double sum(int a, float b) {
+    return a + b;
+}
+
+int mul(float a, float b) {
+    return a + sum(a, b);
+}
+
+// Проверка обычной функции с несколькими преобразованиями
+// CHECK: Function: process
+// CHECK-NEXT: float -> double: 2
+// CHECK-NEXT: int -> float: 1
+// CHECK-NEXT: int -> bool: 1
+
+void process(float f) {
+  double d = f;
+  float x = 3;
+  bool flag = 10;
+  double k = f;
+}
+
+// Проверка конструктора с неявным преобразованием
+class Y {
+public:
+  Y(int val) {}
+};
+
+// CHECK: Function: construct_y
+// CHECK-NEXT: int -> Y: 1
+// CHECK-NEXT: double -> int: 1
+
+void construct_y() {
+  Y y = 5.6;
+}
+
+// Проверка return с преобразованием
+// CHECK: Function: make_bool
+// CHECK-NEXT: int -> bool: 1
+
+bool make_bool() {
+  return 100;
+}
+
+// Проверка указателей
+// CHECK: Function: pointer_test
+// CHECK-NEXT: nullptr_t -> char *: 1
+// CHECK-NEXT: char * -> void *: 1
+
+void pointer_test() {
+  char* p = nullptr;
+  void* vp = p;
+}

--- a/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
+++ b/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
@@ -1,10 +1,11 @@
 // RUN: %clang_cc1 -load %llvmshlibdir/ImplicitConvPlugin_Khovansky_Dmitry_FIIT2_ClangAST%pluginext -plugin ImplicitConvPlugin -fsyntax-only %s 2>&1 | FileCheck %s
 
-// NOLINTBEGIN
 // Проверка глобального скоупа
 // CHECK: In global scope:
 // CHECK-NEXT: int -> double: 1
 double global_par = 42;
+
+// NOLINTBEGIN
 
 // Проверка задач варианта
 // CHECK: Function: sum

--- a/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
+++ b/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
@@ -5,8 +5,6 @@
 // CHECK-NEXT: int -> double: 1
 double global_par = 42;
 
-// NOLINTBEGIN
-
 // Проверка задач варианта
 // CHECK: Function: sum
 // CHECK-NEXT: float -> double: 1
@@ -24,6 +22,8 @@ double sum(int a, float b) {
 int mul(float a, float b) {
     return a + sum(a, b);
 }
+
+// NOLINTBEGIN
 
 // Проверка обычной функции с несколькими преобразованиями
 // CHECK: Function: standart_func

--- a/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
+++ b/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
@@ -3,67 +3,54 @@
 // Проверка глобального скоупа
 // CHECK: In global scope:
 // CHECK-NEXT: int -> double: 1
-double global_par = 42;
+static double GlobalPar = 42;
 
 // Проверка задач варианта
-// CHECK: Function: sum
+// CHECK: Function: Sum
 // CHECK-NEXT: float -> double: 1
 // CHECK-NEXT: int -> float: 1
 
-// CHECK: Function: mul
+// CHECK: Function: Mul
 // CHECK-NEXT: double -> int: 1
 // CHECK-NEXT: float -> double: 1
 // CHECK-NEXT: float -> int: 1
 
-double sum(int a, float b) {
-    return a + b;
+static double Sum(int A, float B) {
+    return A + B;
 }
 
-int mul(float a, float b) {
-    return a + sum(a, b);
+static int Mul(float A, float B) {
+    return A + Sum(A, B);
 }
 
 // Проверка обычной функции с несколькими преобразованиями
-// CHECK: Function: standart_func
+// CHECK: Function: StandartFunc
 // CHECK-NEXT: float -> double: 2
 // CHECK-NEXT: int -> float: 1
 // CHECK-NEXT: int -> bool: 1
 
-void standart_func(float f) {
-  double d = f;
-  float x = 3;
-  bool flag = 10;
-  double k = f;
-}
-
-// Проверка конструктора с неявным преобразованием
-class U {
-public:
-  U(int val) {}
-};
-
-// CHECK: Function: construct_u
-// CHECK-NEXT: int -> U: 1
-// CHECK-NEXT: double -> int: 1
-
-void construct_u() {
-  U u = 5.6;
+static void StandartFunc(float F) {
+    double D = F;
+    float X = 3;
+    bool Flag = 10;
+    double K = F;
 }
 
 // Проверка return с преобразованием
-// CHECK: Function: make_bool
+// CHECK: Function: MakeBool
 // CHECK-NEXT: int -> bool: 1
 
-bool make_bool() {
-  return 100;
+static bool MakeBool() {
+    return 100;
 }
 
 // Проверка указателей
-// CHECK: Function: pointer_test
+// CHECK: Function: PointerTest
 // CHECK-NEXT: nullptr_t -> char *: 1
 // CHECK-NEXT: char * -> void *: 1
 
-void pointer_test() {
-  char* p = nullptr;
-  void* vp = p;
+static void PointerTest() {
+    char* P = nullptr;
+    void* Vp = P;
 }
+

--- a/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
+++ b/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
@@ -67,4 +67,5 @@ void pointer_test() {
   char* p = nullptr;
   void* vp = p;
 }
+// NOLIT
 

--- a/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
+++ b/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
@@ -67,5 +67,5 @@ void pointer_test() {
   char* p = nullptr;
   void* vp = p;
 }
-// NOLIT
+//
 

--- a/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
+++ b/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
@@ -54,8 +54,6 @@ void construct_u() {
 // CHECK: Function: make_bool
 // CHECK-NEXT: int -> bool: 1
 
-// NOLINTBEGIN
-
 bool make_bool() {
   return 100;
 }
@@ -64,6 +62,8 @@ bool make_bool() {
 // CHECK: Function: pointer_test
 // CHECK-NEXT: nullptr_t -> char *: 1
 // CHECK-NEXT: char * -> void *: 1
+
+// NOLINTBEGIN
 
 void pointer_test() {
   char* p = nullptr;

--- a/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
+++ b/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
@@ -3,33 +3,33 @@
 // Проверка глобального скоупа
 // CHECK: In global scope:
 // CHECK-NEXT: int -> double: 1
-double global_var = 42;
+double global_par = 42;
 
 // Проверка задач варианта
-// CHECK: Function: sum
+// CHECK: Function: sum1
 // CHECK-NEXT: float -> double: 1
 // CHECK-NEXT: int -> float: 1
 
-// CHECK: Function: mul
+// CHECK: Function: mul1
 // CHECK-NEXT: double -> int: 1
 // CHECK-NEXT: float -> double: 1
 // CHECK-NEXT: float -> int: 1
 
-double sum(int a, float b) {
+double sum1(int a, float b) {
     return a + b;
 }
 
-int mul(float a, float b) {
-    return a + sum(a, b);
+int mul1(float a, float b) {
+    return a + sum1(a, b);
 }
 
 // Проверка обычной функции с несколькими преобразованиями
-// CHECK: Function: process
+// CHECK: Function: standart_func
 // CHECK-NEXT: float -> double: 2
 // CHECK-NEXT: int -> float: 1
 // CHECK-NEXT: int -> bool: 1
 
-void process(float f) {
+void standart_func(float f) {
   double d = f;
   float x = 3;
   bool flag = 10;
@@ -37,33 +37,33 @@ void process(float f) {
 }
 
 // Проверка конструктора с неявным преобразованием
-class Y {
+class U {
 public:
-  Y(int val) {}
+  U(int val) {}
 };
 
-// CHECK: Function: construct_y
-// CHECK-NEXT: int -> Y: 1
+// CHECK: Function: construct_u
+// CHECK-NEXT: int -> U: 1
 // CHECK-NEXT: double -> int: 1
 
-void construct_y() {
-  Y y = 5.6;
+void construct_u() {
+  U u = 5.6;
 }
 
 // Проверка return с преобразованием
-// CHECK: Function: make_bool
+// CHECK: Function: make_bool1
 // CHECK-NEXT: int -> bool: 1
 
-bool make_bool() {
+bool make_bool1() {
   return 100;
 }
 
 // Проверка указателей
-// CHECK: Function: pointer_test
+// CHECK: Function: pointer_test1
 // CHECK-NEXT: nullptr_t -> char *: 1
 // CHECK-NEXT: char * -> void *: 1
 
-void pointer_test() {
+void pointer_test1() {
   char* p = nullptr;
   void* vp = p;
 }

--- a/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
+++ b/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
@@ -23,8 +23,6 @@ int mul(float a, float b) {
     return a + sum(a, b);
 }
 
-// NOLINTBEGIN
-
 // Проверка обычной функции с несколькими преобразованиями
 // CHECK: Function: standart_func
 // CHECK-NEXT: float -> double: 2
@@ -55,6 +53,8 @@ void construct_u() {
 // Проверка return с преобразованием
 // CHECK: Function: make_bool
 // CHECK-NEXT: int -> bool: 1
+
+// NOLINTBEGIN
 
 bool make_bool() {
   return 100;

--- a/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
+++ b/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -load %llvmshlibdir/ImplicitConvPlugin_Khovansky_Dmitry_FIIT2_ClangAST%pluginext -plugin ImplicitConvPlugin -fsyntax-only %s 2>&1 | FileCheck %s
 
+// NOLINTBEGIN
 // Проверка глобального скоупа
 // CHECK: In global scope:
 // CHECK-NEXT: int -> double: 1
@@ -67,4 +68,5 @@ void pointer_test() {
   char* p = nullptr;
   void* vp = p;
 }
+// NOLINTEND
 

--- a/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
+++ b/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
@@ -6,21 +6,21 @@
 double global_par = 42;
 
 // Проверка задач варианта
-// CHECK: Function: sum1
+// CHECK: Function: sum
 // CHECK-NEXT: float -> double: 1
 // CHECK-NEXT: int -> float: 1
 
-// CHECK: Function: mul1
+// CHECK: Function: mul
 // CHECK-NEXT: double -> int: 1
 // CHECK-NEXT: float -> double: 1
 // CHECK-NEXT: float -> int: 1
 
-double sum1(int a, float b) {
+double sum(int a, float b) {
     return a + b;
 }
 
-int mul1(float a, float b) {
-    return a + sum1(a, b);
+int mul(float a, float b) {
+    return a + sum(a, b);
 }
 
 // Проверка обычной функции с несколькими преобразованиями
@@ -51,19 +51,19 @@ void construct_u() {
 }
 
 // Проверка return с преобразованием
-// CHECK: Function: make_bool1
+// CHECK: Function: make_bool
 // CHECK-NEXT: int -> bool: 1
 
-bool make_bool1() {
+bool make_bool() {
   return 100;
 }
 
 // Проверка указателей
-// CHECK: Function: pointer_test1
+// CHECK: Function: pointer_test
 // CHECK-NEXT: nullptr_t -> char *: 1
 // CHECK-NEXT: char * -> void *: 1
 
-void pointer_test1() {
+void pointer_test() {
   char* p = nullptr;
   void* vp = p;
 }

--- a/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
+++ b/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
@@ -68,6 +68,3 @@ void pointer_test() {
   void* vp = p;
 }
 
-// NOLINTBEGIN
-// NOLINTEND
-

--- a/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
+++ b/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
@@ -68,4 +68,3 @@ void pointer_test() {
   void* vp = p;
 }
 
-

--- a/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
+++ b/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
@@ -3,54 +3,68 @@
 // Проверка глобального скоупа
 // CHECK: In global scope:
 // CHECK-NEXT: int -> double: 1
-static double GlobalPar = 42;
+double global_par = 42;
 
 // Проверка задач варианта
-// CHECK: Function: Sum
+// CHECK: Function: sum
 // CHECK-NEXT: float -> double: 1
 // CHECK-NEXT: int -> float: 1
 
-// CHECK: Function: Mul
+// CHECK: Function: mul
 // CHECK-NEXT: double -> int: 1
 // CHECK-NEXT: float -> double: 1
 // CHECK-NEXT: float -> int: 1
 
-static double Sum(int A, float B) {
-    return A + B;
+double sum(int a, float b) {
+    return a + b;
 }
 
-static int Mul(float A, float B) {
-    return A + Sum(A, B);
+int mul(float a, float b) {
+    return a + sum(a, b);
 }
 
 // Проверка обычной функции с несколькими преобразованиями
-// CHECK: Function: StandartFunc
+// CHECK: Function: standart_func
 // CHECK-NEXT: float -> double: 2
 // CHECK-NEXT: int -> float: 1
 // CHECK-NEXT: int -> bool: 1
 
-static void StandartFunc(float F) {
-    double D = F;
-    float X = 3;
-    bool Flag = 10;
-    double K = F;
+void standart_func(float f) {
+  double d = f;
+  float x = 3;
+  bool flag = 10;
+  double k = f;
+}
+
+// Проверка конструктора с неявным преобразованием
+class U {
+public:
+  U(int val) {}
+};
+
+// CHECK: Function: construct_u
+// CHECK-NEXT: int -> U: 1
+// CHECK-NEXT: double -> int: 1
+
+void construct_u() {
+  U u = 5.6;
 }
 
 // Проверка return с преобразованием
-// CHECK: Function: MakeBool
+// CHECK: Function: make_bool
 // CHECK-NEXT: int -> bool: 1
 
-static bool MakeBool() {
-    return 100;
+bool make_bool() {
+  return 100;
 }
 
 // Проверка указателей
-// CHECK: Function: PointerTest
+// CHECK: Function: pointer_test
 // CHECK-NEXT: nullptr_t -> char *: 1
 // CHECK-NEXT: char * -> void *: 1
 
-static void PointerTest() {
-    char* P = nullptr;
-    void* Vp = P;
+void pointer_test() {
+  char* p = nullptr;
+  void* vp = p;
 }
 

--- a/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
+++ b/clang/test/compiler-course/khovansky_d_lab1_test/khovansky_d_lab1_test.cpp
@@ -67,5 +67,37 @@ void pointer_test() {
   char* p = nullptr;
   void* vp = p;
 }
+
+// Проверка неявного преобразования через пользовательский конструктор
+class X {
+public:
+  X(int x) {}
+};
+
+// CHECK: Function: create_x
+// CHECK-NEXT: int -> X: 1
+
+void create_x() {
+  X obj = 10;
+}
+
+// Несколько преобразований
+// CHECK: Function: create_x_chain
+// CHECK-NEXT: int -> X: 1
+// CHECK-NEXT: double -> int: 1
+
+void create_x_chain() {
+  X obj = 5.5;
+}
+
+// Неявный вызов конструктора в параметрах функции
+void takes_x(X x) {}
+
+// CHECK: Function: call_takes_x
+// CHECK-NEXT: int -> X: 1
+
+void call_takes_x() {
+  takes_x(7);
+}
 //
 


### PR DESCRIPTION
Clang-плагин ImplicitConvPlugin реализует класс ImplicitConvVisitor, унаследованный от RecursiveASTVisitor, и выполняет обход AST, выявляя случаи неявного преобразования типов. В классе ImplicitConvVisitor реализованы методы:

VisitFunctionDecl — получает имя текущей функции и сохраняет его для привязки найденных преобразований к соответствующему имени;

VisitCXXConstructExpr — фиксирует преобразования типов при передаче аргумента в конструктор с одним параметром;

VisitImplicitCastExpr — анализирует неявные преобразования (игнорирует LValueToRValue, FunctionToPointerDecay и подобные "мусорные" приведения);

VisitVarDecl — анализирует преобразования в глобальной области до начала функций;

PrintResults — выводит собранную статистику в стандартный поток вывода.