### PR TITLE
Кошкин Никита. Лабораторная работа 1. Clang AST. Вариант 2

### DIFF
--- a/clang/compiler-course/koshkin_n_ast/CMakeLists.txt
+++ b/clang/compiler-course/koshkin_n_ast/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "MaybeUnused")
+set(Student "Koshkin_Nikita")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/koshkin_n_ast/koshkin_n_ast.cpp
+++ b/clang/compiler-course/koshkin_n_ast/koshkin_n_ast.cpp
@@ -9,19 +9,18 @@
 using namespace clang;
 
 namespace {
-
 class MaybeUnusedVisitor final
-    : public RecursiveASTVisitor<MaybeUnusedVisitor> {
+    : public clang::RecursiveASTVisitor<MaybeUnusedVisitor> {
 public:
-  explicit MaybeUnusedVisitor(ASTContext *Context, Rewriter &R)
-      : Context(Context), TheRewriter(R) {}
+  explicit MaybeUnusedVisitor(clang::ASTContext *context, Rewriter &Rewrite)
+      : m_context(context), TheRewriter(Rewrite) {}
 
   bool VisitFunctionDecl(FunctionDecl *FD) {
     if (!FD->hasBody() || FD->isImplicit())
       return true;
 
-    for (unsigned I = 0, N = FD->getNumParams(); I < N; ++I) {
-      ParmVarDecl *PVD = FD->getParamDecl(I);
+    for (unsigned i = 0, N = FD->getNumParams(); i < N; ++i) {
+      ParmVarDecl *PVD = FD->getParamDecl(i);
       if (PVD && PVD->getName() == "unused" && !PVD->hasAttr<UnusedAttr>()) {
         SourceLocation Loc = PVD->getBeginLoc();
         if (Loc.isValid())
@@ -31,15 +30,15 @@ public:
       }
     }
 
-    Stmt *Body = FD->getBody();
-    if (Body)
-      ProcessLocalVars(Body);
+    Stmt *FuncBody = FD->getBody();
+    if (FuncBody)
+      processLocalVars(FuncBody);
 
     return true;
   }
 
 private:
-  void ProcessLocalVars(Stmt *S) {
+  void processLocalVars(Stmt *S) {
     if (!S)
       return;
 
@@ -50,63 +49,57 @@ private:
               VD->getName() == "unused" && !VD->hasAttr<UnusedAttr>()) {
             SourceLocation Loc = VD->getBeginLoc();
             if (Loc.isValid())
-              TheRewriter.InsertText(Loc, "[[maybe_unused]] ",
-                                     /*InsertBefore=*/true,
-                                     /*IndentNewLines=*/false);
+              TheRewriter.InsertText(Loc, "[[maybe_unused]] ", true, true);
           }
         }
       }
     }
-
-    for (Stmt *Child : S->children())
-      ProcessLocalVars(Child);
+    for (Stmt *Child : S->children()) {
+      processLocalVars(Child);
+    }
   }
 
-  ASTContext *Context;
-  Rewriter &TheRewriter;
+  clang::ASTContext *m_context;
+  clang::Rewriter &TheRewriter;
 };
 
-class MaybeUnusedConsumer final : public ASTConsumer {
+class MaybeUnusedConsumer final : public clang::ASTConsumer {
 public:
-  explicit MaybeUnusedConsumer(ASTContext *Context, Rewriter &R)
-      : Visitor(Context, R) {}
+  explicit MaybeUnusedConsumer(clang::ASTContext *context, Rewriter &Rewrite)
+      : Visitor(context, Rewrite) {}
 
-  void HandleTranslationUnit(ASTContext &Context) override {
-    Visitor.TraverseDecl(Context.getTranslationUnitDecl());
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    Visitor.TraverseDecl(context.getTranslationUnitDecl());
   }
 
 private:
   MaybeUnusedVisitor Visitor;
 };
 
-class MaybeUnusedAction final : public PluginASTAction {
+class MaybeUnusedAction final : public clang::PluginASTAction {
 public:
-  std::unique_ptr<ASTConsumer>
-  CreateASTConsumer(CompilerInstance &CI,
-                    llvm::StringRef) override {
-    TheRewriter.setSourceMgr(CI.getSourceManager(), CI.getLangOpts());
-    return std::make_unique<MaybeUnusedConsumer>(&CI.getASTContext(),
-                                                TheRewriter);
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    TheRewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
+    return std::make_unique<MaybeUnusedConsumer>(&ci.getASTContext(),
+                                                 TheRewriter);
   }
 
-  bool ParseArgs(const CompilerInstance &CI,
-                 const std::vector<std::string> &Args) override {
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
     return true;
   }
 
   void EndSourceFileAction() override {
-    const auto &SM = TheRewriter.getSourceMgr();
-    TheRewriter.getEditBuffer(SM.getMainFileID())
-        .write(llvm::outs());
+    auto &SM = TheRewriter.getSourceMgr();
+    TheRewriter.getEditBuffer(SM.getMainFileID()).write(llvm::outs());
   }
 
 private:
   Rewriter TheRewriter;
 };
-
 } // namespace
 
-static FrontendPluginRegistry::Add<MaybeUnusedAction>
+static clang::FrontendPluginRegistry::Add<MaybeUnusedAction>
     X("koshkin_n_MaybeUnused_plugin",
       "Marks unused parameters/variables with [[maybe_unused]] attribute");
-

--- a/clang/compiler-course/koshkin_n_ast/koshkin_n_ast.cpp
+++ b/clang/compiler-course/koshkin_n_ast/koshkin_n_ast.cpp
@@ -15,50 +15,26 @@ public:
   explicit MaybeUnusedVisitor(clang::ASTContext *context, Rewriter &Rewrite)
       : m_context(context), TheRewriter(Rewrite) {}
 
-  bool VisitFunctionDecl(FunctionDecl *FD) {
-    if (!FD->hasBody() || FD->isImplicit())
-      return true;
-
-    for (unsigned i = 0, N = FD->getNumParams(); i < N; ++i) {
-      ParmVarDecl *PVD = FD->getParamDecl(i);
-      if (PVD && PVD->getName() == "unused" && !PVD->hasAttr<UnusedAttr>()) {
-        SourceLocation Loc = PVD->getBeginLoc();
-        if (Loc.isValid())
-          TheRewriter.InsertText(Loc, "[[maybe_unused]] ",
-                                 /*InsertBefore=*/true,
-                                 /*IndentNewLines=*/true);
-      }
+  bool VisitParmVarDecl(ParmVarDecl *pvd) {
+    if (!pvd->isUsed(/*CheckUsedAttr=*/true)) {
+      SourceLocation sc = pvd->getBeginLoc();
+      if (sc.isValid())
+        TheRewriter.InsertText(sc, "[[maybe_unused]] ", true, true);
     }
+    return true;
+  }
 
-    Stmt *FuncBody = FD->getBody();
-    if (FuncBody)
-      processLocalVars(FuncBody);
-
+  bool VisitVarDecl(VarDecl *vd) {
+    if (vd->isLocalVarDecl() && !vd->isImplicit() &&
+        !vd->isUsed(/*CheckUsedAttr=*/true)) {
+      SourceLocation sc = vd->getBeginLoc();
+      if (sc.isValid())
+        TheRewriter.InsertText(sc, "[[maybe_unused]] ", true, true);
+    }
     return true;
   }
 
 private:
-  void processLocalVars(Stmt *S) {
-    if (!S)
-      return;
-
-    if (auto *DS = dyn_cast<DeclStmt>(S)) {
-      for (auto *D : DS->decls()) {
-        if (auto *VD = dyn_cast<VarDecl>(D)) {
-          if (VD->isLocalVarDecl() && !VD->isImplicit() &&
-              VD->getName() == "unused" && !VD->hasAttr<UnusedAttr>()) {
-            SourceLocation Loc = VD->getBeginLoc();
-            if (Loc.isValid())
-              TheRewriter.InsertText(Loc, "[[maybe_unused]] ", true, true);
-          }
-        }
-      }
-    }
-    for (Stmt *Child : S->children()) {
-      processLocalVars(Child);
-    }
-  }
-
   clang::ASTContext *m_context;
   clang::Rewriter &TheRewriter;
 };

--- a/clang/compiler-course/koshkin_n_ast/koshkin_n_ast.cpp
+++ b/clang/compiler-course/koshkin_n_ast/koshkin_n_ast.cpp
@@ -12,7 +12,8 @@ namespace {
 class MaybeUnusedVisitor final
     : public clang::RecursiveASTVisitor<MaybeUnusedVisitor> {
 public:
-  explicit MaybeUnusedVisitor(clang::ASTContext *context, Rewriter &Rewrite)
+  explicit MaybeUnusedVisitor(clang::ASTContext *context,
+                              clang::Rewriter &Rewrite)
       : m_context(context), TheRewriter(Rewrite) {}
 
   bool VisitParmVarDecl(ParmVarDecl *pvd) {
@@ -25,8 +26,9 @@ public:
   }
 
   bool VisitVarDecl(VarDecl *vd) {
-    if (vd->isLocalVarDecl() && !vd->isImplicit() &&
-        !vd->isUsed(/*CheckUsedAttr=*/true)) {
+    if (isa<ParmVarDecl>(vd))
+      return true;
+    if (!vd->isImplicit() && !vd->isUsed(/*CheckUsedAttr=*/true)) {
       SourceLocation sc = vd->getBeginLoc();
       if (sc.isValid())
         TheRewriter.InsertText(sc, "[[maybe_unused]] ", true, true);
@@ -68,11 +70,12 @@ public:
 
   void EndSourceFileAction() override {
     auto &SM = TheRewriter.getSourceMgr();
-    TheRewriter.getEditBuffer(SM.getMainFileID()).write(llvm::outs());
+    auto FID = SM.getMainFileID();
+    TheRewriter.getEditBuffer(FID).write(llvm::outs());
   }
 
 private:
-  Rewriter TheRewriter;
+  clang::Rewriter TheRewriter;
 };
 } // namespace
 

--- a/clang/compiler-course/koshkin_n_ast/koshkin_n_ast.cpp
+++ b/clang/compiler-course/koshkin_n_ast/koshkin_n_ast.cpp
@@ -1,6 +1,6 @@
 #include "clang/AST/ASTConsumer.h"
-#include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Attr.h"
+#include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
 #include "clang/Rewrite/Core/Rewriter.h"
@@ -9,91 +9,104 @@
 using namespace clang;
 
 namespace {
-	class MaybeUnusedVisitor final : public clang::RecursiveASTVisitor<MaybeUnusedVisitor> {
-	public:
-		explicit MaybeUnusedVisitor(clang::ASTContext* context, Rewriter& Rewrite) : m_context(context), TheRewriter(Rewrite) {}
 
-		bool VisitFunctionDecl(FunctionDecl* FD) {
-			if (!FD->hasBody() || FD->isImplicit())
-				return true;
+class MaybeUnusedVisitor final
+    : public RecursiveASTVisitor<MaybeUnusedVisitor> {
+public:
+  explicit MaybeUnusedVisitor(ASTContext *Context, Rewriter &R)
+      : Context(Context), TheRewriter(R) {}
 
-			for (unsigned i = 0, N = FD->getNumParams(); i < N; ++i) {
-				ParmVarDecl* PVD = FD->getParamDecl(i);
-				if (PVD && PVD->getName() == "unused" &&
-					!PVD->hasAttr<UnusedAttr>()) {
-					SourceLocation Loc = PVD->getBeginLoc();
-					if (Loc.isValid())
-						TheRewriter.InsertText(Loc, "[[maybe_unused]] ", /*InsertBefore=*/true, /*IndentNewLines=*/true);
-				}
-			}
+  bool VisitFunctionDecl(FunctionDecl *FD) {
+    if (!FD->hasBody() || FD->isImplicit())
+      return true;
 
-			Stmt* FuncBody = FD->getBody();
-			if (FuncBody)
-				processLocalVars(FuncBody);
+    for (unsigned I = 0, N = FD->getNumParams(); I < N; ++I) {
+      ParmVarDecl *PVD = FD->getParamDecl(I);
+      if (PVD && PVD->getName() == "unused" && !PVD->hasAttr<UnusedAttr>()) {
+        SourceLocation Loc = PVD->getBeginLoc();
+        if (Loc.isValid())
+          TheRewriter.InsertText(Loc, "[[maybe_unused]] ",
+                                 /*InsertBefore=*/true,
+                                 /*IndentNewLines=*/true);
+      }
+    }
 
-			return true;
-		}
+    Stmt *Body = FD->getBody();
+    if (Body)
+      ProcessLocalVars(Body);
 
-	private:
-		void processLocalVars(Stmt* S) {
-			if (!S) 
-				return;
+    return true;
+  }
 
-			if (auto* DS = dyn_cast<DeclStmt>(S)) {
-				for (auto* D : DS->decls()) {
-					if (auto* VD = dyn_cast<VarDecl>(D)) {
-						if (VD->isLocalVarDecl() && !VD->isImplicit() &&
-							VD->getName() == "unused" &&
-							!VD->hasAttr<UnusedAttr>()) {
-							SourceLocation Loc = VD->getBeginLoc();
-							if (Loc.isValid())
-								TheRewriter.InsertText(Loc, "[[maybe_unused]] ", true, true);
-						}
-					}
-				}
-			}
-			for (Stmt* Child : S->children()) {
-				processLocalVars(Child);
-			}
-		}
+private:
+  void ProcessLocalVars(Stmt *S) {
+    if (!S)
+      return;
 
-		clang::ASTContext *m_context;
-		clang::Rewriter& TheRewriter;
-	};
+    if (auto *DS = dyn_cast<DeclStmt>(S)) {
+      for (auto *D : DS->decls()) {
+        if (auto *VD = dyn_cast<VarDecl>(D)) {
+          if (VD->isLocalVarDecl() && !VD->isImplicit() &&
+              VD->getName() == "unused" && !VD->hasAttr<UnusedAttr>()) {
+            SourceLocation Loc = VD->getBeginLoc();
+            if (Loc.isValid())
+              TheRewriter.InsertText(Loc, "[[maybe_unused]] ",
+                                     /*InsertBefore=*/true,
+                                     /*IndentNewLines=*/false);
+          }
+        }
+      }
+    }
 
-	class MaybeUnusedConsumer final : public clang::ASTConsumer {
-	public:
-		explicit MaybeUnusedConsumer(clang::ASTContext* context, Rewriter& Rewrite) : Visitor(context, Rewrite) {}
+    for (Stmt *Child : S->children())
+      ProcessLocalVars(Child);
+  }
 
-		void HandleTranslationUnit(clang::ASTContext& context) override {
-			Visitor.TraverseDecl(context.getTranslationUnitDecl());
-		}
+  ASTContext *Context;
+  Rewriter &TheRewriter;
+};
 
-	private:
-		MaybeUnusedVisitor Visitor;
-	};
+class MaybeUnusedConsumer final : public ASTConsumer {
+public:
+  explicit MaybeUnusedConsumer(ASTContext *Context, Rewriter &R)
+      : Visitor(Context, R) {}
 
-	class MaybeUnusedAction final : public clang::PluginASTAction {
-	public:
-		std::unique_ptr<clang::ASTConsumer>
-			CreateASTConsumer(clang::CompilerInstance& ci, llvm::StringRef) override {
-			TheRewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
-			return std::make_unique<MaybeUnusedConsumer>(&ci.getASTContext(), TheRewriter);
-		}
+  void HandleTranslationUnit(ASTContext &Context) override {
+    Visitor.TraverseDecl(Context.getTranslationUnitDecl());
+  }
 
-		bool ParseArgs(const clang::CompilerInstance& ci,
-			const std::vector<std::string>& args) override {
-			return true;
-		}
+private:
+  MaybeUnusedVisitor Visitor;
+};
 
-		void EndSourceFileAction() override {
-			auto& SM = TheRewriter.getSourceMgr();
-			TheRewriter.getEditBuffer(SM.getMainFileID()).write(llvm::outs());
-		}
-	private:
-		Rewriter TheRewriter;
-	};
+class MaybeUnusedAction final : public PluginASTAction {
+public:
+  std::unique_ptr<ASTConsumer>
+  CreateASTConsumer(CompilerInstance &CI,
+                    llvm::StringRef) override {
+    TheRewriter.setSourceMgr(CI.getSourceManager(), CI.getLangOpts());
+    return std::make_unique<MaybeUnusedConsumer>(&CI.getASTContext(),
+                                                TheRewriter);
+  }
+
+  bool ParseArgs(const CompilerInstance &CI,
+                 const std::vector<std::string> &Args) override {
+    return true;
+  }
+
+  void EndSourceFileAction() override {
+    const auto &SM = TheRewriter.getSourceMgr();
+    TheRewriter.getEditBuffer(SM.getMainFileID())
+        .write(llvm::outs());
+  }
+
+private:
+  Rewriter TheRewriter;
+};
+
 } // namespace
 
-static clang::FrontendPluginRegistry::Add<MaybeUnusedAction>
-X("koshkin_n_MaybeUnused_plugin", "Marks unused parameters/variables with [[maybe_unused]] attribute");
+static FrontendPluginRegistry::Add<MaybeUnusedAction>
+    X("koshkin_n_MaybeUnused_plugin",
+      "Marks unused parameters/variables with [[maybe_unused]] attribute");
+

--- a/clang/compiler-course/koshkin_n_ast/koshkin_n_ast.cpp
+++ b/clang/compiler-course/koshkin_n_ast/koshkin_n_ast.cpp
@@ -1,0 +1,99 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/Attr.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace clang;
+
+namespace {
+	class MaybeUnusedVisitor final : public clang::RecursiveASTVisitor<MaybeUnusedVisitor> {
+	public:
+		explicit MaybeUnusedVisitor(clang::ASTContext* context, Rewriter& Rewrite) : m_context(context), TheRewriter(Rewrite) {}
+
+		bool VisitFunctionDecl(FunctionDecl* FD) {
+			if (!FD->hasBody() || FD->isImplicit())
+				return true;
+
+			for (unsigned i = 0, N = FD->getNumParams(); i < N; ++i) {
+				ParmVarDecl* PVD = FD->getParamDecl(i);
+				if (PVD && PVD->getName() == "unused" &&
+					!PVD->hasAttr<UnusedAttr>()) {
+					SourceLocation Loc = PVD->getBeginLoc();
+					if (Loc.isValid())
+						TheRewriter.InsertText(Loc, "[[maybe_unused]] ", /*InsertBefore=*/true, /*IndentNewLines=*/true);
+				}
+			}
+
+			Stmt* FuncBody = FD->getBody();
+			if (FuncBody)
+				processLocalVars(FuncBody);
+
+			return true;
+		}
+
+	private:
+		void processLocalVars(Stmt* S) {
+			if (!S) 
+				return;
+
+			if (auto* DS = dyn_cast<DeclStmt>(S)) {
+				for (auto* D : DS->decls()) {
+					if (auto* VD = dyn_cast<VarDecl>(D)) {
+						if (VD->isLocalVarDecl() && !VD->isImplicit() &&
+							VD->getName() == "unused" &&
+							!VD->hasAttr<UnusedAttr>()) {
+							SourceLocation Loc = VD->getBeginLoc();
+							if (Loc.isValid())
+								TheRewriter.InsertText(Loc, "[[maybe_unused]] ", true, true);
+						}
+					}
+				}
+			}
+			for (Stmt* Child : S->children()) {
+				processLocalVars(Child);
+			}
+		}
+
+		clang::ASTContext *m_context;
+		clang::Rewriter& TheRewriter;
+	};
+
+	class MaybeUnusedConsumer final : public clang::ASTConsumer {
+	public:
+		explicit MaybeUnusedConsumer(clang::ASTContext* context, Rewriter& Rewrite) : Visitor(context, Rewrite) {}
+
+		void HandleTranslationUnit(clang::ASTContext& context) override {
+			Visitor.TraverseDecl(context.getTranslationUnitDecl());
+		}
+
+	private:
+		MaybeUnusedVisitor Visitor;
+	};
+
+	class MaybeUnusedAction final : public clang::PluginASTAction {
+	public:
+		std::unique_ptr<clang::ASTConsumer>
+			CreateASTConsumer(clang::CompilerInstance& ci, llvm::StringRef) override {
+			TheRewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
+			return std::make_unique<MaybeUnusedConsumer>(&ci.getASTContext(), TheRewriter);
+		}
+
+		bool ParseArgs(const clang::CompilerInstance& ci,
+			const std::vector<std::string>& args) override {
+			return true;
+		}
+
+		void EndSourceFileAction() override {
+			auto& SM = TheRewriter.getSourceMgr();
+			TheRewriter.getEditBuffer(SM.getMainFileID()).write(llvm::outs());
+		}
+	private:
+		Rewriter TheRewriter;
+	};
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<MaybeUnusedAction>
+X("koshkin_n_MaybeUnused_plugin", "Marks unused parameters/variables with [[maybe_unused]] attribute");

--- a/clang/test/compiler-course/koshkin_n_ast_test/koshkin_n_ast_test.cpp
+++ b/clang/test/compiler-course/koshkin_n_ast_test/koshkin_n_ast_test.cpp
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/MaybeUnused_Koshkin_Nikita_FIIT3_ClangAST%pluginext -plugin koshkin_n_MaybeUnused_plugin 2>&1 | FileCheck %s --help
+// CHECK:This plugin marks unused variables with \[\[maybe_unused\]\] attribute
+
+// RUN: %clang_cc1 -load %llvmshlibdir/MaybeUnused_Koshkin_Nikita_FIIT3_ClangAST%pluginext -plugin koshkin_n_MaybeUnused_plugin -fsyntax-only %s 2>&1 | FileCheck %s 
+
+// CHECK: int foo(int a, int b, \[\[maybe_unused\]\] int c) {
+// CHECK: \[\[maybe_unused\]\] double value = 0.0;
+// CHECK:   return a + b;
+int foo(int a, int b, int c) {
+	double value = 0.0;
+    return a + b;
+}
+
+// CHECK: \[\[maybe_unused\]\] int notusd=999;
+int notusd=999;
+
+// CHECK: \[\[maybe_unused\]\] double notusd2=2.42;
+double notusd2=2.42;

--- a/clang/test/compiler-course/koshkin_n_ast_test/koshkin_n_ast_test.cpp
+++ b/clang/test/compiler-course/koshkin_n_ast_test/koshkin_n_ast_test.cpp
@@ -1,18 +1,34 @@
-// RUN: %clang_cc1 -load %llvmshlibdir/MaybeUnused_Koshkin_Nikita_FIIT3_ClangAST%pluginext -plugin koshkin_n_MaybeUnused_plugin 2>&1 | FileCheck %s --help
-// CHECK:This plugin marks unused variables with \[\[maybe_unused\]\] attribute
-
-// RUN: %clang_cc1 -load %llvmshlibdir/MaybeUnused_Koshkin_Nikita_FIIT3_ClangAST%pluginext -plugin koshkin_n_MaybeUnused_plugin -fsyntax-only %s 2>&1 | FileCheck %s 
+// RUN: %clang_cc1 -load %llvmshlibdir/MaybeUnused_Koshkin_Nikita_FIIT3_ClangAST%pluginext -plugin koshkin_n_MaybeUnused_plugin -fsyntax-only %s 2>&1 | FileCheck %s
 
 // CHECK: int foo(int a, int b, \[\[maybe_unused\]\] int c) {
-// CHECK: \[\[maybe_unused\]\] double value = 0.0;
-// CHECK:   return a + b;
+// CHECK-NEXT: \[\[maybe_unused\]\] double value = 0.0;
+// CHECK-NEXT: return a + b;
+
 int foo(int a, int b, int c) {
 	double value = 0.0;
     return a + b;
 }
-
 // CHECK: \[\[maybe_unused\]\] int notusd=999;
-int notusd=999;
+// CHECK-NEXT:  \[\[maybe_unused\]\] double notusd2=2.42;
 
-// CHECK: \[\[maybe_unused\]\] double notusd2=2.42;
+int notusd=999;
 double notusd2=2.42;
+
+// CHECK: int usdvar = 444; {
+// CHECK-NEXT: foo1(\[\[maybe_unused\]\] int a) {
+// CHECK-NEXT: usdvar = 0;
+// CHECK-NEXT: \[\[maybe_unused\]\] int value;
+// CHECK-NEXT: return usedvar;
+int usdvar = 444;
+int foo1(int a) {
+	usdvar = 0;
+	int value;
+	return usdvar;
+}
+
+// CHECK: int globalvar = 999; 
+// CHECK-NEXT: \[\[maybe_unused\]\] int gv2 = globalvar + 1;
+
+int globalvar = 999;
+int gv2 = globalvar + 1;
+


### PR DESCRIPTION
Данный плагин использует логику обхода AST с рекурсивной обработкой локальных переменных внутри тела функции и помечает неиспользуемые переменные соответствующий атрибут.