### PR TITLE
Бесхмельнова Ксения. Лабораторная работа 2: Backend. Вариант 3.

### DIFF
--- a/llvm/compiler-course/backend/beskhmelnova_k_fma_decomposition/CMakeLists.txt
+++ b/llvm/compiler-course/backend/beskhmelnova_k_fma_decomposition/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(Title "FmaDecompositionPass")
+set(Student "Beskhmelnova_Kseniya")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_BACKEND")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY
+)
+
+target_include_directories(${TARGET_NAME} PUBLIC ${PATH_TO_X86})
+set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/compiler-course/backend/beskhmelnova_k_fma_decomposition/FmaDecompositionPass.cpp
+++ b/llvm/compiler-course/backend/beskhmelnova_k_fma_decomposition/FmaDecompositionPass.cpp
@@ -19,8 +19,6 @@ public:
 
   bool runOnMachineFunction(llvm::MachineFunction &MF) override {
     const llvm::X86Subtarget &ST = MF.getSubtarget<llvm::X86Subtarget>();
-    if (!ST.hasAVX())
-      return false;
 
     const llvm::X86InstrInfo *TII = ST.getInstrInfo();
     llvm::MachineRegisterInfo &MRI = MF.getRegInfo();
@@ -31,9 +29,14 @@ public:
       for (auto &MI : MBB) {
         unsigned Opc = MI.getOpcode();
         if (Opc == llvm::X86::VFMADD132SSr || Opc == llvm::X86::VFMADD213SSr ||
-            Opc == llvm::X86::VFMADD231SSr) {
-          if (MI.getNumOperands() != 5)
+            Opc == llvm::X86::VFMADD231SSr ||
+            Opc == llvm::X86::VFMADD132SSr_Int ||
+            Opc == llvm::X86::VFMADD213SSr_Int ||
+            Opc == llvm::X86::VFMADD231SSr_Int) {
+
+          if (MI.getNumExplicitOperands() < 4)
             continue;
+
           if (!MI.getOperand(0).isReg() || !MI.getOperand(1).isReg() ||
               !MI.getOperand(2).isReg() || !MI.getOperand(3).isReg())
             continue;
@@ -46,15 +49,14 @@ public:
           const llvm::TargetRegisterClass *RC =
               MRI.getTargetRegisterInfo()->getRegClass(
                   llvm::X86::FR32RegClassID);
-          if (!RC->contains(Dest) || !RC->contains(Src1) ||
-              !RC->contains(Src2) || !RC->contains(Src3))
-            continue;
 
           llvm::Register Tmp = MRI.createVirtualRegister(RC);
+
           llvm::BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(llvm::X86::MULSSrr),
                         Tmp)
               .addReg(Src1)
               .addReg(Src2);
+
           llvm::BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(llvm::X86::ADDSSrr),
                         Dest)
               .addReg(Src3)

--- a/llvm/compiler-course/backend/beskhmelnova_k_fma_decomposition/FmaDecompositionPass.cpp
+++ b/llvm/compiler-course/backend/beskhmelnova_k_fma_decomposition/FmaDecompositionPass.cpp
@@ -1,0 +1,80 @@
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/CodeGen/TargetOpcodes.h"
+
+#define DEBUG_TYPE "fma-decompose-x86"
+
+namespace {
+
+class FmaDecompositionPass : public llvm::MachineFunctionPass {
+public:
+  static char ID;
+  FmaDecompositionPass() : llvm::MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(llvm::MachineFunction &MF) override {
+    const llvm::X86Subtarget &ST = MF.getSubtarget<llvm::X86Subtarget>();
+    if (!ST.hasAVX())
+      return false;
+
+    const llvm::X86InstrInfo *TII = ST.getInstrInfo();
+    llvm::MachineRegisterInfo &MRI = MF.getRegInfo();
+    bool Changed = false;
+
+    for (auto &MBB : MF) {
+      llvm::SmallVector<llvm::MachineInstr *, 4> ToErase;
+      for (auto &MI : MBB) {
+        unsigned Opc = MI.getOpcode();
+        if (Opc == llvm::X86::VFMADD132SSr || Opc == llvm::X86::VFMADD213SSr ||
+            Opc == llvm::X86::VFMADD231SSr) {
+          if (MI.getNumOperands() != 5)
+            continue;
+          if (!MI.getOperand(0).isReg() || !MI.getOperand(1).isReg() ||
+              !MI.getOperand(2).isReg() || !MI.getOperand(3).isReg())
+            continue;
+
+          llvm::Register Dest = MI.getOperand(0).getReg();
+          llvm::Register Src1 = MI.getOperand(1).getReg();
+          llvm::Register Src2 = MI.getOperand(2).getReg();
+          llvm::Register Src3 = MI.getOperand(3).getReg();
+
+          const llvm::TargetRegisterClass *RC =
+              MRI.getTargetRegisterInfo()->getRegClass(
+                  llvm::X86::FR32RegClassID);
+          if (!RC->contains(Dest) || !RC->contains(Src1) ||
+              !RC->contains(Src2) || !RC->contains(Src3))
+            continue;
+
+          llvm::Register Tmp = MRI.createVirtualRegister(RC);
+          llvm::BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(llvm::X86::MULSSrr),
+                        Tmp)
+              .addReg(Src1)
+              .addReg(Src2);
+          llvm::BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(llvm::X86::ADDSSrr),
+                        Dest)
+              .addReg(Src3)
+              .addReg(Tmp);
+
+          ToErase.push_back(&MI);
+          Changed = true;
+        }
+      }
+      for (auto *Old : ToErase)
+        Old->eraseFromParent();
+    }
+
+    return Changed;
+  }
+};
+
+char FmaDecompositionPass::ID = 0;
+
+} // namespace
+
+static llvm::RegisterPass<FmaDecompositionPass>
+    X("fma-decompose-x86", "Decompose FMA to MUL + ADD", false, false);

--- a/llvm/compiler-course/backend/beskhmelnova_k_fma_decomposition/FmaDecompositionPass.cpp
+++ b/llvm/compiler-course/backend/beskhmelnova_k_fma_decomposition/FmaDecompositionPass.cpp
@@ -59,8 +59,8 @@ public:
 
           llvm::BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(llvm::X86::ADDSSrr),
                         Dest)
-              .addReg(Src3)
-              .addReg(Tmp);
+              .addReg(Tmp)
+              .addReg(Src3);
 
           ToErase.push_back(&MI);
           Changed = true;

--- a/llvm/test/compiler-course/beskhmelnova_k_fma_decomposition/fma_test.mir
+++ b/llvm/test/compiler-course/beskhmelnova_k_fma_decomposition/fma_test.mir
@@ -24,6 +24,21 @@
 #    return _mm_cvtss_f32(add);
 #}
 
+# CHECK-LABEL: name: _Z14test_fma_basicfff
+# CHECK: [[TMP:%[0-9]+]]:fr32 = MULSSrr %1, %0
+# CHECK-NEXT: %3:fr32 = ADDSSrr %2, [[TMP]]
+# CHECK-NOT: VFMADD{{.*}}SSr
+
+# CHECK-LABEL: name: _Z17test_fma_same_regff
+# CHECK: [[TMP:%[0-9]+]]:fr32 = MULSSrr %0, %0
+# CHECK-NEXT: %2:fr32 = ADDSSrr %1, [[TMP]]
+# CHECK-NOT: VFMADD{{.*}}SSr
+
+# CHECK-LABEL: name: _Z11test_no_fmafff
+# CHECK: %3:fr32 = nofpexcept VMULSSrr %0, %1, {{.*}}
+# CHECK-NEXT: %4:fr32 = nofpexcept VADDSSrr killed %3, %2, {{.*}}
+# CHECK-NOT: VFMADD{{.*}}SSr
+
 --- |
   ; ModuleID = 'llvm/test/compiler-course/beskhmelnova_k_fma_decomposition/fma_test.ll'
   source_filename = "llvm/test/compiler-course/beskhmelnova_k_fma_decomposition/fma_test.cpp"
@@ -68,7 +83,7 @@
 
 ...
 ---
-# CHECK-LABEL: name:            _Z14test_fma_basicfff
+
 name:            _Z14test_fma_basicfff
 alignment:       16
 exposesReturnsTwice: false
@@ -118,10 +133,6 @@ machineFunctionInfo: {}
 body:             |
   bb.0 (%ir-block.3):
     liveins: $xmm0, $xmm1, $xmm2
-
-    # CHECK: MULSSrr
-    # CHECK-NEXT: ADDSSrr
-    # CHECK-NOT: VFMADD{{.*}}SSr
   
     %2:fr32 = COPY $xmm2
     %1:fr32 = COPY $xmm1
@@ -132,7 +143,7 @@ body:             |
 
 ...
 ---
-# CHECK-LABEL: name:            _Z17test_fma_same_regff
+
 name:            _Z17test_fma_same_regff
 alignment:       16
 exposesReturnsTwice: false
@@ -180,10 +191,6 @@ machineFunctionInfo: {}
 body:             |
   bb.0 (%ir-block.2):
     liveins: $xmm0, $xmm1
-  
-    # CHECK: MULSSrr
-    # CHECK-NEXT: ADDSSrr
-    # CHECK-NOT: VFMADD{{.*}}SSr
 
     %1:fr32 = COPY $xmm1
     %0:fr32 = COPY $xmm0
@@ -193,7 +200,7 @@ body:             |
 
 ...
 ---
-# CHECK-LABEL: name:            _Z11test_no_fmafff
+
 name:            _Z11test_no_fmafff
 alignment:       16
 exposesReturnsTwice: false
@@ -244,10 +251,6 @@ machineFunctionInfo: {}
 body:             |
   bb.0 (%ir-block.3):
     liveins: $xmm0, $xmm1, $xmm2
-
-    # CHECK: MULSSrr
-    # CHECK-NEXT: ADDSSrr
-    # CHECK-NOT: VFMADD{{.*}}SSr
   
     %2:fr32 = COPY $xmm2
     %1:fr32 = COPY $xmm1

--- a/llvm/test/compiler-course/beskhmelnova_k_fma_decomposition/fma_test.mir
+++ b/llvm/test/compiler-course/beskhmelnova_k_fma_decomposition/fma_test.mir
@@ -46,7 +46,7 @@
 # CHECK-NOT: VFMADD{{.*}}SSr
 
 # CHECK-LABEL: name: _Z12test_fma_immff
-# CHECK: %2:fr32 = nofpexcept VFMADD213SSr_Int  %0, %1, 0, {{.*}}
+# CHECK: %2:fr32 = nofpexcept VFMADD213SSm  %1, %0, {{.*}}, %const.0, {{.*}}
 # CHECK-NOT: MULSSrr
 # CHECK-NOT: ADDSSrr
 

--- a/llvm/test/compiler-course/beskhmelnova_k_fma_decomposition/fma_test.mir
+++ b/llvm/test/compiler-course/beskhmelnova_k_fma_decomposition/fma_test.mir
@@ -23,21 +23,32 @@
 #    __m128 add = _mm_add_ss(mul, _mm_set_ss(c));
 #    return _mm_cvtss_f32(add);
 #}
+#
+#// Test 4: FMA with immediate operand
+#float test_fma_imm(float a, float b) {
+#    __m128 imm = _mm_set_ss(2.0f);
+#    return _mm_cvtss_f32(_mm_fmadd_ss(_mm_set_ss(a), _mm_set_ss(b), imm));
+#}
 
 # CHECK-LABEL: name: _Z14test_fma_basicfff
 # CHECK: [[TMP:%[0-9]+]]:fr32 = MULSSrr %1, %0
-# CHECK-NEXT: %3:fr32 = ADDSSrr %2, [[TMP]]
+# CHECK-NEXT: %3:fr32 = ADDSSrr [[TMP]], %2
 # CHECK-NOT: VFMADD{{.*}}SSr
 
 # CHECK-LABEL: name: _Z17test_fma_same_regff
 # CHECK: [[TMP:%[0-9]+]]:fr32 = MULSSrr %0, %0
-# CHECK-NEXT: %2:fr32 = ADDSSrr %1, [[TMP]]
+# CHECK-NEXT: %2:fr32 = ADDSSrr [[TMP]], %1
 # CHECK-NOT: VFMADD{{.*}}SSr
 
 # CHECK-LABEL: name: _Z11test_no_fmafff
 # CHECK: %3:fr32 = nofpexcept VMULSSrr %0, %1, {{.*}}
 # CHECK-NEXT: %4:fr32 = nofpexcept VADDSSrr killed %3, %2, {{.*}}
 # CHECK-NOT: VFMADD{{.*}}SSr
+
+# CHECK-LABEL: name: _Z12test_fma_immff
+# CHECK: %2:fr32 = nofpexcept VFMADD213SSr_Int  %0, %1, 0, {{.*}}
+# CHECK-NOT: MULSSrr
+# CHECK-NOT: ADDSSrr
 
 --- |
   ; ModuleID = 'llvm/test/compiler-course/beskhmelnova_k_fma_decomposition/fma_test.ll'
@@ -260,4 +271,61 @@ body:             |
     $xmm0 = COPY %4
     RET 0, $xmm0
 
+...
+---
+
+name: _Z12test_fma_immff
+alignment: 16
+exposesReturnsTwice: false
+legalized: false
+regBankSelected: false
+selected: false
+failedISel: false
+tracksRegLiveness: true
+hasWinCFI: false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap: false
+  hasPatchPoint: false
+  stackSize: 0
+  offsetAdjustment: 0
+  maxAlignment: 1
+  adjustsStack: false
+  hasCalls: false
+  stackProtector: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart: false
+  hasMustTailInVarArgFunc: false
+  hasTailCall: false
+  localFrameSize: 0
+  savePoint: ''
+  restorePoint: ''
+fixedStack: []
+stack: []
+callSites: []
+debugValueSubstitutions: []
+constants:
+  - { id: 0, value: 2.0, alignment: 4 }
+machineFunctionInfo: {}
+body: |
+  bb.0 (%ir-block.2):
+    liveins: $xmm0, $xmm1
+  
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %2:fr32 = nofpexcept VFMADD213SSr_Int %0, %1, 0, implicit $mxcsr
+    $xmm0 = COPY %2
+    RET 0, $xmm0
 ...

--- a/llvm/test/compiler-course/beskhmelnova_k_fma_decomposition/fma_test.mir
+++ b/llvm/test/compiler-course/beskhmelnova_k_fma_decomposition/fma_test.mir
@@ -1,0 +1,260 @@
+# RUN: llc -mtriple=x86_64-unknown-linux-gnu -mattr=+avx,+fma \
+# RUN: --load=%llvmshlibdir/FmaDecompositionPass_Beskhmelnova_Kseniya_FIIT1_BACKEND%shlibext \
+# RUN: -run-pass=fma-decompose-x86 %s -o - | FileCheck %s
+
+# Source files
+# fma_test.cpp
+#
+# #include <immintrin.h>
+#
+#// Test 1: Basic FMA-operation (a * b + c)
+#float test_fma_basic(float a, float b, float c) {
+#    return _mm_cvtss_f32(_mm_fmadd_ss(_mm_set_ss(a), _mm_set_ss(b), _mm_set_ss(c)));
+#}
+#
+#// Test 2: FMA-operation with the same registers (a * a + b)
+#float test_fma_same_reg(float a, float b) {
+#    return _mm_cvtss_f32(_mm_fmadd_ss(_mm_set_ss(a), _mm_set_ss(a), _mm_set_ss(b)));
+#}
+#
+#// Test 3: Code without FMA (just mul and add)
+#float test_no_fma(float a, float b, float c) {
+#    __m128 mul = _mm_mul_ss(_mm_set_ss(a), _mm_set_ss(b));
+#    __m128 add = _mm_add_ss(mul, _mm_set_ss(c));
+#    return _mm_cvtss_f32(add);
+#}
+
+--- |
+  ; ModuleID = 'llvm/test/compiler-course/beskhmelnova_k_fma_decomposition/fma_test.ll'
+  source_filename = "llvm/test/compiler-course/beskhmelnova_k_fma_decomposition/fma_test.cpp"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-unknown-linux-gnu"
+  
+  ; Function Attrs: mustprogress nofree nosync nounwind readnone uwtable willreturn
+  define dso_local noundef float @_Z14test_fma_basicfff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #0 {
+    %4 = tail call float @llvm.fma.f32(float %0, float %1, float %2) #3
+    ret float %4
+  }
+  
+  ; Function Attrs: mustprogress nofree nosync nounwind readnone uwtable willreturn
+  define dso_local noundef float @_Z17test_fma_same_regff(float noundef %0, float noundef %1) local_unnamed_addr #0 {
+    %3 = tail call float @llvm.fma.f32(float %0, float %0, float %1) #3
+    ret float %3
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind readnone uwtable willreturn
+  define dso_local noundef float @_Z11test_no_fmafff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
+    %4 = fmul float %0, %1
+    %5 = fadd float %4, %2
+    ret float %5
+  }
+  
+  ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+  declare float @llvm.fma.f32(float, float, float) #2
+  
+  attributes #0 = { mustprogress nofree nosync nounwind readnone uwtable willreturn "frame-pointer"="none" "min-legal-vector-width"="128" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+avx,+crc32,+cx8,+fma,+fxsr,+mmx,+popcnt,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3,+x87,+xsave,+avx,+fma" "tune-cpu"="generic" }
+  attributes #1 = { mustprogress nofree norecurse nosync nounwind readnone uwtable willreturn "frame-pointer"="none" "min-legal-vector-width"="128" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+avx,+crc32,+cx8,+fma,+fxsr,+mmx,+popcnt,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3,+x87,+xsave,+avx,+fma" "tune-cpu"="generic" }
+  attributes #2 = { nofree nosync nounwind readnone speculatable willreturn "target-features"="+avx,+fma" }
+  attributes #3 = { nounwind }
+  
+  !llvm.module.flags = !{!0, !1, !2, !3}
+  !llvm.ident = !{!4}
+  
+  !0 = !{i32 1, !"wchar_size", i32 4}
+  !1 = !{i32 7, !"PIC Level", i32 2}
+  !2 = !{i32 7, !"PIE Level", i32 2}
+  !3 = !{i32 7, !"uwtable", i32 1}
+  !4 = !{!"Ubuntu clang version 14.0.0-1ubuntu1.1"}
+
+...
+---
+# CHECK-LABEL: name:            _Z14test_fma_basicfff
+name:            _Z14test_fma_basicfff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo: {}
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $xmm0, $xmm1, $xmm2
+
+    # CHECK: MULSSrr
+    # CHECK-NEXT: ADDSSrr
+    # CHECK-NOT: VFMADD{{.*}}SSr
+  
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VFMADD213SSr %1, %0, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+# CHECK-LABEL: name:            _Z17test_fma_same_regff
+name:            _Z17test_fma_same_regff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo: {}
+body:             |
+  bb.0 (%ir-block.2):
+    liveins: $xmm0, $xmm1
+  
+    # CHECK: MULSSrr
+    # CHECK-NEXT: ADDSSrr
+    # CHECK-NOT: VFMADD{{.*}}SSr
+
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %2:fr32 = nofpexcept VFMADD213SSr %0, %0, %1, implicit $mxcsr
+    $xmm0 = COPY %2
+    RET 0, $xmm0
+
+...
+---
+# CHECK-LABEL: name:            _Z11test_no_fmafff
+name:            _Z11test_no_fmafff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+  - { id: 4, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo: {}
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $xmm0, $xmm1, $xmm2
+
+    # CHECK: MULSSrr
+    # CHECK-NEXT: ADDSSrr
+    # CHECK-NOT: VFMADD{{.*}}SSr
+  
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr
+    %4:fr32 = nofpexcept VADDSSrr killed %3, %2, implicit $mxcsr
+    $xmm0 = COPY %4
+    RET 0, $xmm0
+
+...

--- a/llvm/test/compiler-course/beskhmelnova_k_fma_decomposition/fma_test.mir
+++ b/llvm/test/compiler-course/beskhmelnova_k_fma_decomposition/fma_test.mir
@@ -75,6 +75,12 @@
     ret float %5
   }
   
+  ; Function Attrs: mustprogress nofree nosync nounwind readnone uwtable willreturn
+  define dso_local noundef float @_Z12test_fma_immff(float noundef %0, float noundef %1) local_unnamed_addr #0 {
+    %3 = tail call float @llvm.fma.f32(float %0, float %1, float 2.000000e+00) #3
+    ret float %3
+  }
+  
   ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
   declare float @llvm.fma.f32(float, float, float) #2
   
@@ -94,7 +100,6 @@
 
 ...
 ---
-
 name:            _Z14test_fma_basicfff
 alignment:       16
 exposesReturnsTwice: false
@@ -154,7 +159,6 @@ body:             |
 
 ...
 ---
-
 name:            _Z17test_fma_same_regff
 alignment:       16
 exposesReturnsTwice: false
@@ -202,7 +206,7 @@ machineFunctionInfo: {}
 body:             |
   bb.0 (%ir-block.2):
     liveins: $xmm0, $xmm1
-
+  
     %1:fr32 = COPY $xmm1
     %0:fr32 = COPY $xmm0
     %2:fr32 = nofpexcept VFMADD213SSr %0, %0, %1, implicit $mxcsr
@@ -211,7 +215,6 @@ body:             |
 
 ...
 ---
-
 name:            _Z11test_no_fmafff
 alignment:       16
 exposesReturnsTwice: false
@@ -273,16 +276,15 @@ body:             |
 
 ...
 ---
-
-name: _Z12test_fma_immff
-alignment: 16
+name:            _Z12test_fma_immff
+alignment:       16
 exposesReturnsTwice: false
-legalized: false
+legalized:       false
 regBankSelected: false
-selected: false
-failedISel: false
+selected:        false
+failedISel:      false
 tracksRegLiveness: true
-hasWinCFI: false
+hasWinCFI:       false
 failsVerification: false
 tracksDebugUserValues: false
 registers:
@@ -295,37 +297,42 @@ liveins:
 frameInfo:
   isFrameAddressTaken: false
   isReturnAddressTaken: false
-  hasStackMap: false
-  hasPatchPoint: false
-  stackSize: 0
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
   offsetAdjustment: 0
-  maxAlignment: 1
-  adjustsStack: false
-  hasCalls: false
-  stackProtector: ''
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
   maxCallFrameSize: 4294967295
   cvBytesOfCalleeSavedRegisters: 0
   hasOpaqueSPAdjustment: false
-  hasVAStart: false
+  hasVAStart:      false
   hasMustTailInVarArgFunc: false
-  hasTailCall: false
-  localFrameSize: 0
-  savePoint: ''
-  restorePoint: ''
-fixedStack: []
-stack: []
-callSites: []
+  hasTailCall:     false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+callSites:       []
 debugValueSubstitutions: []
 constants:
-  - { id: 0, value: 2.0, alignment: 4 }
+  - id:              0
+    value:           'float 2.000000e+00'
+    alignment:       4
+    isTargetSpecific: false
 machineFunctionInfo: {}
-body: |
+body:             |
   bb.0 (%ir-block.2):
     liveins: $xmm0, $xmm1
   
     %1:fr32 = COPY $xmm1
     %0:fr32 = COPY $xmm0
-    %2:fr32 = nofpexcept VFMADD213SSr_Int %0, %1, 0, implicit $mxcsr
+    %2:fr32 = nofpexcept VFMADD213SSm %1, %0, $rip, 1, $noreg, %const.0, $noreg, implicit $mxcsr :: (load (s32) from constant-pool)
     $xmm0 = COPY %2
     RET 0, $xmm0
+
 ...
+


### PR DESCRIPTION
FmaDecompositionPass для LLVM, который декомпозирует FMA-инструкции (VFMADD132SSr, VFMADD213SSr, VFMADD231SSr и их _Int варианты) в Machine IR в последовательность операций MULSSrr и ADDSSrr с классом регистров fr32. Пасс заменяет каждую FMA-инструкцию, выполняющую операцию вида Dest = Src3 + (Src1 * Src2), на две инструкции: умножение Tmp = Src1 * Src2 и сложение Dest = Src3 + Tmp.