### PR TITLE
Чистов Алексей. Лабораторная работа 3: Backend. Вариант 1.

### DIFF
--- a/llvm/compiler-course/backend/chistov_a_combination/CMakeLists.txt
+++ b/llvm/compiler-course/backend/chistov_a_combination/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(Title "CombinationPass")
+set(Student "Chistov_Alexey")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_BACKEND")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY
+)
+
+target_include_directories(${TARGET_NAME} PUBLIC ${PATH_TO_X86})
+set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/compiler-course/backend/chistov_a_combination/chistov_a_backend.cpp
+++ b/llvm/compiler-course/backend/chistov_a_combination/chistov_a_backend.cpp
@@ -1,26 +1,227 @@
 #include "X86.h"
 #include "X86InstrInfo.h"
 #include "X86Subtarget.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
-
-using namespace llvm;
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/CodeGen/TargetOpcodes.h"
+#include "llvm/Passes/PassBuilder.h"
+#include <functional>
 
 namespace {
-class ExamplePass : public MachineFunctionPass {
+class X86LogicOptPass : public llvm::MachineFunctionPass {
+private:
+  bool Changed = false;
+  const llvm::X86InstrInfo *TII;
+  const llvm::MachineRegisterInfo *MRI;
+
+  using OptimizationPredicate = std::function<bool(llvm::MachineInstr &)>;
+  using OptimizationTransform =
+      std::function<void(llvm::MachineBasicBlock &, llvm::MachineInstr &,
+                         llvm::SmallVectorImpl<llvm::MachineInstr *> &)>;
+
+private:
+  void applyOptimizations(llvm::MachineFunction &MF,
+                          OptimizationPredicate shouldTransform,
+                          OptimizationTransform performTransform) {
+    for (auto &MBB : MF) {
+      llvm::SmallVector<llvm::MachineInstr *, 8> InstrsToRemove;
+      for (auto &MI : MBB) {
+        if (shouldTransform(MI)) {
+          performTransform(MBB, MI, InstrsToRemove);
+          Changed = true;
+        }
+      }
+      for (auto *I : InstrsToRemove)
+        I->eraseFromParent();
+    }
+  }
+
+  bool isLogicOpcode(unsigned Opcode) const {
+    switch (Opcode) {
+    case llvm::X86::ANDPSrr:
+    case llvm::X86::ORPSrr:
+    case llvm::X86::XORPSrr:
+    case llvm::X86::PANDrr:
+    case llvm::X86::PORrr:
+    case llvm::X86::PXORrr:
+    case llvm::X86::PANDNrr:
+      return true;
+    default:
+      return false;
+    }
+  }
+
+  unsigned getAVXOpcode(unsigned Opcode) const {
+    switch (Opcode) {
+    case llvm::X86::ANDPSrr:
+      return llvm::X86::VANDPSrr;
+    case llvm::X86::ORPSrr:
+      return llvm::X86::VORPSrr;
+    case llvm::X86::XORPSrr:
+      return llvm::X86::VXORPSrr;
+    case llvm::X86::PANDrr:
+      return llvm::X86::VPANDrr;
+    case llvm::X86::PORrr:
+      return llvm::X86::VPORrr;
+    case llvm::X86::PXORrr:
+      return llvm::X86::VPXORrr;
+    case llvm::X86::PANDNrr:
+      return llvm::X86::VPANDNrr;
+    default:
+      return 0;
+    }
+  }
+
+  void replaceWithAVX(llvm::MachineBasicBlock &MBB, llvm::MachineInstr &MI,
+                      llvm::SmallVectorImpl<llvm::MachineInstr *> &ToRemove) {
+    unsigned NewOpc = getAVXOpcode(MI.getOpcode());
+    if (!NewOpc)
+      return;
+
+    llvm::Register DestReg = MI.getOperand(0).getReg();
+    llvm::Register SrcReg1 = MI.getOperand(1).getReg();
+    llvm::Register SrcReg2 = MI.getOperand(2).getReg();
+
+    llvm::BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(NewOpc), DestReg)
+        .addReg(SrcReg1)
+        .addReg(SrcReg2);
+    ToRemove.push_back(&MI);
+  }
+
+  bool isZeroRegister(llvm::Register Reg) const {
+    if (auto *DefInstr = MRI->getUniqueVRegDef(Reg)) {
+      switch (DefInstr->getOpcode()) {
+      case llvm::X86::PXORrr:
+      case llvm::X86::XORPSrr:
+      case llvm::X86::XORPDrr:
+        auto &Op1 = DefInstr->getOperand(1);
+        auto &Op2 = DefInstr->getOperand(2);
+        return Op1.isReg() && Op2.isReg() && Op1.getReg() == Op2.getReg();
+      }
+    }
+    return false;
+  }
+
+  bool
+  handleZeroOperands(llvm::MachineBasicBlock &MBB, llvm::MachineInstr &MI,
+                     unsigned Opc, llvm::Register DestReg,
+                     llvm::Register SrcReg1, llvm::Register SrcReg2,
+                     llvm::SmallVectorImpl<llvm::MachineInstr *> &ToRemove) {
+    const bool Src1IsZero = isZeroRegister(SrcReg1);
+    const bool Src2IsZero = isZeroRegister(SrcReg2);
+
+    if (!Src1IsZero && !Src2IsZero)
+      return false;
+
+    switch (Opc) {
+    case llvm::X86::PANDrr: {
+      llvm::Register ZeroReg = Src1IsZero ? SrcReg1 : SrcReg2;
+      llvm::BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(llvm::X86::VPXORrr),
+                    DestReg)
+          .addReg(ZeroReg)
+          .addReg(ZeroReg);
+      break;
+    }
+    case llvm::X86::PORrr: {
+      llvm::Register NonZeroReg = Src1IsZero ? SrcReg2 : SrcReg1;
+      llvm::BuildMI(MBB, MI, MI.getDebugLoc(),
+                    TII->get(llvm::TargetOpcode::COPY), DestReg)
+          .addReg(NonZeroReg);
+      break;
+    }
+    case llvm::X86::PXORrr: {
+      if (!Src1IsZero)
+        return false;
+
+      llvm::BuildMI(MBB, MI, MI.getDebugLoc(),
+                    TII->get(llvm::TargetOpcode::COPY), DestReg)
+          .addReg(SrcReg2);
+      break;
+    }
+    default:
+      return false;
+    }
+
+    ToRemove.push_back(&MI);
+    return true;
+  }
+
+private:
+  void optimizeLogicOperations(llvm::MachineFunction &MF) {
+    auto shouldTransform = [&](llvm::MachineInstr &MI) {
+      return isLogicOpcode(MI.getOpcode());
+    };
+
+    auto transformInstr =
+        [&](llvm::MachineBasicBlock &MBB, llvm::MachineInstr &MI,
+            llvm::SmallVectorImpl<llvm::MachineInstr *> &ToRemove) {
+          const unsigned Opc = MI.getOpcode();
+          const llvm::Register DestReg = MI.getOperand(0).getReg();
+          const llvm::Register SrcReg1 = MI.getOperand(1).getReg();
+          const llvm::Register SrcReg2 = MI.getOperand(2).getReg();
+
+          if (handleZeroOperands(MBB, MI, Opc, DestReg, SrcReg1, SrcReg2,
+                                 ToRemove)) {
+            return;
+          }
+
+          replaceWithAVX(MBB, MI, ToRemove);
+        };
+
+    applyOptimizations(MF, shouldTransform, transformInstr);
+  }
+
+  void combineLogicOperations(llvm::MachineFunction &MF) {
+    OptimizationPredicate shouldTransform = [&](llvm::MachineInstr &MI) {
+      return isLogicOpcode(MI.getOpcode());
+    };
+
+    OptimizationTransform transformInstr =
+        [&](llvm::MachineBasicBlock &MBB, llvm::MachineInstr &MI,
+            llvm::SmallVectorImpl<llvm::MachineInstr *> &InstrsToRemove) {
+          llvm::Register IntermediateReg = MI.getOperand(1).getReg();
+          auto *FirstInstr = MRI->getUniqueVRegDef(IntermediateReg);
+          if (!FirstInstr || !MRI->hasOneUse(IntermediateReg))
+            return;
+
+          unsigned FirstOpcode = FirstInstr->getOpcode();
+          if (!isLogicOpcode(FirstOpcode))
+            return;
+
+          unsigned AVXFirstOp = getAVXOpcode(FirstOpcode);
+          unsigned AVXSecondOp = getAVXOpcode(MI.getOpcode());
+          if (!AVXFirstOp || !AVXSecondOp)
+            return;
+
+          replaceWithAVX(MBB, *FirstInstr, InstrsToRemove);
+          replaceWithAVX(MBB, MI, InstrsToRemove);
+        };
+
+    applyOptimizations(MF, shouldTransform, transformInstr);
+  }
+
 public:
   static char ID;
-  ExamplePass() : MachineFunctionPass(ID) {}
-  bool runOnMachineFunction(MachineFunction &MF) override;
+  X86LogicOptPass() : llvm::MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(llvm::MachineFunction &MF) override {
+    const auto *ST = &MF.getSubtarget<llvm::X86Subtarget>();
+    TII = ST->getInstrInfo();
+    MRI = &MF.getRegInfo();
+
+    optimizeLogicOperations(MF);
+    combineLogicOperations(MF);
+
+    return Changed;
+  }
 };
 
-char ExamplePass::ID = 0;
-
-bool ExamplePass::runOnMachineFunction(MachineFunction &func) {
-  llvm::outs() << func.getName() << '\n';
-  return true;
-}
+char X86LogicOptPass::ID = 0;
 } // namespace
 
-static RegisterPass<ExamplePass> X("CombinationPass", "replaces sequences of logical operations with more efficient instructions", false,
-                                   false);
+static llvm::RegisterPass<X86LogicOptPass>
+    X("x86-logic-opt", "X86 Logical Operations Optimization Pass", false,
+      false);

--- a/llvm/compiler-course/backend/chistov_a_combination/chistov_a_backend.cpp
+++ b/llvm/compiler-course/backend/chistov_a_combination/chistov_a_backend.cpp
@@ -6,7 +6,6 @@
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
-#include "llvm/CodeGen/TargetOpcodes.h"
 #include "llvm/Passes/PassBuilder.h"
 #include <functional>
 
@@ -22,7 +21,7 @@ private:
       std::function<void(llvm::MachineBasicBlock &, llvm::MachineInstr &,
                          llvm::SmallVectorImpl<llvm::MachineInstr *> &)>;
 
-private:
+private: // auxiliary functions
   void applyOptimizations(llvm::MachineFunction &MF,
                           OptimizationPredicate shouldTransform,
                           OptimizationTransform performTransform) {
@@ -91,65 +90,7 @@ private:
     ToRemove.push_back(&MI);
   }
 
-  bool isZeroRegister(llvm::Register Reg) const {
-    if (auto *DefInstr = MRI->getUniqueVRegDef(Reg)) {
-      switch (DefInstr->getOpcode()) {
-      case llvm::X86::PXORrr:
-      case llvm::X86::XORPSrr:
-      case llvm::X86::XORPDrr:
-        auto &Op1 = DefInstr->getOperand(1);
-        auto &Op2 = DefInstr->getOperand(2);
-        return Op1.isReg() && Op2.isReg() && Op1.getReg() == Op2.getReg();
-      }
-    }
-    return false;
-  }
-
-  bool
-  handleZeroOperands(llvm::MachineBasicBlock &MBB, llvm::MachineInstr &MI,
-                     unsigned Opc, llvm::Register DestReg,
-                     llvm::Register SrcReg1, llvm::Register SrcReg2,
-                     llvm::SmallVectorImpl<llvm::MachineInstr *> &ToRemove) {
-    const bool Src1IsZero = isZeroRegister(SrcReg1);
-    const bool Src2IsZero = isZeroRegister(SrcReg2);
-
-    if (!Src1IsZero && !Src2IsZero)
-      return false;
-
-    switch (Opc) {
-    case llvm::X86::PANDrr: {
-      llvm::Register ZeroReg = Src1IsZero ? SrcReg1 : SrcReg2;
-      llvm::BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(llvm::X86::VPXORrr),
-                    DestReg)
-          .addReg(ZeroReg)
-          .addReg(ZeroReg);
-      break;
-    }
-    case llvm::X86::PORrr: {
-      llvm::Register NonZeroReg = Src1IsZero ? SrcReg2 : SrcReg1;
-      llvm::BuildMI(MBB, MI, MI.getDebugLoc(),
-                    TII->get(llvm::TargetOpcode::COPY), DestReg)
-          .addReg(NonZeroReg);
-      break;
-    }
-    case llvm::X86::PXORrr: {
-      if (!Src1IsZero)
-        return false;
-
-      llvm::BuildMI(MBB, MI, MI.getDebugLoc(),
-                    TII->get(llvm::TargetOpcode::COPY), DestReg)
-          .addReg(SrcReg2);
-      break;
-    }
-    default:
-      return false;
-    }
-
-    ToRemove.push_back(&MI);
-    return true;
-  }
-
-private:
+private: // optimizing passes
   void optimizeLogicOperations(llvm::MachineFunction &MF) {
     auto shouldTransform = [&](llvm::MachineInstr &MI) {
       return isLogicOpcode(MI.getOpcode());
@@ -158,16 +99,6 @@ private:
     auto transformInstr =
         [&](llvm::MachineBasicBlock &MBB, llvm::MachineInstr &MI,
             llvm::SmallVectorImpl<llvm::MachineInstr *> &ToRemove) {
-          const unsigned Opc = MI.getOpcode();
-          const llvm::Register DestReg = MI.getOperand(0).getReg();
-          const llvm::Register SrcReg1 = MI.getOperand(1).getReg();
-          const llvm::Register SrcReg2 = MI.getOperand(2).getReg();
-
-          if (handleZeroOperands(MBB, MI, Opc, DestReg, SrcReg1, SrcReg2,
-                                 ToRemove)) {
-            return;
-          }
-
           replaceWithAVX(MBB, MI, ToRemove);
         };
 

--- a/llvm/compiler-course/backend/chistov_a_combination/chistov_a_backend.cpp
+++ b/llvm/compiler-course/backend/chistov_a_combination/chistov_a_backend.cpp
@@ -124,6 +124,7 @@ public:
   X86LogicOptPass() : llvm::MachineFunctionPass(ID) {}
 
   bool runOnMachineFunction(llvm::MachineFunction &MF) override {
+    Changed = false;
     const auto *ST = &MF.getSubtarget<llvm::X86Subtarget>();
     TII = ST->getInstrInfo();
     MRI = &MF.getRegInfo();

--- a/llvm/compiler-course/backend/chistov_a_combination/chistov_a_backend.cpp
+++ b/llvm/compiler-course/backend/chistov_a_combination/chistov_a_backend.cpp
@@ -1,0 +1,26 @@
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+
+using namespace llvm;
+
+namespace {
+class ExamplePass : public MachineFunctionPass {
+public:
+  static char ID;
+  ExamplePass() : MachineFunctionPass(ID) {}
+  bool runOnMachineFunction(MachineFunction &MF) override;
+};
+
+char ExamplePass::ID = 0;
+
+bool ExamplePass::runOnMachineFunction(MachineFunction &func) {
+  llvm::outs() << func.getName() << '\n';
+  return true;
+}
+} // namespace
+
+static RegisterPass<ExamplePass> X("CombinationPass", "replaces sequences of logical operations with more efficient instructions", false,
+                                   false);

--- a/llvm/compiler-course/backend/chistov_a_combination/chistov_a_backend.cpp
+++ b/llvm/compiler-course/backend/chistov_a_combination/chistov_a_backend.cpp
@@ -1,6 +1,7 @@
 #include "X86.h"
 #include "X86InstrInfo.h"
 #include "X86Subtarget.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
@@ -15,6 +16,16 @@ private:
   bool Changed = false;
   const llvm::X86InstrInfo *TII;
   const llvm::MachineRegisterInfo *MRI;
+
+  llvm::DenseMap<unsigned, unsigned> LogicToAVX = {
+      {llvm::X86::ANDPSrr, llvm::X86::VANDPSrr},
+      {llvm::X86::ORPSrr, llvm::X86::VORPSrr},
+      {llvm::X86::XORPSrr, llvm::X86::VXORPSrr},
+      {llvm::X86::PANDrr, llvm::X86::VPANDrr},
+      {llvm::X86::PORrr, llvm::X86::VPORrr},
+      {llvm::X86::PXORrr, llvm::X86::VPXORrr},
+      {llvm::X86::PANDNrr, llvm::X86::VPANDNrr},
+  };
 
   using OptimizationPredicate = std::function<bool(llvm::MachineInstr &)>;
   using OptimizationTransform =
@@ -39,39 +50,12 @@ private: // auxiliary functions
   }
 
   bool isLogicOpcode(unsigned Opcode) const {
-    switch (Opcode) {
-    case llvm::X86::ANDPSrr:
-    case llvm::X86::ORPSrr:
-    case llvm::X86::XORPSrr:
-    case llvm::X86::PANDrr:
-    case llvm::X86::PORrr:
-    case llvm::X86::PXORrr:
-    case llvm::X86::PANDNrr:
-      return true;
-    default:
-      return false;
-    }
+    return LogicToAVX.contains(Opcode);
   }
 
   unsigned getAVXOpcode(unsigned Opcode) const {
-    switch (Opcode) {
-    case llvm::X86::ANDPSrr:
-      return llvm::X86::VANDPSrr;
-    case llvm::X86::ORPSrr:
-      return llvm::X86::VORPSrr;
-    case llvm::X86::XORPSrr:
-      return llvm::X86::VXORPSrr;
-    case llvm::X86::PANDrr:
-      return llvm::X86::VPANDrr;
-    case llvm::X86::PORrr:
-      return llvm::X86::VPORrr;
-    case llvm::X86::PXORrr:
-      return llvm::X86::VPXORrr;
-    case llvm::X86::PANDNrr:
-      return llvm::X86::VPANDNrr;
-    default:
-      return 0;
-    }
+    auto It = LogicToAVX.find(Opcode);
+    return It != LogicToAVX.end() ? It->second : 0;
   }
 
   void replaceWithAVX(llvm::MachineBasicBlock &MBB, llvm::MachineInstr &MI,
@@ -88,15 +72,16 @@ private: // auxiliary functions
         .addReg(SrcReg1)
         .addReg(SrcReg2);
     ToRemove.push_back(&MI);
+    Changed = true;
   }
 
 private: // optimizing passes
   void optimizeLogicOperations(llvm::MachineFunction &MF) {
-    auto shouldTransform = [&](llvm::MachineInstr &MI) {
+    OptimizationPredicate shouldTransform = [&](llvm::MachineInstr &MI) {
       return isLogicOpcode(MI.getOpcode());
     };
 
-    auto transformInstr =
+    OptimizationTransform transformInstr =
         [&](llvm::MachineBasicBlock &MBB, llvm::MachineInstr &MI,
             llvm::SmallVectorImpl<llvm::MachineInstr *> &ToRemove) {
           replaceWithAVX(MBB, MI, ToRemove);

--- a/llvm/test/compiler-course/chistov_a_combination_test/chistov_a_backend_test.mir
+++ b/llvm/test/compiler-course/chistov_a_combination_test/chistov_a_backend_test.mir
@@ -158,7 +158,6 @@ body:             |
     ; CHECK: %1:vr128 = COPY $xmm1
     ; CHECK-NEXT: %0:vr128 = COPY $xmm0
     ; CHECK-NEXT: %2:vr128 = VPANDrr %1, %0
-    ; CHECK-NOT: %2:vr128 = PANDrr %1, %0
     ; CHECK-NEXT: $xmm0 = COPY %2
     ; CHECK-NEXT: RET 0, $xmm0
   
@@ -233,7 +232,6 @@ body:             |
     ; CHECK: %1:vr128 = COPY $xmm1
     ; CHECK-NEXT: %0:vr128 = COPY $xmm0
     ; CHECK-NEXT: %2:vr128 = VPORrr %1, %0
-    ; CHECK-NOT: %2:vr128 = PORrr %1, %0
     ; CHECK-NEXT: $xmm0 = COPY %2
     ; CHECK-NEXT: RET 0, $xmm0
   
@@ -308,7 +306,6 @@ body:             |
     ; CHECK: %1:vr128 = COPY $xmm1
     ; CHECK-NEXT: %0:vr128 = COPY $xmm0
     ; CHECK-NEXT: %2:vr128 = VPXORrr %1, %0
-    ; CHECK-NOT: %2:vr128 = PXORrr %1, %0
     ; CHECK-NEXT: $xmm0 = COPY %2
     ; CHECK-NEXT: RET 0, $xmm0
   
@@ -391,9 +388,6 @@ body:             |
     ; CHECK-NEXT: %3:vr128 = VPANDrr %1, %0
     ; CHECK-NEXT: %4:vr128 = VPORrr %3, %2
     ; CHECK-NEXT: %5:vr128 = VPXORrr %4, %0
-    ; CHECK-NOT: %3:vr128 = PANDrr %1, %0
-    ; CHECK-NOT: %4:vr128 = PORrr %3, %2
-    ; CHECK-NOT: %5:vr128 = PXORrr %4, %0
     ; CHECK-NEXT: $xmm0 = COPY %5
     ; CHECK-NEXT: RET 0, $xmm0
   

--- a/llvm/test/compiler-course/chistov_a_combination_test/chistov_a_backend_test.mir
+++ b/llvm/test/compiler-course/chistov_a_combination_test/chistov_a_backend_test.mir
@@ -1,38 +1,118 @@
 # RUN: llc -mtriple x86_64-unknown-linux-gnu --load=%llvmshlibdir/CombinationPass_Chistov_Alexey_FIIT1_BACKEND%shlibext \
-# RUN: -run-pass=CombinationPass %s -o - | FileCheck %s
+# RUN: -run-pass=x86-logic-opt %s -o - | FileCheck %s
 
+##include <emmintrin.h>
 
-# Source files
+#__m128 test_basic_and_operation(__m128 a, __m128 b) {
+#    return _mm_and_ps(a, b);
+#}
 
-# test.cpp
-#
-# [[nodiscard]] bool isEven(int value) noexcept { return value % 2 == 0; }
+#__m128 test_basic_or_operation(__m128 a, __m128 b) {
+#    return _mm_or_ps(a, b);
+#}
 
-# test.ll (-O2)
-#
-# define dso_local noundef zeroext i1 @_Z6isEveni(i32 noundef %0) local_unnamed_addr {
-#  %2 = and i32 %0, 1
-#  %3 = icmp eq i32 %2, 0
-#  ret i1 %3
-# }
+#__m128 test_basic_xor_operation(__m128 a, __m128 b) {
+#    return _mm_xor_ps(a, b);
+#}
 
+#__m128 test_and_with_self_is_copy(__m128 a) {
+#    return _mm_and_ps(a, a);
+#}
+
+#__m128 test_or_with_self(__m128 a) {
+#    return _mm_or_ps(a, a);
+#}
+
+#__m128 test_combined_logic_operations(__m128 a, __m128 b, __m128 c) {
+#    __m128 t1 = _mm_and_ps(a, b);
+#    __m128 t2 = _mm_or_ps(t1, c);
+#    __m128 t3 = _mm_xor_ps(t2, a);
+#    return t3;
+#} 
+
+# CHECK-LABEL:name: _Z24test_basic_and_operationDv4_fS_
+# CHECK: VPANDrr
+# CHECK-NOT: PANDrr
+
+# CHECK-LABEL:name: _Z23test_basic_or_operationDv4_fS_
+# CHECK: VPORrr
+# CHECK-NOT: PORrr
+
+# CHECK-LABEL:name: _Z24test_basic_xor_operationDv4_fS_
+# CHECK: VPXORrr
+# CHECK-NOT: PXORrr
+
+# CHECK-LABEL:name: _Z30test_combined_logic_operationsDv4_fS_S_
+# CHECK: VPANDrr
+# CHECK: VPORrr
+# CHECK: VPXORrr
+# CHECK-NOT: PANDrr
+# CHECK-NOT: PORrr
+# CHECK-NOT: PXORrr
 
 --- |
-  ; ModuleID = 'test.ll'
-  source_filename = "test.ll"
+  ; ModuleID = 'llvm/test/compiler-course/chistov_a_combination_test/test.ll'
+  source_filename = "/home/alexe/code/compiler-course-2025/llvm/test/compiler-course/chistov_a_combination_test/test.cpp"
   target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-unknown-linux-gnu"
   
-  define dso_local noundef zeroext i1 @_Z6isEveni(i32 noundef %0) local_unnamed_addr {
-    %2 = and i32 %0, 1
-    %3 = icmp eq i32 %2, 0
-    ret i1 %3
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <4 x float> @_Z24test_basic_and_operationDv4_fS_(<4 x float> noundef %a, <4 x float> noundef %b) local_unnamed_addr #0 {
+  entry:
+    %0 = bitcast <4 x float> %a to <4 x i32>
+    %1 = bitcast <4 x float> %b to <4 x i32>
+    %and.i = and <4 x i32> %1, %0
+    %2 = bitcast <4 x i32> %and.i to <4 x float>
+    ret <4 x float> %2
   }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <4 x float> @_Z23test_basic_or_operationDv4_fS_(<4 x float> noundef %a, <4 x float> noundef %b) local_unnamed_addr #0 {
+  entry:
+    %0 = bitcast <4 x float> %a to <4 x i32>
+    %1 = bitcast <4 x float> %b to <4 x i32>
+    %or.i = or <4 x i32> %1, %0
+    %2 = bitcast <4 x i32> %or.i to <4 x float>
+    ret <4 x float> %2
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <4 x float> @_Z24test_basic_xor_operationDv4_fS_(<4 x float> noundef %a, <4 x float> noundef %b) local_unnamed_addr #0 {
+  entry:
+    %0 = bitcast <4 x float> %a to <4 x i32>
+    %1 = bitcast <4 x float> %b to <4 x i32>
+    %xor.i = xor <4 x i32> %1, %0
+    %2 = bitcast <4 x i32> %xor.i to <4 x float>
+    ret <4 x float> %2
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <4 x float> @_Z30test_combined_logic_operationsDv4_fS_S_(<4 x float> noundef %a, <4 x float> noundef %b, <4 x float> noundef %c) local_unnamed_addr #0 {
+  entry:
+    %0 = bitcast <4 x float> %a to <4 x i32>
+    %1 = bitcast <4 x float> %b to <4 x i32>
+    %and.i = and <4 x i32> %1, %0
+    %2 = bitcast <4 x float> %c to <4 x i32>
+    %or.i = or <4 x i32> %and.i, %2
+    %xor.i = xor <4 x i32> %or.i, %0
+    %3 = bitcast <4 x i32> %xor.i to <4 x float>
+    ret <4 x float> %3
+  }
+  
+  attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable "min-legal-vector-width"="128" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+  
+  !llvm.module.flags = !{!0, !1, !2, !3}
+  !llvm.ident = !{!4}
+  
+  !0 = !{i32 1, !"wchar_size", i32 4}
+  !1 = !{i32 8, !"PIC Level", i32 2}
+  !2 = !{i32 7, !"PIE Level", i32 2}
+  !3 = !{i32 7, !"uwtable", i32 2}
+  !4 = !{!"clang version 19.1.6 (git@github.com:wabka22/compiler-course-2025.git b1d11e23163ceba6c5fab91e30f0f2c49ac43d9f)"}
 
 ...
 ---
-# CHECK: _Z6isEveni
-# CHECK: name:            _Z6isEveni
-name:            _Z6isEveni
+name:            _Z24test_basic_and_operationDv4_fS_
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -49,10 +129,14 @@ hasEHFunclets:   false
 isOutlined:      false
 debugInstrRef:   true
 failsVerification: false
-tracksDebugUserValues: true
-registers:       []
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128, preferred-register: '' }
+  - { id: 1, class: vr128, preferred-register: '' }
+  - { id: 2, class: vr128, preferred-register: '' }
 liveins:
-  - { reg: '$edi', virtual-reg: '' }
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
 frameInfo:
   isFrameAddressTaken: false
   isReturnAddressTaken: false
@@ -65,13 +149,13 @@ frameInfo:
   hasCalls:        false
   stackProtector:  ''
   functionContext: ''
-  maxCallFrameSize: 0
+  maxCallFrameSize: 4294967295
   cvBytesOfCalleeSavedRegisters: 0
   hasOpaqueSPAdjustment: false
   hasVAStart:      false
   hasMustTailInVarArgFunc: false
   hasTailCall:     false
-  isCalleeSavedInfoValid: true
+  isCalleeSavedInfoValid: false
   localFrameSize:  0
   savePoint:       ''
   restorePoint:    ''
@@ -84,15 +168,221 @@ constants:       []
 machineFunctionInfo:
   amxProgModel:    None
 body:             |
-  bb.0 (%ir-block.1):
-    liveins: $edi
+  bb.0.entry:
+    liveins: $xmm0, $xmm1
   
-    ; CHECK: TEST8ri renamable $dil, 1, implicit-def $eflags, implicit killed $edi
-    ; CHECK-NEXT: renamable $al = SETCCr 4, implicit killed $eflags
-    ; CHECK-NEXT: RET64 $al
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %2:vr128 = PANDrr %1, %0
+    $xmm0 = COPY %2
+    RET 0, $xmm0
 
-    TEST8ri renamable $dil, 1, implicit-def $eflags, implicit killed $edi
-    renamable $al = SETCCr 4, implicit killed $eflags
-    RET64 $al
+...
+---
+name:            _Z23test_basic_or_operationDv4_fS_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128, preferred-register: '' }
+  - { id: 1, class: vr128, preferred-register: '' }
+  - { id: 2, class: vr128, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1
+  
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %2:vr128 = PORrr %1, %0
+    $xmm0 = COPY %2
+    RET 0, $xmm0
+
+...
+---
+name:            _Z24test_basic_xor_operationDv4_fS_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128, preferred-register: '' }
+  - { id: 1, class: vr128, preferred-register: '' }
+  - { id: 2, class: vr128, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1
+  
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %2:vr128 = PXORrr %1, %0
+    $xmm0 = COPY %2
+    RET 0, $xmm0
+
+...
+---
+name:            _Z30test_combined_logic_operationsDv4_fS_S_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128, preferred-register: '' }
+  - { id: 1, class: vr128, preferred-register: '' }
+  - { id: 2, class: vr128, preferred-register: '' }
+  - { id: 3, class: vr128, preferred-register: '' }
+  - { id: 4, class: vr128, preferred-register: '' }
+  - { id: 5, class: vr128, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+  
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = PANDrr %1, %0
+    %4:vr128 = PORrr %3, %2
+    %5:vr128 = PXORrr %4, %0
+    $xmm0 = COPY %5
+    RET 0, $xmm0
 
 ...

--- a/llvm/test/compiler-course/chistov_a_combination_test/chistov_a_backend_test.mir
+++ b/llvm/test/compiler-course/chistov_a_combination_test/chistov_a_backend_test.mir
@@ -1,0 +1,98 @@
+# RUN: llc -mtriple x86_64-unknown-linux-gnu --load=%llvmshlibdir/CombinationPass_Chistov_Alexey_FIIT1_BACKEND%shlibext \
+# RUN: -run-pass=CombinationPass %s -o - | FileCheck %s
+
+
+# Source files
+
+# test.cpp
+#
+# [[nodiscard]] bool isEven(int value) noexcept { return value % 2 == 0; }
+
+# test.ll (-O2)
+#
+# define dso_local noundef zeroext i1 @_Z6isEveni(i32 noundef %0) local_unnamed_addr {
+#  %2 = and i32 %0, 1
+#  %3 = icmp eq i32 %2, 0
+#  ret i1 %3
+# }
+
+
+--- |
+  ; ModuleID = 'test.ll'
+  source_filename = "test.ll"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  
+  define dso_local noundef zeroext i1 @_Z6isEveni(i32 noundef %0) local_unnamed_addr {
+    %2 = and i32 %0, 1
+    %3 = icmp eq i32 %2, 0
+    ret i1 %3
+  }
+
+...
+---
+# CHECK: _Z6isEveni
+# CHECK: name:            _Z6isEveni
+name:            _Z6isEveni
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: true
+registers:       []
+liveins:
+  - { reg: '$edi', virtual-reg: '' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 0
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: true
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0 (%ir-block.1):
+    liveins: $edi
+  
+    ; CHECK: TEST8ri renamable $dil, 1, implicit-def $eflags, implicit killed $edi
+    ; CHECK-NEXT: renamable $al = SETCCr 4, implicit killed $eflags
+    ; CHECK-NEXT: RET64 $al
+
+    TEST8ri renamable $dil, 1, implicit-def $eflags, implicit killed $edi
+    renamable $al = SETCCr 4, implicit killed $eflags
+    RET64 $al
+
+...

--- a/llvm/test/compiler-course/chistov_a_combination_test/chistov_a_backend_test.mir
+++ b/llvm/test/compiler-course/chistov_a_combination_test/chistov_a_backend_test.mir
@@ -1,7 +1,10 @@
 # RUN: llc -mtriple x86_64-unknown-linux-gnu --load=%llvmshlibdir/CombinationPass_Chistov_Alexey_FIIT1_BACKEND%shlibext \
 # RUN: -run-pass=x86-logic-opt %s -o - | FileCheck %s
 
-##include <emmintrin.h>
+# Source files
+# test.cpp
+
+#include <emmintrin.h>
 
 #__m128 test_basic_and_operation(__m128 a, __m128 b) {
 #    return _mm_and_ps(a, b);
@@ -29,26 +32,6 @@
 #    __m128 t3 = _mm_xor_ps(t2, a);
 #    return t3;
 #} 
-
-# CHECK-LABEL:name: _Z24test_basic_and_operationDv4_fS_
-# CHECK: VPANDrr
-# CHECK-NOT: PANDrr
-
-# CHECK-LABEL:name: _Z23test_basic_or_operationDv4_fS_
-# CHECK: VPORrr
-# CHECK-NOT: PORrr
-
-# CHECK-LABEL:name: _Z24test_basic_xor_operationDv4_fS_
-# CHECK: VPXORrr
-# CHECK-NOT: PXORrr
-
-# CHECK-LABEL:name: _Z30test_combined_logic_operationsDv4_fS_S_
-# CHECK: VPANDrr
-# CHECK: VPORrr
-# CHECK: VPXORrr
-# CHECK-NOT: PANDrr
-# CHECK-NOT: PORrr
-# CHECK-NOT: PXORrr
 
 --- |
   ; ModuleID = 'llvm/test/compiler-course/chistov_a_combination_test/test.ll'
@@ -112,6 +95,7 @@
 
 ...
 ---
+# CHECK-LABEL:name: _Z24test_basic_and_operationDv4_fS_
 name:            _Z24test_basic_and_operationDv4_fS_
 alignment:       16
 exposesReturnsTwice: false
@@ -170,6 +154,13 @@ machineFunctionInfo:
 body:             |
   bb.0.entry:
     liveins: $xmm0, $xmm1
+
+    ; CHECK: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %2:vr128 = VPANDrr %1, %0
+    ; CHECK-NOT: %2:vr128 = PANDrr %1, %0
+    ; CHECK-NEXT: $xmm0 = COPY %2
+    ; CHECK-NEXT: RET 0, $xmm0
   
     %1:vr128 = COPY $xmm1
     %0:vr128 = COPY $xmm0
@@ -179,6 +170,7 @@ body:             |
 
 ...
 ---
+# CHECK-LABEL:name: _Z23test_basic_or_operationDv4_fS_
 name:            _Z23test_basic_or_operationDv4_fS_
 alignment:       16
 exposesReturnsTwice: false
@@ -237,6 +229,13 @@ machineFunctionInfo:
 body:             |
   bb.0.entry:
     liveins: $xmm0, $xmm1
+
+    ; CHECK: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %2:vr128 = VPORrr %1, %0
+    ; CHECK-NOT: %2:vr128 = PORrr %1, %0
+    ; CHECK-NEXT: $xmm0 = COPY %2
+    ; CHECK-NEXT: RET 0, $xmm0
   
     %1:vr128 = COPY $xmm1
     %0:vr128 = COPY $xmm0
@@ -246,6 +245,7 @@ body:             |
 
 ...
 ---
+# CHECK-LABEL:name: _Z24test_basic_xor_operationDv4_fS_
 name:            _Z24test_basic_xor_operationDv4_fS_
 alignment:       16
 exposesReturnsTwice: false
@@ -304,6 +304,13 @@ machineFunctionInfo:
 body:             |
   bb.0.entry:
     liveins: $xmm0, $xmm1
+
+    ; CHECK: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %2:vr128 = VPXORrr %1, %0
+    ; CHECK-NOT: %2:vr128 = PXORrr %1, %0
+    ; CHECK-NEXT: $xmm0 = COPY %2
+    ; CHECK-NEXT: RET 0, $xmm0
   
     %1:vr128 = COPY $xmm1
     %0:vr128 = COPY $xmm0
@@ -313,6 +320,7 @@ body:             |
 
 ...
 ---
+# CHECK-LABEL:name: _Z30test_combined_logic_operationsDv4_fS_S_
 name:            _Z30test_combined_logic_operationsDv4_fS_S_
 alignment:       16
 exposesReturnsTwice: false
@@ -375,6 +383,19 @@ machineFunctionInfo:
 body:             |
   bb.0.entry:
     liveins: $xmm0, $xmm1, $xmm2
+
+    
+    ; CHECK: %2:vr128 = COPY $xmm2
+    ; CHECK-NEXT: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %3:vr128 = VPANDrr %1, %0
+    ; CHECK-NEXT: %4:vr128 = VPORrr %3, %2
+    ; CHECK-NEXT: %5:vr128 = VPXORrr %4, %0
+    ; CHECK-NOT: %3:vr128 = PANDrr %1, %0
+    ; CHECK-NOT: %4:vr128 = PORrr %3, %2
+    ; CHECK-NOT: %5:vr128 = PXORrr %4, %0
+    ; CHECK-NEXT: $xmm0 = COPY %5
+    ; CHECK-NEXT: RET 0, $xmm0
   
     %2:vr128 = COPY $xmm2
     %1:vr128 = COPY $xmm1

--- a/llvm/test/compiler-course/chistov_a_combination_test/chistov_a_backend_test.mir
+++ b/llvm/test/compiler-course/chistov_a_combination_test/chistov_a_backend_test.mir
@@ -399,5 +399,3 @@ body:             |
     %5:vr128 = PXORrr %4, %0
     $xmm0 = COPY %5
     RET 0, $xmm0
-
-...


### PR DESCRIPTION
Проход для оптимизации логических операций (AND, OR, XOR) в архитектуре X86 с фугкцией `applyOptimizations`, которая принимает предикат `shouldTransform` для проверки применимости оптимизации и функцию `performTransform` для выполнения преобразований. Основные оптимизации включают преобразование SSE инструкций (ANDPS/ORPS/XORPS) в более эффективные AVX аналоги (VANDPS/VORPS/VXORPS) и объединение последовательных логических операций для сокращения количества инструкций, поддерживая как операции с плавающей точкой (ANDPS, ORPS, XORPS), так и целочисленные (PAND, POR, PXOR, PANDN). Подход обеспечивает расширяемость за счет простого добавления новых оптимизаций.