### PR TITLE
Соловьев Алексей. Лабораторная работа 3: Backend. Вариант 4

### DIFF
--- a/llvm/compiler-course/backend/solovev_a/CMakeLists.txt
+++ b/llvm/compiler-course/backend/solovev_a/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(Title "Lab_3_backend")
+set(Student "Solovev_a")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_BACKEND")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY
+)
+
+target_include_directories(${TARGET_NAME} PUBLIC ${PATH_TO_X86})
+set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/compiler-course/backend/solovev_a/solovev_a.cpp
+++ b/llvm/compiler-course/backend/solovev_a/solovev_a.cpp
@@ -21,14 +21,16 @@ public:
   static char ID;
   FMSUBComposePass() : MachineFunctionPass(ID) {}
 
-  bool runOnMachineFunction(MachineFunction &MF) override {
-    const X86Subtarget &ST = MF.getSubtarget<X86Subtarget>();
-    const X86InstrInfo *TII = ST.getInstrInfo();
+  bool runOnMachineFunction(MachineFunction& MF) override {
+    const X86Subtarget& ST = MF.getSubtarget<X86Subtarget>();
+    if (!ST.hasFMA())
+      return false;
+    const X86InstrInfo* TII = ST.getInstrInfo();
     auto &MRI = MF.getRegInfo();
     bool Changed = false;
     for (auto &MBB : MF) {
       for (auto MI = MBB.instr_begin(), ME = MBB.instr_end(); MI != ME;) {
-        MachineInstr &Sub = *MI++;
+        MachineInstr& Sub = *MI++;
         if (Sub.isMetaInstruction())
           continue;
         unsigned SubOpcode = Sub.getOpcode();
@@ -37,6 +39,8 @@ public:
         Register SubDst = Sub.getOperand(0).getReg();
         Register SubOp1 = Sub.getOperand(1).getReg();
         Register SubOp2 = Sub.getOperand(2).getReg();
+        if (!MRI.hasOneUse(SubOp2))
+          continue;
         MachineInstr *Mul = MRI.getUniqueVRegDef(SubOp2);
         if (!Mul)
           continue;
@@ -46,7 +50,7 @@ public:
         Register MulOp1 = Mul->getOperand(1).getReg();
         Register MulOp2 = Mul->getOperand(2).getReg();
         DebugLoc DL = Sub.getDebugLoc();
-        MachineBasicBlock &MBBRef = *Sub.getParent();
+        MachineBasicBlock& MBBRef = *Sub.getParent();
         unsigned NewOpcode = (SubOpcode == X86::VSUBSSrr) ? X86::VFNMADD213SSr
                                                           : X86::VFNMADD213SDr;
         BuildMI(MBBRef, &Sub, DL, TII->get(NewOpcode), SubDst)

--- a/llvm/compiler-course/backend/solovev_a/solovev_a.cpp
+++ b/llvm/compiler-course/backend/solovev_a/solovev_a.cpp
@@ -21,16 +21,16 @@ public:
   static char ID;
   FMSUBComposePass() : MachineFunctionPass(ID) {}
 
-  bool runOnMachineFunction(MachineFunction& MF) override {
-    const X86Subtarget& ST = MF.getSubtarget<X86Subtarget>();
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    const X86Subtarget &ST = MF.getSubtarget<X86Subtarget>();
     if (!ST.hasFMA())
       return false;
-    const X86InstrInfo* TII = ST.getInstrInfo();
+    const X86InstrInfo *TII = ST.getInstrInfo();
     auto &MRI = MF.getRegInfo();
     bool Changed = false;
     for (auto &MBB : MF) {
       for (auto MI = MBB.instr_begin(), ME = MBB.instr_end(); MI != ME;) {
-        MachineInstr& Sub = *MI++;
+        MachineInstr &Sub = *MI++;
         if (Sub.isMetaInstruction())
           continue;
         unsigned SubOpcode = Sub.getOpcode();
@@ -50,7 +50,7 @@ public:
         Register MulOp1 = Mul->getOperand(1).getReg();
         Register MulOp2 = Mul->getOperand(2).getReg();
         DebugLoc DL = Sub.getDebugLoc();
-        MachineBasicBlock& MBBRef = *Sub.getParent();
+        MachineBasicBlock &MBBRef = *Sub.getParent();
         unsigned NewOpcode = (SubOpcode == X86::VSUBSSrr) ? X86::VFNMADD213SSr
                                                           : X86::VFNMADD213SDr;
         BuildMI(MBBRef, &Sub, DL, TII->get(NewOpcode), SubDst)

--- a/llvm/compiler-course/backend/solovev_a/solovev_a.cpp
+++ b/llvm/compiler-course/backend/solovev_a/solovev_a.cpp
@@ -1,0 +1,86 @@
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/TargetInstrInfo.h"
+#include "llvm/Target/TargetMachine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+#include "X86.h"
+
+#define DEBUG_TYPE "mul_sub_solovev"
+
+using namespace llvm;
+
+namespace {
+
+    class FMSUBComposePass : public MachineFunctionPass {
+    public:
+        static char ID;
+        FMSUBComposePass() : MachineFunctionPass(ID) {}
+
+        bool runOnMachineFunction(MachineFunction& MF) override {
+            const X86Subtarget& ST = MF.getSubtarget<X86Subtarget>();
+            const X86InstrInfo* TII = ST.getInstrInfo();
+
+            auto& MRI = MF.getRegInfo();
+            bool Changed = false;
+
+            for (auto& MBB : MF) {
+                for (auto MI = MBB.instr_begin(), ME = MBB.instr_end(); MI != ME;) {
+                    MachineInstr& Sub = *MI++;
+
+                    if (Sub.isMetaInstruction())
+                        continue;
+
+                    unsigned SubOpcode = Sub.getOpcode();
+                    if (SubOpcode != X86::VSUBSSrr && SubOpcode != X86::VSUBSDrr)
+                        continue;
+
+                    Register SubDst = Sub.getOperand(0).getReg();
+                    Register SubOp1 = Sub.getOperand(1).getReg(); 
+                    Register SubOp2 = Sub.getOperand(2).getReg(); 
+
+                    MachineInstr* Mul = MRI.getUniqueVRegDef(SubOp2);
+                    if (!Mul)
+                        continue;
+
+                    unsigned MulOpcode = Mul->getOpcode();
+                    if (MulOpcode != X86::VMULSSrr && MulOpcode != X86::VMULSDrr)
+                        continue;
+
+                    Register MulOp1 = Mul->getOperand(1).getReg(); 
+                    Register MulOp2 = Mul->getOperand(2).getReg(); 
+
+                    DebugLoc DL = Sub.getDebugLoc();
+                    MachineBasicBlock& MBBRef = *Sub.getParent();
+
+                    unsigned NewOpcode = (SubOpcode == X86::VSUBSSrr)
+                        ? X86::VFNMADD213SSr
+                        : X86::VFNMADD213SDr;
+
+                    BuildMI(MBBRef, &Sub, DL, TII->get(NewOpcode), SubDst)
+                        .addReg(SubOp1) 
+                        .addReg(MulOp1) 
+                        .addReg(MulOp2) 
+                        .addImm(0)      
+                        .addReg(X86::MXCSR, RegState::Implicit); 
+
+                    Sub.eraseFromParent();
+                    Mul->eraseFromParent();
+                    Changed = true;
+                }
+            }
+
+            return Changed;
+        }
+    };
+
+    char FMSUBComposePass::ID = 0;
+
+} 
+
+static RegisterPass<FMSUBComposePass>
+X("mul_sub_solovev", "Fuse MUL + SUB into VFNMADD213 instructions", false, false);

--- a/llvm/compiler-course/backend/solovev_a/solovev_a.cpp
+++ b/llvm/compiler-course/backend/solovev_a/solovev_a.cpp
@@ -35,16 +35,16 @@ public:
         if (SubOpcode != X86::VSUBSSrr && SubOpcode != X86::VSUBSDrr)
           continue;
         Register SubDst = Sub.getOperand(0).getReg();
-        Register SubOp1 = Sub.getOperand(1).getReg(); 
-        Register SubOp2 = Sub.getOperand(2).getReg(); 
+        Register SubOp1 = Sub.getOperand(1).getReg();
+        Register SubOp2 = Sub.getOperand(2).getReg();
         MachineInstr *Mul = MRI.getUniqueVRegDef(SubOp2);
         if (!Mul)
           continue;
         unsigned MulOpcode = Mul->getOpcode();
         if (MulOpcode != X86::VMULSSrr && MulOpcode != X86::VMULSDrr)
           continue;
-        Register MulOp1 = Mul->getOperand(1).getReg(); 
-        Register MulOp2 = Mul->getOperand(2).getReg(); 
+        Register MulOp1 = Mul->getOperand(1).getReg();
+        Register MulOp2 = Mul->getOperand(2).getReg();
         DebugLoc DL = Sub.getDebugLoc();
         MachineBasicBlock &MBBRef = *Sub.getParent();
         unsigned NewOpcode = (SubOpcode == X86::VSUBSSrr) ? X86::VFNMADD213SSr
@@ -61,12 +61,12 @@ public:
       }
     }
     return Changed;
-  }      
+  }
 };
 char FMSUBComposePass::ID = 0;
 
 } // namespace
 
 static RegisterPass<FMSUBComposePass>
-   X("mul_sub_solovev", "Fuse MUL + SUB into VFNMADD213 instructions", false,
-     false);
+    X("mul_sub_solovev", "Fuse MUL + SUB into VFNMADD213 instructions", false,
+      false);

--- a/llvm/compiler-course/backend/solovev_a/solovev_a.cpp
+++ b/llvm/compiler-course/backend/solovev_a/solovev_a.cpp
@@ -1,14 +1,14 @@
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
-#include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/TargetInstrInfo.h"
-#include "llvm/Target/TargetMachine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
-#include "X86InstrInfo.h"
-#include "X86Subtarget.h"
-#include "X86.h"
+#include "llvm/Target/TargetMachine.h"
 
 #define DEBUG_TYPE "mul_sub_solovev"
 
@@ -16,71 +16,57 @@ using namespace llvm;
 
 namespace {
 
-    class FMSUBComposePass : public MachineFunctionPass {
-    public:
-        static char ID;
-        FMSUBComposePass() : MachineFunctionPass(ID) {}
+class FMSUBComposePass : public MachineFunctionPass {
+public:
+  static char ID;
+  FMSUBComposePass() : MachineFunctionPass(ID) {}
 
-        bool runOnMachineFunction(MachineFunction& MF) override {
-            const X86Subtarget& ST = MF.getSubtarget<X86Subtarget>();
-            const X86InstrInfo* TII = ST.getInstrInfo();
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    const X86Subtarget &ST = MF.getSubtarget<X86Subtarget>();
+    const X86InstrInfo *TII = ST.getInstrInfo();
+    auto &MRI = MF.getRegInfo();
+    bool Changed = false;
+    for (auto &MBB : MF) {
+      for (auto MI = MBB.instr_begin(), ME = MBB.instr_end(); MI != ME;) {
+        MachineInstr &Sub = *MI++;
+        if (Sub.isMetaInstruction())
+          continue;
+        unsigned SubOpcode = Sub.getOpcode();
+        if (SubOpcode != X86::VSUBSSrr && SubOpcode != X86::VSUBSDrr)
+          continue;
+        Register SubDst = Sub.getOperand(0).getReg();
+        Register SubOp1 = Sub.getOperand(1).getReg(); 
+        Register SubOp2 = Sub.getOperand(2).getReg(); 
+        MachineInstr *Mul = MRI.getUniqueVRegDef(SubOp2);
+        if (!Mul)
+          continue;
+        unsigned MulOpcode = Mul->getOpcode();
+        if (MulOpcode != X86::VMULSSrr && MulOpcode != X86::VMULSDrr)
+          continue;
+        Register MulOp1 = Mul->getOperand(1).getReg(); 
+        Register MulOp2 = Mul->getOperand(2).getReg(); 
+        DebugLoc DL = Sub.getDebugLoc();
+        MachineBasicBlock &MBBRef = *Sub.getParent();
+        unsigned NewOpcode = (SubOpcode == X86::VSUBSSrr) ? X86::VFNMADD213SSr
+                                                          : X86::VFNMADD213SDr;
+        BuildMI(MBBRef, &Sub, DL, TII->get(NewOpcode), SubDst)
+            .addReg(SubOp1)
+            .addReg(MulOp1)
+            .addReg(MulOp2)
+            .addImm(0)
+            .addReg(X86::MXCSR, RegState::Implicit);
+        Sub.eraseFromParent();
+        Mul->eraseFromParent();
+        Changed = true;
+      }
+    }
+    return Changed;
+  }      
+};
+char FMSUBComposePass::ID = 0;
 
-            auto& MRI = MF.getRegInfo();
-            bool Changed = false;
-
-            for (auto& MBB : MF) {
-                for (auto MI = MBB.instr_begin(), ME = MBB.instr_end(); MI != ME;) {
-                    MachineInstr& Sub = *MI++;
-
-                    if (Sub.isMetaInstruction())
-                        continue;
-
-                    unsigned SubOpcode = Sub.getOpcode();
-                    if (SubOpcode != X86::VSUBSSrr && SubOpcode != X86::VSUBSDrr)
-                        continue;
-
-                    Register SubDst = Sub.getOperand(0).getReg();
-                    Register SubOp1 = Sub.getOperand(1).getReg(); 
-                    Register SubOp2 = Sub.getOperand(2).getReg(); 
-
-                    MachineInstr* Mul = MRI.getUniqueVRegDef(SubOp2);
-                    if (!Mul)
-                        continue;
-
-                    unsigned MulOpcode = Mul->getOpcode();
-                    if (MulOpcode != X86::VMULSSrr && MulOpcode != X86::VMULSDrr)
-                        continue;
-
-                    Register MulOp1 = Mul->getOperand(1).getReg(); 
-                    Register MulOp2 = Mul->getOperand(2).getReg(); 
-
-                    DebugLoc DL = Sub.getDebugLoc();
-                    MachineBasicBlock& MBBRef = *Sub.getParent();
-
-                    unsigned NewOpcode = (SubOpcode == X86::VSUBSSrr)
-                        ? X86::VFNMADD213SSr
-                        : X86::VFNMADD213SDr;
-
-                    BuildMI(MBBRef, &Sub, DL, TII->get(NewOpcode), SubDst)
-                        .addReg(SubOp1) 
-                        .addReg(MulOp1) 
-                        .addReg(MulOp2) 
-                        .addImm(0)      
-                        .addReg(X86::MXCSR, RegState::Implicit); 
-
-                    Sub.eraseFromParent();
-                    Mul->eraseFromParent();
-                    Changed = true;
-                }
-            }
-
-            return Changed;
-        }
-    };
-
-    char FMSUBComposePass::ID = 0;
-
-} 
+} // namespace
 
 static RegisterPass<FMSUBComposePass>
-X("mul_sub_solovev", "Fuse MUL + SUB into VFNMADD213 instructions", false, false);
+   X("mul_sub_solovev", "Fuse MUL + SUB into VFNMADD213 instructions", false,
+     false);

--- a/llvm/test/compiler-course/solovev_a_test_3/test_backend.mir
+++ b/llvm/test/compiler-course/solovev_a_test_3/test_backend.mir
@@ -1,0 +1,283 @@
+#  RUN: llc -mtriple=x86_64-unknown-linux-gnu -mattr=+fma \
+#  RUN:     --load=%llvmshlibdir/Lab_3_backend_Solovev_a_FIIT1_BACKEND%shlibext \
+#  RUN:     -run-pass=mul_sub_solovev %s -o - | FileCheck %s
+
+# CHECK-LABEL: name: test_solovev_float
+# CHECK: %[[RES:[0-9]+]]:fr32 = VFNMADD213SSr %2, %0, %1, 0, implicit $mxcsr, implicit $mxcsr
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
+# CHECK-LABEL: name: test_solovev_double
+# CHECK: %[[RES:[0-9]+]]:fr64 = VFNMADD213SDr %2, %0, %1, 0, implicit $mxcsr, implicit $mxcsr
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
+# CHECK-LABEL: name: test_solovev_double_change_vals
+# CHECK: %[[RES:[0-9]+]]:fr64 = VFNMADD213SDr %2, %1, %0, 0, implicit $mxcsr, implicit $mxcsr
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
+--- |
+  ; ModuleID = 'mulsub_test_solovev_a.ll'
+  source_filename = "mulsub_test_solovev_a.cpp"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-pc-linux-gnu"
+
+  module asm ".globl _ZSt21ios_base_library_initv"
+
+  %"class.std::basic_ostream" = type { ptr, %"class.std::basic_ios" }
+  %"class.std::basic_ios" = type { %"class.std::ios_base", ptr, i8, i8, ptr, ptr, ptr, ptr }
+  %"class.std::ios_base" = type { ptr, i64, i64, i32, i32, i32, ptr, %"struct.std::ios_base::_Words", [8 x %"struct.std::ios_base::_Words"], i32, ptr, %"class.std::locale" }
+  %"struct.std::ios_base::_Words" = type { ptr, i64 }
+  %"class.std::locale" = type { ptr }
+
+  @_ZSt4cout = external global %"class.std::basic_ostream", align 8
+
+  ; Function Attrs: noinline nounwind mustprogress uwtable
+  define dso_local float @test_solovev_float(float %x, float %y, float %acc) {
+  entry:
+    %mul = fmul float %x, %y
+    %acc_val = fsub float %acc, %mul
+    ret float %acc_val
+  }
+
+  ; Function Attrs: noinline nounwind mustprogress uwtable
+  define dso_local noundef double @test_solovev_double(double noundef %x, double noundef %y, double noundef %acc) #0 {
+  entry:
+    %mul = fmul double %x, %y
+    %acc_val = fsub double %acc, %mul
+    ret double %acc_val
+  }
+
+  ; Function Attrs: noinline nounwind mustprogress uwtable
+  define dso_local noundef double @test_solovev_double_change_vals(double noundef %x, double noundef %y, double noundef %acc) #0 {
+  entry:
+    %mul = fmul double %y, %x
+    %acc_val = fsub double %acc, %mul
+    ret double %acc_val
+  }
+
+
+  attributes #0 = { mustprogress noinline norecurse nounwind uwtable "frame-pointer"="non-leaf" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+fma,-avx" "tune-cpu"="x86-64-v3" }
+
+  !llvm.module.flags = !{!0, !1, !2, !3}
+  !llvm.ident = !{!4}
+
+  !0 = !{i32 1, !"wchar_size", i32 4}
+  !1 = !{i32 2, !"Debug Info Version", i32 3}
+  !2 = !{i32 7, !"uwtable", i32 2}
+  !3 = !{i32 7, !"frame-pointer", i32 1}
+  !4 = !{!"Solovev LLVM Custom v1.0"}
+
+...
+---
+name:            test_solovev_float
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+  - { id: 4, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }  
+  - { reg: '$xmm1', virtual-reg: '%1' }  
+  - { reg: '$xmm2', virtual-reg: '%2' }  
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+    %0:fr32 = COPY $xmm0  ; x
+    %1:fr32 = COPY $xmm1  ; y
+    %2:fr32 = COPY $xmm2  ; acc
+    %3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr
+    %4:fr32 = nofpexcept VSUBSSrr %2, killed %3, implicit $mxcsr
+    $xmm0 = COPY %4
+    RET64 implicit $xmm0
+
+...
+---
+name:            test_solovev_double
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr64, preferred-register: '' }
+  - { id: 1, class: fr64, preferred-register: '' }
+  - { id: 2, class: fr64, preferred-register: '' }
+  - { id: 3, class: fr64, preferred-register: '' }
+  - { id: 4, class: fr64, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+    %0:fr64 = COPY $xmm0  ; x
+    %1:fr64 = COPY $xmm1  ; y
+    %2:fr64 = COPY $xmm2  ; acc
+    %3:fr64 = nofpexcept VMULSDrr %0, %1, implicit $mxcsr
+    %4:fr64 = nofpexcept VSUBSDrr %2, killed %3, implicit $mxcsr
+    $xmm0 = COPY %4
+    RET64 implicit $xmm0
+
+...
+---
+name:            test_solovev_double_change_vals
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr64, preferred-register: '' }
+  - { id: 1, class: fr64, preferred-register: '' }
+  - { id: 2, class: fr64, preferred-register: '' }
+  - { id: 3, class: fr64, preferred-register: '' }
+  - { id: 4, class: fr64, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+    %0:fr64 = COPY $xmm0  ; x
+    %1:fr64 = COPY $xmm1  ; y
+    %2:fr64 = COPY $xmm2  ; acc
+    %3:fr64 = nofpexcept VMULSDrr %1, %0, implicit $mxcsr
+    %4:fr64 = nofpexcept VSUBSDrr %2, killed %3, implicit $mxcsr
+    $xmm0 = COPY %4
+    RET64 implicit $xmm0

--- a/llvm/test/compiler-course/solovev_a_test_3/test_backend.mir
+++ b/llvm/test/compiler-course/solovev_a_test_3/test_backend.mir
@@ -2,21 +2,6 @@
 #  RUN:     --load=%llvmshlibdir/Lab_3_backend_Solovev_a_FIIT1_BACKEND%shlibext \
 #  RUN:     -run-pass=mul_sub_solovev %s -o - | FileCheck %s
 
-# CHECK-LABEL: name: test_solovev_float
-# CHECK: %[[RES:[0-9]+]]:fr32 = VFNMADD213SSr %2, %0, %1, 0, implicit $mxcsr, implicit $mxcsr
-# CHECK: $xmm0 = COPY %[[RES]]
-# CHECK: RET64 implicit $xmm0
-
-# CHECK-LABEL: name: test_solovev_double
-# CHECK: %[[RES:[0-9]+]]:fr64 = VFNMADD213SDr %2, %0, %1, 0, implicit $mxcsr, implicit $mxcsr
-# CHECK: $xmm0 = COPY %[[RES]]
-# CHECK: RET64 implicit $xmm0
-
-# CHECK-LABEL: name: test_solovev_double_change_vals
-# CHECK: %[[RES:[0-9]+]]:fr64 = VFNMADD213SDr %2, %1, %0, 0, implicit $mxcsr, implicit $mxcsr
-# CHECK: $xmm0 = COPY %[[RES]]
-# CHECK: RET64 implicit $xmm0
-
 --- |
   ; ModuleID = 'mulsub_test_solovev_a.ll'
   source_filename = "mulsub_test_solovev_a.cpp"
@@ -71,6 +56,12 @@
 
 ...
 ---
+
+# CHECK-LABEL: name: test_solovev_float
+# CHECK: %[[RES:[0-9]+]]:fr32 = VFNMADD213SSr %2, %0, %1, 0, implicit $mxcsr, implicit $mxcsr
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
 name:            test_solovev_float
 alignment:       16
 exposesReturnsTwice: false
@@ -142,6 +133,12 @@ body:             |
 
 ...
 ---
+
+# CHECK-LABEL: name: test_solovev_double
+# CHECK: %[[RES:[0-9]+]]:fr64 = VFNMADD213SDr %2, %0, %1, 0, implicit $mxcsr, implicit $mxcsr
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
 name:            test_solovev_double
 alignment:       16
 exposesReturnsTwice: false
@@ -213,6 +210,12 @@ body:             |
 
 ...
 ---
+
+# CHECK-LABEL: name: test_solovev_double_change_vals
+# CHECK: %[[RES:[0-9]+]]:fr64 = VFNMADD213SDr %2, %1, %0, 0, implicit $mxcsr, implicit $mxcsr
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
 name:            test_solovev_double_change_vals
 alignment:       16
 exposesReturnsTwice: false


### PR DESCRIPTION
Этот пасс выполняет оптимизацию на уровне машинных инструкций для архитектуры x86 с поддержкой FMA, улучшая вычисления выражений вида acc - (x * y). Он находит пары инструкций, состоящие из умножения (например, VMULSSrr или VMULSDrr) и вычитания (например, VSUBSSrr или VSUBSDrr), и заменяет их на одну инструкцию FMA — VFNMADD213SSr или VFNMADD213SDr, в зависимости от типа данных. Эта оптимизация снижает количество инструкций и может улучшить производительность за счет использования FMA-инструкции, которая выполняет обе операции (умножение и вычитание) за один шаг. Пасс также правильно обрабатывает операнды и сохраняет информацию о возможных побочных эффектах.