### PR TITLE
Фролова Елизавета. Лабораторная работа 3: Backend. Вариант 3

### DIFF
--- a/llvm/compiler-course/backend/frolova_e_fma/CMakeLists.txt
+++ b/llvm/compiler-course/backend/frolova_e_fma/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(Title "DecomposeFMAPass")
+set(Student "Frolova_Elizaveta")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_BACKEND")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY
+)
+
+target_include_directories(${TARGET_NAME} PUBLIC ${PATH_TO_X86})
+set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/compiler-course/backend/frolova_e_fma/frolova_e_pass.cpp
+++ b/llvm/compiler-course/backend/frolova_e_fma/frolova_e_pass.cpp
@@ -1,0 +1,95 @@
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/TargetRegisterInfo.h"
+
+using namespace llvm;
+
+namespace {
+
+using OperandOrder = std::array<unsigned, 3>;
+
+class DecomposeFMAPass : public MachineFunctionPass {
+public:
+  static char ID;
+  DecomposeFMAPass() : MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    bool Changed = false;
+    const X86InstrInfo *TII = MF.getSubtarget<X86Subtarget>().getInstrInfo();
+
+    for (auto &MBB : MF) {
+      for (auto MI = MBB.begin(); MI != MBB.end();) {
+        MachineInstr &Instr = *MI++;
+        if (isFMAOpcode(Instr.getOpcode())) {
+          Changed |= decomposeFMA(Instr, MBB);
+        }
+      }
+    }
+
+    return Changed;
+  }
+
+private:
+  const DenseMap<unsigned, OperandOrder> FMAOperandOrder = {
+      {X86::VFMADD213SSr, {2, 1, 3}}, {X86::VFMADD213SDr, {2, 1, 3}},
+      {X86::VFMADD213PSr, {2, 1, 3}}, {X86::VFMADD213PDr, {2, 1, 3}},
+      {X86::VFMADD231SSr, {1, 3, 2}}, {X86::VFMADD231SDr, {1, 3, 2}},
+      {X86::VFMADD231PSr, {1, 3, 2}}, {X86::VFMADD231PDr, {1, 3, 2}},
+      {X86::VFMADD132SSr, {1, 2, 3}}, {X86::VFMADD132SDr, {1, 2, 3}},
+      {X86::VFMADD132PSr, {1, 2, 3}}, {X86::VFMADD132PDr, {1, 2, 3}},
+  };
+
+  bool isFMAOpcode(unsigned Opcode) const {
+    return FMAOperandOrder.contains(Opcode);
+  }
+
+  std::pair<unsigned, unsigned> getMulAddOpcodes(unsigned Opcode) const {
+    if (Opcode == X86::VFMADD213SSr || Opcode == X86::VFMADD231SSr ||
+        Opcode == X86::VFMADD132SSr)
+      return {X86::VMULSSrr, X86::VADDSSrr};
+    if (Opcode == X86::VFMADD213SDr || Opcode == X86::VFMADD231SDr ||
+        Opcode == X86::VFMADD132SDr)
+      return {X86::VMULSDrr, X86::VADDSDrr};
+    if (Opcode == X86::VFMADD213PSr || Opcode == X86::VFMADD231PSr ||
+        Opcode == X86::VFMADD132PSr)
+      return {X86::VMULPSrr, X86::VADDPSrr};
+    return {X86::VMULPDrr, X86::VADDPDrr};
+  }
+
+  bool decomposeFMA(MachineInstr &MI, MachineBasicBlock &MBB) {
+    const X86InstrInfo *TII =
+        MBB.getParent()->getSubtarget<X86Subtarget>().getInstrInfo();
+    MachineRegisterInfo &MRI = MBB.getParent()->getRegInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    unsigned Opcode = MI.getOpcode();
+
+    auto It = FMAOperandOrder.find(Opcode);
+    assert(It != FMAOperandOrder.end() && "Unexpected FMA opcode!");
+    OperandOrder Order = It->second;
+
+    Register Dest = MI.getOperand(0).getReg();
+    Register A = MI.getOperand(Order[0]).getReg();
+    Register B = MI.getOperand(Order[1]).getReg();
+    Register C = MI.getOperand(Order[2]).getReg();
+
+    auto [MulOpcode, AddOpcode] = getMulAddOpcodes(Opcode);
+    Register Temp = MRI.createVirtualRegister(MRI.getRegClass(A));
+
+    BuildMI(MBB, MI, DL, TII->get(MulOpcode), Temp).addReg(A).addReg(B);
+    BuildMI(MBB, MI, DL, TII->get(AddOpcode), Dest).addReg(C).addReg(Temp);
+
+    MI.eraseFromParent();
+    return true;
+  }
+};
+
+char DecomposeFMAPass::ID = 0;
+
+static RegisterPass<DecomposeFMAPass>
+    X("fma-x86", "Decompose FMA into MUL + ADD", false, false);
+
+} // namespace

--- a/llvm/compiler-course/backend/frolova_e_fma/frolova_e_pass.cpp
+++ b/llvm/compiler-course/backend/frolova_e_fma/frolova_e_pass.cpp
@@ -19,7 +19,6 @@ public:
 
   bool runOnMachineFunction(MachineFunction &MF) override {
     bool Changed = false;
-    const X86InstrInfo *TII = MF.getSubtarget<X86Subtarget>().getInstrInfo();
 
     for (auto &MBB : MF) {
       for (auto MI = MBB.begin(); MI != MBB.end();) {
@@ -37,10 +36,10 @@ private:
   const DenseMap<unsigned, OperandOrder> FMAOperandOrder = {
       {X86::VFMADD213SSr, {2, 1, 3}}, {X86::VFMADD213SDr, {2, 1, 3}},
       {X86::VFMADD213PSr, {2, 1, 3}}, {X86::VFMADD213PDr, {2, 1, 3}},
-      {X86::VFMADD231SSr, {1, 3, 2}}, {X86::VFMADD231SDr, {1, 3, 2}},
-      {X86::VFMADD231PSr, {1, 3, 2}}, {X86::VFMADD231PDr, {1, 3, 2}},
-      {X86::VFMADD132SSr, {1, 2, 3}}, {X86::VFMADD132SDr, {1, 2, 3}},
-      {X86::VFMADD132PSr, {1, 2, 3}}, {X86::VFMADD132PDr, {1, 2, 3}},
+      {X86::VFMADD231SSr, {2, 3, 1}}, {X86::VFMADD231SDr, {2, 3, 1}},
+      {X86::VFMADD231PSr, {2, 3, 1}}, {X86::VFMADD231PDr, {2, 3, 1}},
+      {X86::VFMADD132SSr, {1, 3, 2}}, {X86::VFMADD132SDr, {1, 3, 2}},
+      {X86::VFMADD132PSr, {1, 3, 2}}, {X86::VFMADD132PDr, {1, 3, 2}},
   };
 
   bool isFMAOpcode(unsigned Opcode) const {

--- a/llvm/test/compiler-course/frolova_e_fma_tests/frolova_e_backend.mir
+++ b/llvm/test/compiler-course/frolova_e_fma_tests/frolova_e_backend.mir
@@ -1,0 +1,393 @@
+#  RUN: llc -mtriple=x86_64-unknown-linux-gnu -mattr=+avx \
+#  RUN:     --load=%llvmshlibdir/DecomposeFMAPass_Frolova_Elizaveta_FIIT3_BACKEND%shlibext \
+#  RUN:     -run-pass=fma-x86 %s -o - | FileCheck %s
+
+# Source File
+# test.cpp
+
+#include <immintrin.h>
+
+#// Test 1: Basic FMA-operation (a * b + c)
+#float test_fma_basic(float a, float b, float c) {
+#    return _mm_cvtss_f32(_mm_fmadd_ss(_mm_set_ss(a), _mm_set_ss(b), _mm_set_ss(c)));
+#}
+
+#// Test 2: FMA with same operand
+#float test_fma_same_reg(float a, float b) {
+#    return _mm_cvtss_f32(_mm_fmadd_ss(_mm_set_ss(a), _mm_set_ss(a), _mm_set_ss(b)));
+#}
+
+#// Test 3: No FMA
+#float test_no_fma(float a, float b, float c) {
+#    __m128 mul = _mm_mul_ss(_mm_set_ss(a), _mm_set_ss(b));
+#    return _mm_cvtss_f32(mul);
+#}
+
+#// Test 4: No FMA, but mul + add separately
+#float test_mul_add(float a, float b, float c) {
+#    __m128 mul = _mm_mul_ss(_mm_set_ss(a), _mm_set_ss(b));
+#    __m128 res = _mm_add_ss(mul, _mm_set_ss(c));
+#    return _mm_cvtss_f32(res);
+#}
+
+--- |
+  ; ModuleID = 'llvm/test/compiler-course/frolova_e_fma_tests/test.ll'
+  source_filename = "/home/liza/code/compiler-course-2025/llvm/test/compiler-course/frolova_e_fma_tests/test.cpp"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-unknown-linux-gnu"
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef float @_Z14test_fma_basicfff(float noundef %a, float noundef %b, float noundef %c) local_unnamed_addr #0 {
+  entry:
+    %0 = tail call float @llvm.fma.f32(float %a, float %b, float %c)
+    ret float %0
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef float @_Z17test_fma_same_regff(float noundef %a, float noundef %b) local_unnamed_addr #0 {
+  entry:
+    %0 = tail call float @llvm.fma.f32(float %a, float %a, float %b)
+    ret float %0
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef float @_Z11test_no_fmafff(float noundef %a, float noundef %b, float noundef %c) local_unnamed_addr #0 {
+  entry:
+    %mul.i = fmul float %a, %b
+    ret float %mul.i
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef float @_Z12test_mul_addfff(float noundef %a, float noundef %b, float noundef %c) local_unnamed_addr #0 {
+  entry:
+    %mul.i = fmul float %a, %b
+    %add.i = fadd float %mul.i, %c
+    ret float %add.i
+  }
+  
+  ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+  declare float @llvm.fma.f32(float, float, float) #1
+  
+  attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable "min-legal-vector-width"="128" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+avx,+cmov,+crc32,+cx8,+fma,+fxsr,+mmx,+popcnt,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3,+x87,+xsave" "tune-cpu"="generic" }
+  attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+  
+  !llvm.module.flags = !{!0, !1, !2, !3}
+  !llvm.ident = !{!4}
+  
+  !0 = !{i32 1, !"wchar_size", i32 4}
+  !1 = !{i32 8, !"PIC Level", i32 2}
+  !2 = !{i32 7, !"PIE Level", i32 2}
+  !3 = !{i32 7, !"uwtable", i32 2}
+  !4 = !{!"clang version 19.1.6 (git@github.com:/ElizavetaFrolova/compiler-course-2025.git 62d577dfb25de83c29ad4caf5b71586b5d2fa66c)"}
+
+...
+---
+# CHECK-LABEL: name:            _Z14test_fma_basicfff
+name:            _Z14test_fma_basicfff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+
+    ;CHECK: %2:fr32 = COPY $xmm2
+    ;CHECK-NEXT: %1:fr32 = COPY $xmm1
+    ;CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ;CHECK-NEXT: %4:fr32 = VMULSSrr %0, %1, implicit $mxcsr
+    ;CHECK-NEXT: %3:fr32 = VADDSSrr %2, %4, implicit $mxcsr
+    ;CHECK-NEXT: $xmm0 = COPY %3
+    ;CHECK-NEXT: RET 0, $xmm0
+  
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VFMADD213SSr %1, %0, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+# CHECK-LABEL: name:            _Z17test_fma_same_regff
+name:            _Z17test_fma_same_regff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1
+
+    ; CHECK: %1:fr32 = COPY $xmm1
+    ; CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ; CHECK-NEXT: %3:fr32 = VMULSSrr %0, %0, implicit $mxcsr
+    ; CHECK-NEXT: %2:fr32 = VADDSSrr %1, %3, implicit $mxcsr
+    ; CHECK-NEXT: $xmm0 = COPY %2
+    ; CHECK-NEXT: RET 0, $xmm0
+  
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %2:fr32 = nofpexcept VFMADD213SSr %0, %0, %1, implicit $mxcsr
+    $xmm0 = COPY %2
+    RET 0, $xmm0
+
+...
+---
+# CHECK-LABEL: name:            _Z11test_no_fmafff
+name:            _Z11test_no_fmafff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1
+
+    ;CHECK: %1:fr32 = COPY $xmm1
+    ;CHECK-NEXT:%0:fr32 = COPY $xmm0
+    ;CHECK-NEXT:%3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr
+    ;CHECK-NEXT:$xmm0 = COPY %3
+    ;CHECK-NEXT:RET 0, $xmm0
+  
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+# CHECK-LABEL: name:            _Z12test_mul_addfff
+name:            _Z12test_mul_addfff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+  - { id: 4, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+
+    ;CHECK: %2:fr32 = COPY $xmm2
+    ;CHECK-NEXT: %1:fr32 = COPY $xmm1
+    ;CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ;CHECK-NEXT: %3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr
+    ;CHECK-NEXT: %4:fr32 = nofpexcept VADDSSrr killed %3, %2, implicit $mxcsr
+    ;CHECK-NEXT: $xmm0 = COPY %4
+    ;CHECK-NEXT: RET 0, $xmm0
+  
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr
+    %4:fr32 = nofpexcept VADDSSrr killed %3, %2, implicit $mxcsr
+    $xmm0 = COPY %4
+    RET 0, $xmm0
+
+...

--- a/llvm/test/compiler-course/frolova_e_fma_tests/frolova_e_backend.mir
+++ b/llvm/test/compiler-course/frolova_e_fma_tests/frolova_e_backend.mir
@@ -37,7 +37,21 @@
   target triple = "x86_64-unknown-linux-gnu"
   
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef float @_Z14test_fma_basicfff(float noundef %a, float noundef %b, float noundef %c) local_unnamed_addr #0 {
+  define dso_local noundef float @_Z17test_fma_basic132fff(float noundef %a, float noundef %b, float noundef %c) local_unnamed_addr #0 {
+  entry:
+    %0 = tail call float @llvm.fma.f32(float %a, float %b, float %c)
+    ret float %0
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef float @_Z17test_fma_basic213fff(float noundef %a, float noundef %b, float noundef %c) local_unnamed_addr #0 {
+  entry:
+    %0 = tail call float @llvm.fma.f32(float %a, float %b, float %c)
+    ret float %0
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef float @_Z17test_fma_basic231fff(float noundef %a, float noundef %b, float noundef %c) local_unnamed_addr #0 {
   entry:
     %0 = tail call float @llvm.fma.f32(float %a, float %b, float %c)
     ret float %0
@@ -78,12 +92,91 @@
   !1 = !{i32 8, !"PIC Level", i32 2}
   !2 = !{i32 7, !"PIE Level", i32 2}
   !3 = !{i32 7, !"uwtable", i32 2}
-  !4 = !{!"clang version 19.1.6 (git@github.com:/ElizavetaFrolova/compiler-course-2025.git 62d577dfb25de83c29ad4caf5b71586b5d2fa66c)"}
+  !4 = !{!"clang version 19.1.6 (git@github.com:/ElizavetaFrolova/compiler-course-2025.git 294a518caccae62a31b81c6898596b1c74db4c98)"}
 
 ...
 ---
-# CHECK-LABEL: name:            _Z14test_fma_basicfff
-name:            _Z14test_fma_basicfff
+# CHECK-LABEL: name:            _Z17test_fma_basic132fff
+name:            _Z17test_fma_basic132fff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+
+    ;CHECK: %2:fr32 = COPY $xmm2
+    ;CHECK-NEXT: %1:fr32 = COPY $xmm1
+    ;CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ;CHECK-NEXT: %4:fr32 = VMULSSrr %1, %2, implicit $mxcsr
+    ;CHECK-NEXT: %3:fr32 = VADDSSrr %0, %4, implicit $mxcsr
+    ;CHECK-NEXT: $xmm0 = COPY %3
+    ;CHECK-NEXT: RET 0, $xmm0
+  
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VFMADD132SSr %1, %0, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+# CHECK-LABEL: name:            _Z17test_fma_basic213fff
+name:            _Z17test_fma_basic213fff
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -161,7 +254,86 @@ body:             |
 
 ...
 ---
-# CHECK-LABEL: name:            _Z17test_fma_same_regff
+# CHECK-LABEL: name:            _Z17test_fma_basic231fff
+name:            _Z17test_fma_basic231fff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+
+    ;CHECK: %2:fr32 = COPY $xmm2
+    ;CHECK-NEXT: %1:fr32 = COPY $xmm1
+    ;CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ;CHECK-NEXT: %4:fr32 = VMULSSrr %0, %2, implicit $mxcsr
+    ;CHECK-NEXT: %3:fr32 = VADDSSrr %1, %4, implicit $mxcsr
+    ;CHECK-NEXT: $xmm0 = COPY %3
+    ;CHECK-NEXT: RET 0, $xmm0
+  
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VFMADD231SSr %1, %0, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+# CHECK-LABEL: name:            _Z17test_fma_same_regff 
 name:            _Z17test_fma_same_regff
 alignment:       16
 exposesReturnsTwice: false
@@ -221,12 +393,12 @@ body:             |
   bb.0.entry:
     liveins: $xmm0, $xmm1
 
-    ; CHECK: %1:fr32 = COPY $xmm1
-    ; CHECK-NEXT: %0:fr32 = COPY $xmm0
-    ; CHECK-NEXT: %3:fr32 = VMULSSrr %0, %0, implicit $mxcsr
-    ; CHECK-NEXT: %2:fr32 = VADDSSrr %1, %3, implicit $mxcsr
-    ; CHECK-NEXT: $xmm0 = COPY %2
-    ; CHECK-NEXT: RET 0, $xmm0
+    ;CHECK: %1:fr32 = COPY $xmm1
+    ;CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ;CHECK-NEXT: %3:fr32 = VMULSSrr %0, %0, implicit $mxcsr
+    ;CHECK-NEXT: %2:fr32 = VADDSSrr %1, %3, implicit $mxcsr
+    ;CHECK-NEXT: $xmm0 = COPY %2
+    ;CHECK-NEXT: RET 0, $xmm0
   
     %1:fr32 = COPY $xmm1
     %0:fr32 = COPY $xmm0
@@ -298,10 +470,10 @@ body:             |
     liveins: $xmm0, $xmm1
 
     ;CHECK: %1:fr32 = COPY $xmm1
-    ;CHECK-NEXT:%0:fr32 = COPY $xmm0
-    ;CHECK-NEXT:%3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr
-    ;CHECK-NEXT:$xmm0 = COPY %3
-    ;CHECK-NEXT:RET 0, $xmm0
+    ;CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ;CHECK-NEXT: %3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr
+    ;CHECK-NEXT: $xmm0 = COPY %3
+    ;CHECK-NEXT: RET 0, $xmm0
   
     %1:fr32 = COPY $xmm1
     %0:fr32 = COPY $xmm0


### PR DESCRIPTION
Пасс DecomposeFMAPass  преобразует (раскладывает) инструкции FMA (Fused Multiply-Add), такие как VFMADD213SSr, VFMADD231SDr и др., в эквивалентную последовательность из двух инструкций: умножения (MUL) и сложения (ADD). Это разложение производится с сохранением порядка операндов в зависимости от конкретного варианта инструкции FMA.

Пасс проходит по всем базовым блокам и инструкциям в функции, находит инструкции FMA и заменяет их на две новые инструкции: сначала создаётся временный регистр, в который записывается результат умножения двух операндов, а затем к этому результату прибавляется третий операнд, и итог сохраняется в целевой регистр. После вставки новых инструкций оригинальная FMA-инструкция удаляется.