### PR TITLE
Резанцева Анастасия. Лабораторная работа 3: Backend. Вариант 4. 

### DIFF
--- a/llvm/compiler-course/backend/rezantseva_a_backend/CMakeLists.txt
+++ b/llvm/compiler-course/backend/rezantseva_a_backend/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(Title "MultiplySubtractPass")
+set(Student "RezantsevaAnastasia")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_BACKEND")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY
+)
+
+target_include_directories(${TARGET_NAME} PUBLIC ${PATH_TO_X86})
+set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/compiler-course/backend/rezantseva_a_backend/rezantsesva_a_backend.cpp
+++ b/llvm/compiler-course/backend/rezantseva_a_backend/rezantsesva_a_backend.cpp
@@ -1,118 +1,115 @@
-#include "llvm/CodeGen/MachineFunctionPass.h"
-#include "llvm/CodeGen/MachineInstrBuilder.h"
 #include "X86.h"
 #include "X86InstrInfo.h"
 #include "X86Subtarget.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
 
 using namespace llvm;
 
 namespace {
-    class MultiplySubtractPass : public MachineFunctionPass {
-    public:
-        static char ID;
-        MultiplySubtractPass() : MachineFunctionPass(ID) {}
+class MultiplySubtractPass : public MachineFunctionPass {
+public:
+  static char ID;
+  MultiplySubtractPass() : MachineFunctionPass(ID) {}
 
-        bool runOnMachineFunction(MachineFunction& MF) override;
+  bool runOnMachineFunction(MachineFunction &MF) override;
 
-    private:
-        const X86InstrInfo* TII;
-        bool runOnMachineBasicBlock(MachineBasicBlock& MBB);
-    };
+private:
+  const X86InstrInfo *TII;
+  bool runOnMachineBasicBlock(MachineBasicBlock &MBB);
+};
 
-    char MultiplySubtractPass::ID = 0;
+char MultiplySubtractPass::ID = 0;
 
-    bool MultiplySubtractPass::runOnMachineFunction(MachineFunction& MF) {
-        const X86Subtarget& STI = MF.getSubtarget<X86Subtarget>();
-        TII = STI.getInstrInfo();
+bool MultiplySubtractPass::runOnMachineFunction(MachineFunction &MF) {
+  const X86Subtarget &STI = MF.getSubtarget<X86Subtarget>();
+  TII = STI.getInstrInfo();
 
-        bool Modified = false;
-        for (MachineBasicBlock& MBB : MF) {
-            Modified |= runOnMachineBasicBlock(MBB);
-        }
-        return Modified;
+  bool Modified = false;
+  for (MachineBasicBlock &MBB : MF) {
+    Modified |= runOnMachineBasicBlock(MBB);
+  }
+  return Modified;
+}
+
+bool MultiplySubtractPass::runOnMachineBasicBlock(MachineBasicBlock &MBB) {
+  bool Modified = false;
+
+  for (MachineInstr &MI : make_early_inc_range(MBB)) {
+    // SUB: SUBSSrr, SUBPSrr, VSUBPSYrr, VSUBSDrr, VSUBPDYrr
+    unsigned SubOpc = MI.getOpcode();
+    if (SubOpc != X86::SUBSSrr && SubOpc != X86::SUBPSrr &&
+        SubOpc != X86::VSUBPSYrr && SubOpc != X86::VSUBSDrr &&
+        SubOpc != X86::VSUBPDYrr) {
+      continue;
     }
 
-    bool MultiplySubtractPass::runOnMachineBasicBlock(MachineBasicBlock& MBB) {
-        bool Modified = false;
-
-        for (MachineInstr& MI : make_early_inc_range(MBB)) {
-            // SUB: SUBSSrr, SUBPSrr, VSUBPSYrr, VSUBSDrr, VSUBPDYrr
-            unsigned SubOpc = MI.getOpcode();
-            if (SubOpc != X86::SUBSSrr && SubOpc != X86::SUBPSrr &&
-                SubOpc != X86::VSUBPSYrr && SubOpc != X86::VSUBSDrr &&
-                SubOpc != X86::VSUBPDYrr) {
-                continue;
-            }
-
-            MachineOperand& Src1 = MI.getOperand(1); // c (from c - x)
-            MachineOperand& Src2 = MI.getOperand(2); // x (from c - x)
-            if (!Src1.isReg() || !Src2.isReg()) {
-                continue;
-            }
-
-
-            MachineInstr* MulMI = nullptr;
-            MachineBasicBlock::iterator I = MBB.begin();
-            MachineBasicBlock::iterator E = MI.getIterator();
-            for (; I != E; ++I) {
-                MachineInstr& PrevMI = *I;
-                if (PrevMI.getOpcode() == X86::MULSSrr || PrevMI.getOpcode() == X86::MULPSrr ||
-                    PrevMI.getOpcode() == X86::VMULPSYrr || PrevMI.getOpcode() == X86::MULSDrr ||
-                    PrevMI.getOpcode() == X86::VMULPDYrr) {
-                    if (PrevMI.getOperand(0).getReg() == Src2.getReg()) {
-                        MulMI = &PrevMI;
-                        break;
-                    }
-                }
-
-                else if (PrevMI.getOpcode() == X86::VMULPSYrm || PrevMI.getOpcode() == X86::VMULPDYrm) {
-                    continue;
-                }
-            }
-
-            if (!MulMI) {
-                continue;
-            }
-
-
-            MachineOperand& MulOp1 = MulMI->getOperand(1); // a
-            MachineOperand& MulOp2 = MulMI->getOperand(2); // b
-            if (!MulOp1.isReg() || !MulOp2.isReg()) {
-                continue;
-            }
-
-
-            unsigned FMSUBOpcode;
-            if (SubOpc == X86::SUBSSrr) {
-                FMSUBOpcode = X86::VFMSUB213SSr;
-            }
-            else if (SubOpc == X86::VSUBSDrr) {
-                FMSUBOpcode = X86::VFMSUB213SDr;
-            }
-            else if (SubOpc == X86::VSUBPDYrr) {
-                FMSUBOpcode = X86::VFMSUB213PDYr; //VFMSUB213PDrr
-            }
-            else {
-                FMSUBOpcode = X86::VFMSUB213PSr; // SUBPSrr, VSUBPSYrr
-            }
-
-
-            BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(FMSUBOpcode), MI.getOperand(0).getReg())
-                .addReg(Src1.getReg())  // c
-                .addReg(MulOp1.getReg()) // a
-                .addReg(MulOp2.getReg()) // b
-                .addImm(0)              // rounding mode
-                .addReg(X86::MXCSR, RegState::Implicit)
-                .addReg(X86::MXCSR, RegState::Implicit);
-
-
-            MulMI->eraseFromParent();
-            MI.eraseFromParent();
-            Modified = true;
-        }
-
-        return Modified;
+    MachineOperand &Src1 = MI.getOperand(1); // c (from c - x)
+    MachineOperand &Src2 = MI.getOperand(2); // x (from c - x)
+    if (!Src1.isReg() || !Src2.isReg()) {
+      continue;
     }
+
+    MachineInstr *MulMI = nullptr;
+    MachineBasicBlock::iterator I = MBB.begin();
+    MachineBasicBlock::iterator E = MI.getIterator();
+    for (; I != E; ++I) {
+      MachineInstr &PrevMI = *I;
+      if (PrevMI.getOpcode() == X86::MULSSrr ||
+          PrevMI.getOpcode() == X86::MULPSrr ||
+          PrevMI.getOpcode() == X86::VMULPSYrr ||
+          PrevMI.getOpcode() == X86::MULSDrr ||
+          PrevMI.getOpcode() == X86::VMULPDYrr) {
+        if (PrevMI.getOperand(0).getReg() == Src2.getReg()) {
+          MulMI = &PrevMI;
+          break;
+        }
+      }
+
+      else if (PrevMI.getOpcode() == X86::VMULPSYrm ||
+               PrevMI.getOpcode() == X86::VMULPDYrm) {
+        continue;
+      }
+    }
+
+    if (!MulMI) {
+      continue;
+    }
+
+    MachineOperand &MulOp1 = MulMI->getOperand(1); // a
+    MachineOperand &MulOp2 = MulMI->getOperand(2); // b
+    if (!MulOp1.isReg() || !MulOp2.isReg()) {
+      continue;
+    }
+
+    unsigned FMSUBOpcode;
+    if (SubOpc == X86::SUBSSrr) {
+      FMSUBOpcode = X86::VFMSUB213SSr;
+    } else if (SubOpc == X86::VSUBSDrr) {
+      FMSUBOpcode = X86::VFMSUB213SDr;
+    } else if (SubOpc == X86::VSUBPDYrr) {
+      FMSUBOpcode = X86::VFMSUB213PDYr; // VFMSUB213PDrr
+    } else {
+      FMSUBOpcode = X86::VFMSUB213PSr; // SUBPSrr, VSUBPSYrr
+    }
+
+    BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(FMSUBOpcode),
+            MI.getOperand(0).getReg())
+        .addReg(Src1.getReg())   // c
+        .addReg(MulOp1.getReg()) // a
+        .addReg(MulOp2.getReg()) // b
+        .addImm(0)               // rounding mode
+        .addReg(X86::MXCSR, RegState::Implicit)
+        .addReg(X86::MXCSR, RegState::Implicit);
+
+    MulMI->eraseFromParent();
+    MI.eraseFromParent();
+    Modified = true;
+  }
+
+  return Modified;
+}
 } // namespace
 
-static RegisterPass<MultiplySubtractPass> X("mult_sub_pass", "fused multiply-subtract", false, false);
+static RegisterPass<MultiplySubtractPass>
+    X("mult_sub_pass", "fused multiply-subtract", false, false);

--- a/llvm/compiler-course/backend/rezantseva_a_backend/rezantsesva_a_backend.cpp
+++ b/llvm/compiler-course/backend/rezantseva_a_backend/rezantsesva_a_backend.cpp
@@ -1,0 +1,118 @@
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+
+using namespace llvm;
+
+namespace {
+    class MultiplySubtractPass : public MachineFunctionPass {
+    public:
+        static char ID;
+        MultiplySubtractPass() : MachineFunctionPass(ID) {}
+
+        bool runOnMachineFunction(MachineFunction& MF) override;
+
+    private:
+        const X86InstrInfo* TII;
+        bool runOnMachineBasicBlock(MachineBasicBlock& MBB);
+    };
+
+    char MultiplySubtractPass::ID = 0;
+
+    bool MultiplySubtractPass::runOnMachineFunction(MachineFunction& MF) {
+        const X86Subtarget& STI = MF.getSubtarget<X86Subtarget>();
+        TII = STI.getInstrInfo();
+
+        bool Modified = false;
+        for (MachineBasicBlock& MBB : MF) {
+            Modified |= runOnMachineBasicBlock(MBB);
+        }
+        return Modified;
+    }
+
+    bool MultiplySubtractPass::runOnMachineBasicBlock(MachineBasicBlock& MBB) {
+        bool Modified = false;
+
+        for (MachineInstr& MI : make_early_inc_range(MBB)) {
+            // SUB: SUBSSrr, SUBPSrr, VSUBPSYrr, VSUBSDrr, VSUBPDYrr
+            unsigned SubOpc = MI.getOpcode();
+            if (SubOpc != X86::SUBSSrr && SubOpc != X86::SUBPSrr &&
+                SubOpc != X86::VSUBPSYrr && SubOpc != X86::VSUBSDrr &&
+                SubOpc != X86::VSUBPDYrr) {
+                continue;
+            }
+
+            MachineOperand& Src1 = MI.getOperand(1); // c (from c - x)
+            MachineOperand& Src2 = MI.getOperand(2); // x (from c - x)
+            if (!Src1.isReg() || !Src2.isReg()) {
+                continue;
+            }
+
+
+            MachineInstr* MulMI = nullptr;
+            MachineBasicBlock::iterator I = MBB.begin();
+            MachineBasicBlock::iterator E = MI.getIterator();
+            for (; I != E; ++I) {
+                MachineInstr& PrevMI = *I;
+                if (PrevMI.getOpcode() == X86::MULSSrr || PrevMI.getOpcode() == X86::MULPSrr ||
+                    PrevMI.getOpcode() == X86::VMULPSYrr || PrevMI.getOpcode() == X86::MULSDrr ||
+                    PrevMI.getOpcode() == X86::VMULPDYrr) {
+                    if (PrevMI.getOperand(0).getReg() == Src2.getReg()) {
+                        MulMI = &PrevMI;
+                        break;
+                    }
+                }
+
+                else if (PrevMI.getOpcode() == X86::VMULPSYrm || PrevMI.getOpcode() == X86::VMULPDYrm) {
+                    continue;
+                }
+            }
+
+            if (!MulMI) {
+                continue;
+            }
+
+
+            MachineOperand& MulOp1 = MulMI->getOperand(1); // a
+            MachineOperand& MulOp2 = MulMI->getOperand(2); // b
+            if (!MulOp1.isReg() || !MulOp2.isReg()) {
+                continue;
+            }
+
+
+            unsigned FMSUBOpcode;
+            if (SubOpc == X86::SUBSSrr) {
+                FMSUBOpcode = X86::VFMSUB213SSr;
+            }
+            else if (SubOpc == X86::VSUBSDrr) {
+                FMSUBOpcode = X86::VFMSUB213SDr;
+            }
+            else if (SubOpc == X86::VSUBPDYrr) {
+                FMSUBOpcode = X86::VFMSUB213PDYr; //VFMSUB213PDrr
+            }
+            else {
+                FMSUBOpcode = X86::VFMSUB213PSr; // SUBPSrr, VSUBPSYrr
+            }
+
+
+            BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(FMSUBOpcode), MI.getOperand(0).getReg())
+                .addReg(Src1.getReg())  // c
+                .addReg(MulOp1.getReg()) // a
+                .addReg(MulOp2.getReg()) // b
+                .addImm(0)              // rounding mode
+                .addReg(X86::MXCSR, RegState::Implicit)
+                .addReg(X86::MXCSR, RegState::Implicit);
+
+
+            MulMI->eraseFromParent();
+            MI.eraseFromParent();
+            Modified = true;
+        }
+
+        return Modified;
+    }
+} // namespace
+
+static RegisterPass<MultiplySubtractPass> X("mult_sub_pass", "fused multiply-subtract", false, false);

--- a/llvm/compiler-course/backend/rezantseva_a_backend/rezantsesva_a_backend.cpp
+++ b/llvm/compiler-course/backend/rezantseva_a_backend/rezantsesva_a_backend.cpp
@@ -1,115 +1,120 @@
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
 #include "X86.h"
 #include "X86InstrInfo.h"
 #include "X86Subtarget.h"
-#include "llvm/CodeGen/MachineFunctionPass.h"
-#include "llvm/CodeGen/MachineInstrBuilder.h"
 
 using namespace llvm;
 
 namespace {
-class MultiplySubtractPass : public MachineFunctionPass {
-public:
-  static char ID;
-  MultiplySubtractPass() : MachineFunctionPass(ID) {}
+    class MultiplySubtractPass : public MachineFunctionPass {
+    public:
+        static char ID;
+        MultiplySubtractPass() : MachineFunctionPass(ID) {}
 
-  bool runOnMachineFunction(MachineFunction &MF) override;
+        bool runOnMachineFunction(MachineFunction& MF) override;
 
-private:
-  const X86InstrInfo *TII;
-  bool runOnMachineBasicBlock(MachineBasicBlock &MBB);
-};
+    private:
+        const X86InstrInfo* TII;
+        bool runOnMachineBasicBlock(MachineBasicBlock& MBB);
+    };
 
-char MultiplySubtractPass::ID = 0;
+    char MultiplySubtractPass::ID = 0;
 
-bool MultiplySubtractPass::runOnMachineFunction(MachineFunction &MF) {
-  const X86Subtarget &STI = MF.getSubtarget<X86Subtarget>();
-  TII = STI.getInstrInfo();
+    bool MultiplySubtractPass::runOnMachineFunction(MachineFunction& MF) {
+        const X86Subtarget& STI = MF.getSubtarget<X86Subtarget>();
+        if (!STI.hasFMA())
+            return false;
+        TII = STI.getInstrInfo();
 
-  bool Modified = false;
-  for (MachineBasicBlock &MBB : MF) {
-    Modified |= runOnMachineBasicBlock(MBB);
-  }
-  return Modified;
-}
-
-bool MultiplySubtractPass::runOnMachineBasicBlock(MachineBasicBlock &MBB) {
-  bool Modified = false;
-
-  for (MachineInstr &MI : make_early_inc_range(MBB)) {
-    // SUB: SUBSSrr, SUBPSrr, VSUBPSYrr, VSUBSDrr, VSUBPDYrr
-    unsigned SubOpc = MI.getOpcode();
-    if (SubOpc != X86::SUBSSrr && SubOpc != X86::SUBPSrr &&
-        SubOpc != X86::VSUBPSYrr && SubOpc != X86::VSUBSDrr &&
-        SubOpc != X86::VSUBPDYrr) {
-      continue;
-    }
-
-    MachineOperand &Src1 = MI.getOperand(1); // c (from c - x)
-    MachineOperand &Src2 = MI.getOperand(2); // x (from c - x)
-    if (!Src1.isReg() || !Src2.isReg()) {
-      continue;
-    }
-
-    MachineInstr *MulMI = nullptr;
-    MachineBasicBlock::iterator I = MBB.begin();
-    MachineBasicBlock::iterator E = MI.getIterator();
-    for (; I != E; ++I) {
-      MachineInstr &PrevMI = *I;
-      if (PrevMI.getOpcode() == X86::MULSSrr ||
-          PrevMI.getOpcode() == X86::MULPSrr ||
-          PrevMI.getOpcode() == X86::VMULPSYrr ||
-          PrevMI.getOpcode() == X86::MULSDrr ||
-          PrevMI.getOpcode() == X86::VMULPDYrr) {
-        if (PrevMI.getOperand(0).getReg() == Src2.getReg()) {
-          MulMI = &PrevMI;
-          break;
+        bool Modified = false;
+        for (MachineBasicBlock& MBB : MF) {
+            Modified |= runOnMachineBasicBlock(MBB);
         }
-      }
-
-      else if (PrevMI.getOpcode() == X86::VMULPSYrm ||
-               PrevMI.getOpcode() == X86::VMULPDYrm) {
-        continue;
-      }
+        return Modified;
     }
 
-    if (!MulMI) {
-      continue;
+    bool MultiplySubtractPass::runOnMachineBasicBlock(MachineBasicBlock& MBB) {
+        bool Modified = false;
+
+        for (MachineInstr& MI : make_early_inc_range(MBB)) {
+            // SUB: SUBSSrr, SUBPSrr, VSUBPSYrr, VSUBSDrr, VSUBPDYrr
+            unsigned SubOpc = MI.getOpcode();
+            if (SubOpc != X86::SUBSSrr && SubOpc != X86::SUBPSrr &&
+                SubOpc != X86::VSUBPSYrr && SubOpc != X86::VSUBSDrr &&
+                SubOpc != X86::VSUBPDYrr) {
+                continue;
+            }
+
+            MachineOperand& Src1 = MI.getOperand(1); // c (from c - x)
+            MachineOperand& Src2 = MI.getOperand(2); // x (from c - x)
+            if (!Src1.isReg() || !Src2.isReg()) {
+                continue;
+            }
+
+            MachineInstr* MulMI = nullptr;
+            MachineBasicBlock::iterator I = MBB.begin();
+            MachineBasicBlock::iterator E = MI.getIterator();
+            for (; I != E; ++I) {
+                MachineInstr& PrevMI = *I;
+                if (PrevMI.getOpcode() == X86::MULSSrr ||
+                    PrevMI.getOpcode() == X86::MULPSrr ||
+                    PrevMI.getOpcode() == X86::VMULPSYrr ||
+                    PrevMI.getOpcode() == X86::MULSDrr ||
+                    PrevMI.getOpcode() == X86::VMULPDYrr) {
+                    if (PrevMI.getOperand(0).getReg() == Src2.getReg()) {
+                        MulMI = &PrevMI;
+                        break;
+                    }
+                }
+
+                else if (PrevMI.getOpcode() == X86::VMULPSYrm ||
+                         PrevMI.getOpcode() == X86::VMULPDYrm) {
+                    continue;
+                }
+            }
+
+            if (!MulMI) {
+                continue;
+            }
+
+            MachineOperand& MulOp1 = MulMI->getOperand(1); // a
+            MachineOperand& MulOp2 = MulMI->getOperand(2); // b
+            if (!MulOp1.isReg() || !MulOp2.isReg()) {
+                continue;
+            }
+
+            unsigned FMSUBOpcode;
+            if (SubOpc == X86::SUBSSrr) {
+                FMSUBOpcode = X86::VFMSUB213SSr;
+            }
+            else if (SubOpc == X86::VSUBSDrr) {
+                FMSUBOpcode = X86::VFMSUB213SDr;
+            }
+            else if (SubOpc == X86::VSUBPDYrr) {
+                FMSUBOpcode = X86::VFMSUB213PDYr; // VFMSUB213PDrr
+            }
+            else {
+                FMSUBOpcode = X86::VFMSUB213PSr; // SUBPSrr, VSUBPSYrr
+            }
+
+            BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(FMSUBOpcode),
+                    MI.getOperand(0).getReg())
+                .addReg(Src1.getReg())   // c
+                .addReg(MulOp1.getReg()) // a
+                .addReg(MulOp2.getReg()) // b
+                .addImm(0)               // rounding mode
+                .addReg(X86::MXCSR, RegState::Implicit)
+                .addReg(X86::MXCSR, RegState::Implicit);
+
+            MulMI->eraseFromParent();
+            MI.eraseFromParent();
+            Modified = true;
+        }
+
+        return Modified;
     }
-
-    MachineOperand &MulOp1 = MulMI->getOperand(1); // a
-    MachineOperand &MulOp2 = MulMI->getOperand(2); // b
-    if (!MulOp1.isReg() || !MulOp2.isReg()) {
-      continue;
-    }
-
-    unsigned FMSUBOpcode;
-    if (SubOpc == X86::SUBSSrr) {
-      FMSUBOpcode = X86::VFMSUB213SSr;
-    } else if (SubOpc == X86::VSUBSDrr) {
-      FMSUBOpcode = X86::VFMSUB213SDr;
-    } else if (SubOpc == X86::VSUBPDYrr) {
-      FMSUBOpcode = X86::VFMSUB213PDYr; // VFMSUB213PDrr
-    } else {
-      FMSUBOpcode = X86::VFMSUB213PSr; // SUBPSrr, VSUBPSYrr
-    }
-
-    BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(FMSUBOpcode),
-            MI.getOperand(0).getReg())
-        .addReg(Src1.getReg())   // c
-        .addReg(MulOp1.getReg()) // a
-        .addReg(MulOp2.getReg()) // b
-        .addImm(0)               // rounding mode
-        .addReg(X86::MXCSR, RegState::Implicit)
-        .addReg(X86::MXCSR, RegState::Implicit);
-
-    MulMI->eraseFromParent();
-    MI.eraseFromParent();
-    Modified = true;
-  }
-
-  return Modified;
-}
 } // namespace
 
 static RegisterPass<MultiplySubtractPass>
-    X("mult_sub_pass", "fused multiply-subtract", false, false);
+X("mult_sub_pass", "fused multiply-subtract", false, false);

--- a/llvm/compiler-course/backend/rezantseva_a_backend/rezantsesva_a_backend.cpp
+++ b/llvm/compiler-course/backend/rezantseva_a_backend/rezantsesva_a_backend.cpp
@@ -1,120 +1,117 @@
-#include "llvm/CodeGen/MachineFunctionPass.h"
-#include "llvm/CodeGen/MachineInstrBuilder.h"
 #include "X86.h"
 #include "X86InstrInfo.h"
 #include "X86Subtarget.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
 
 using namespace llvm;
 
 namespace {
-    class MultiplySubtractPass : public MachineFunctionPass {
-    public:
-        static char ID;
-        MultiplySubtractPass() : MachineFunctionPass(ID) {}
+class MultiplySubtractPass : public MachineFunctionPass {
+public:
+  static char ID;
+  MultiplySubtractPass() : MachineFunctionPass(ID) {}
 
-        bool runOnMachineFunction(MachineFunction& MF) override;
+  bool runOnMachineFunction(MachineFunction &MF) override;
 
-    private:
-        const X86InstrInfo* TII;
-        bool runOnMachineBasicBlock(MachineBasicBlock& MBB);
-    };
+private:
+  const X86InstrInfo *TII;
+  bool runOnMachineBasicBlock(MachineBasicBlock &MBB);
+};
 
-    char MultiplySubtractPass::ID = 0;
+char MultiplySubtractPass::ID = 0;
 
-    bool MultiplySubtractPass::runOnMachineFunction(MachineFunction& MF) {
-        const X86Subtarget& STI = MF.getSubtarget<X86Subtarget>();
-        if (!STI.hasFMA())
-            return false;
-        TII = STI.getInstrInfo();
+bool MultiplySubtractPass::runOnMachineFunction(MachineFunction &MF) {
+  const X86Subtarget &STI = MF.getSubtarget<X86Subtarget>();
+  if (!STI.hasFMA())
+    return false;
+  TII = STI.getInstrInfo();
 
-        bool Modified = false;
-        for (MachineBasicBlock& MBB : MF) {
-            Modified |= runOnMachineBasicBlock(MBB);
-        }
-        return Modified;
+  bool Modified = false;
+  for (MachineBasicBlock &MBB : MF) {
+    Modified |= runOnMachineBasicBlock(MBB);
+  }
+  return Modified;
+}
+
+bool MultiplySubtractPass::runOnMachineBasicBlock(MachineBasicBlock &MBB) {
+  bool Modified = false;
+
+  for (MachineInstr &MI : make_early_inc_range(MBB)) {
+    // SUB: SUBSSrr, SUBPSrr, VSUBPSYrr, VSUBSDrr, VSUBPDYrr
+    unsigned SubOpc = MI.getOpcode();
+    if (SubOpc != X86::SUBSSrr && SubOpc != X86::SUBPSrr &&
+        SubOpc != X86::VSUBPSYrr && SubOpc != X86::VSUBSDrr &&
+        SubOpc != X86::VSUBPDYrr) {
+      continue;
     }
 
-    bool MultiplySubtractPass::runOnMachineBasicBlock(MachineBasicBlock& MBB) {
-        bool Modified = false;
-
-        for (MachineInstr& MI : make_early_inc_range(MBB)) {
-            // SUB: SUBSSrr, SUBPSrr, VSUBPSYrr, VSUBSDrr, VSUBPDYrr
-            unsigned SubOpc = MI.getOpcode();
-            if (SubOpc != X86::SUBSSrr && SubOpc != X86::SUBPSrr &&
-                SubOpc != X86::VSUBPSYrr && SubOpc != X86::VSUBSDrr &&
-                SubOpc != X86::VSUBPDYrr) {
-                continue;
-            }
-
-            MachineOperand& Src1 = MI.getOperand(1); // c (from c - x)
-            MachineOperand& Src2 = MI.getOperand(2); // x (from c - x)
-            if (!Src1.isReg() || !Src2.isReg()) {
-                continue;
-            }
-
-            MachineInstr* MulMI = nullptr;
-            MachineBasicBlock::iterator I = MBB.begin();
-            MachineBasicBlock::iterator E = MI.getIterator();
-            for (; I != E; ++I) {
-                MachineInstr& PrevMI = *I;
-                if (PrevMI.getOpcode() == X86::MULSSrr ||
-                    PrevMI.getOpcode() == X86::MULPSrr ||
-                    PrevMI.getOpcode() == X86::VMULPSYrr ||
-                    PrevMI.getOpcode() == X86::MULSDrr ||
-                    PrevMI.getOpcode() == X86::VMULPDYrr) {
-                    if (PrevMI.getOperand(0).getReg() == Src2.getReg()) {
-                        MulMI = &PrevMI;
-                        break;
-                    }
-                }
-
-                else if (PrevMI.getOpcode() == X86::VMULPSYrm ||
-                         PrevMI.getOpcode() == X86::VMULPDYrm) {
-                    continue;
-                }
-            }
-
-            if (!MulMI) {
-                continue;
-            }
-
-            MachineOperand& MulOp1 = MulMI->getOperand(1); // a
-            MachineOperand& MulOp2 = MulMI->getOperand(2); // b
-            if (!MulOp1.isReg() || !MulOp2.isReg()) {
-                continue;
-            }
-
-            unsigned FMSUBOpcode;
-            if (SubOpc == X86::SUBSSrr) {
-                FMSUBOpcode = X86::VFMSUB213SSr;
-            }
-            else if (SubOpc == X86::VSUBSDrr) {
-                FMSUBOpcode = X86::VFMSUB213SDr;
-            }
-            else if (SubOpc == X86::VSUBPDYrr) {
-                FMSUBOpcode = X86::VFMSUB213PDYr; // VFMSUB213PDrr
-            }
-            else {
-                FMSUBOpcode = X86::VFMSUB213PSr; // SUBPSrr, VSUBPSYrr
-            }
-
-            BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(FMSUBOpcode),
-                    MI.getOperand(0).getReg())
-                .addReg(Src1.getReg())   // c
-                .addReg(MulOp1.getReg()) // a
-                .addReg(MulOp2.getReg()) // b
-                .addImm(0)               // rounding mode
-                .addReg(X86::MXCSR, RegState::Implicit)
-                .addReg(X86::MXCSR, RegState::Implicit);
-
-            MulMI->eraseFromParent();
-            MI.eraseFromParent();
-            Modified = true;
-        }
-
-        return Modified;
+    MachineOperand &Src1 = MI.getOperand(1); // c (from c - x)
+    MachineOperand &Src2 = MI.getOperand(2); // x (from c - x)
+    if (!Src1.isReg() || !Src2.isReg()) {
+      continue;
     }
+
+    MachineInstr *MulMI = nullptr;
+    MachineBasicBlock::iterator I = MBB.begin();
+    MachineBasicBlock::iterator E = MI.getIterator();
+    for (; I != E; ++I) {
+      MachineInstr &PrevMI = *I;
+      if (PrevMI.getOpcode() == X86::MULSSrr ||
+          PrevMI.getOpcode() == X86::MULPSrr ||
+          PrevMI.getOpcode() == X86::VMULPSYrr ||
+          PrevMI.getOpcode() == X86::MULSDrr ||
+          PrevMI.getOpcode() == X86::VMULPDYrr) {
+        if (PrevMI.getOperand(0).getReg() == Src2.getReg()) {
+          MulMI = &PrevMI;
+          break;
+        }
+      }
+
+      else if (PrevMI.getOpcode() == X86::VMULPSYrm ||
+               PrevMI.getOpcode() == X86::VMULPDYrm) {
+        continue;
+      }
+    }
+
+    if (!MulMI) {
+      continue;
+    }
+
+    MachineOperand &MulOp1 = MulMI->getOperand(1); // a
+    MachineOperand &MulOp2 = MulMI->getOperand(2); // b
+    if (!MulOp1.isReg() || !MulOp2.isReg()) {
+      continue;
+    }
+
+    unsigned FMSUBOpcode;
+    if (SubOpc == X86::SUBSSrr) {
+      FMSUBOpcode = X86::VFMSUB213SSr;
+    } else if (SubOpc == X86::VSUBSDrr) {
+      FMSUBOpcode = X86::VFMSUB213SDr;
+    } else if (SubOpc == X86::VSUBPDYrr) {
+      FMSUBOpcode = X86::VFMSUB213PDYr; // VFMSUB213PDrr
+    } else {
+      FMSUBOpcode = X86::VFMSUB213PSr; // SUBPSrr, VSUBPSYrr
+    }
+
+    BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(FMSUBOpcode),
+            MI.getOperand(0).getReg())
+        .addReg(Src1.getReg())   // c
+        .addReg(MulOp1.getReg()) // a
+        .addReg(MulOp2.getReg()) // b
+        .addImm(0)               // rounding mode
+        .addReg(X86::MXCSR, RegState::Implicit)
+        .addReg(X86::MXCSR, RegState::Implicit);
+
+    MulMI->eraseFromParent();
+    MI.eraseFromParent();
+    Modified = true;
+  }
+
+  return Modified;
+}
 } // namespace
 
 static RegisterPass<MultiplySubtractPass>
-X("mult_sub_pass", "fused multiply-subtract", false, false);
+    X("mult_sub_pass", "fused multiply-subtract", false, false);

--- a/llvm/test/compiler-course/rezantseva_a_backend_test/rezantseva_test.mir
+++ b/llvm/test/compiler-course/rezantseva_a_backend_test/rezantseva_test.mir
@@ -1,33 +1,6 @@
-# RUN: llc -mtriple=x86_64-unknown-linux-gnu -mattr=+fma \
-# RUN:     --load %llvmshlibdir/MultiplySubtractPass_RezantsevaAnastasia_FIIT1_BACKEND%shlibext \
-# RUN:     -run-pass=mult_sub_pass -o - %s | FileCheck %s
-
-# CHECK-LABEL: name: test_scalar
-# CHECK: %8:vr128 = VFMSUB213SSr %6, %4, %5, 0, implicit $mxcsr, implicit $mxcsr, implicit $mxcsr
-# CHECK-NEXT: MOVSSmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s32) into %ir.d, align 4)
-# CHECK-NEXT: RET64
-
-# CHECK-LABEL: name: test_sse
-# CHECK: %8:vr128 = VFMSUB213PSr %6, %4, %5, 0, implicit $mxcsr, implicit $mxcsr, implicit $mxcsr
-# CHECK-NEXT: MOVUPSmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s128) into %ir.d, align 16)
-# CHECK-NEXT: RET64
-
-# CHECK-LABEL: name: test_avx
-# CHECK: %8:vr256 = VFMSUB213PSr %6, %4, %5, 0, implicit $mxcsr, implicit $mxcsr, implicit $mxcsr
-# CHECK-NEXT: VMOVUPSYmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s256) into %ir.d, align 32)
-# CHECK-NEXT: RET64
-
-# CHECK-LABEL: name: test_avx_memory
-# CHECK: %6:vr256 = VMULPSYrm %4:vr256, %1:gr64, 1, $noreg, 0, $noreg, implicit $mxcsr :: (load (s256) from %ir.b, align 32)
-# CHECK: %8:vr256 = VSUBPSYrr %7:vr256, %6:vr256, implicit $mxcsr
-# CHECK-NEXT: VMOVUPSYmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s256) into %ir.d, align 32)
-# CHECK-NEXT: RET64
-
-# CHECK-LABEL: name: test_negative
-# CHECK: VADDPSYrr
-# CHECK-NOT: VFMSUB213
-# CHECK-NEXT: RET64
-
+#  RUN: llc -mattr=+fma \
+#  RUN:     --load=%llvmshlibdir/MultiplySubtractPass_RezantsevaAnastasia_FIIT1_BACKEND%shlibext \
+#  RUN:     -run-pass=mult_sub_pass %s -o - | FileCheck %s
 --- |
   ; ModuleID = 'rezantseva_test.mir'
   source_filename = "test_rezantseva_a.c"
@@ -89,6 +62,7 @@
   attributes #0 = { "target-features"="+avx" }
 
 ---
+# CHECK-LABEL: name: test_scalar
 name:            test_scalar
 alignment:       16
 exposesReturnsTwice: false
@@ -156,6 +130,17 @@ body:             |
   bb.0.entry:
     liveins: $rdi, $rsi, $rdx, $rcx
 
+    ; CHECK: %0:gr64 = COPY $rdi
+    ; CHECK-NEXT: %1:gr64 = COPY $rsi
+    ; CHECK-NEXT: %2:gr64 = COPY $rdx
+    ; CHECK-NEXT: %3:gr64 = COPY $rcx
+    ; CHECK-NEXT: %4:vr128 = MOVSSrm %0, 1, $noreg, 0, $noreg :: (load (s32) from %ir.a)
+    ; CHECK-NEXT: %5:vr128 = MOVSSrm %1, 1, $noreg, 0, $noreg :: (load (s32) from %ir.b)
+    ; CHECK-NEXT: %6:vr128 = MOVSSrm %2, 1, $noreg, 0, $noreg :: (load (s32) from %ir.c)
+    ; CHECK-NEXT: %8:vr128 = VFMSUB213SSr %6, %4, %5, 0, implicit $mxcsr, implicit $mxcsr, implicit $mxcsr
+    ; CHECK-NEXT: MOVSSmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s32) into %ir.d)
+    ; CHECK-NEXT: RET64
+
     %0:gr64 = COPY $rdi
     %1:gr64 = COPY $rsi
     %2:gr64 = COPY $rdx
@@ -167,8 +152,8 @@ body:             |
     %8:vr128 = SUBSSrr %6:vr128, %7:vr128, implicit $mxcsr
     MOVSSmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s32) into %ir.d, align 4)
     RET64
-
 ---
+# CHECK-LABEL: name: test_sse
 name:            test_sse
 alignment:       16
 exposesReturnsTwice: false
@@ -236,6 +221,17 @@ body:             |
   bb.0.entry:
     liveins: $rdi, $rsi, $rdx, $rcx
 
+    ; CHECK: %0:gr64 = COPY $rdi
+    ; CHECK-NEXT: %1:gr64 = COPY $rsi
+    ; CHECK-NEXT: %2:gr64 = COPY $rdx
+    ; CHECK-NEXT: %3:gr64 = COPY $rcx
+    ; CHECK-NEXT: %4:vr128 = MOVUPSrm %0, 1, $noreg, 0, $noreg :: (load (s128) from %ir.a)
+    ; CHECK-NEXT: %5:vr128 = MOVUPSrm %1, 1, $noreg, 0, $noreg :: (load (s128) from %ir.b)
+    ; CHECK-NEXT: %6:vr128 = MOVUPSrm %2, 1, $noreg, 0, $noreg :: (load (s128) from %ir.c)
+    ; CHECK-NEXT: %8:vr128 = VFMSUB213PSr %6, %4, %5, 0, implicit $mxcsr, implicit $mxcsr, implicit $mxcsr
+    ; CHECK-NEXT: MOVUPSmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s128) into %ir.d)
+    ; CHECK-NEXT: RET64
+
     %0:gr64 = COPY $rdi
     %1:gr64 = COPY $rsi
     %2:gr64 = COPY $rdx
@@ -247,8 +243,8 @@ body:             |
     %8:vr128 = SUBPSrr %6:vr128, %7:vr128, implicit $mxcsr
     MOVUPSmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s128) into %ir.d, align 16)
     RET64
-
 ---
+# CHECK-LABEL: name: test_avx
 name:            test_avx
 alignment:       16
 exposesReturnsTwice: false
@@ -316,6 +312,17 @@ body:             |
   bb.0.entry:
     liveins: $rdi, $rsi, $rdx, $rcx
 
+    ; CHECK: %0:gr64 = COPY $rdi
+    ; CHECK-NEXT: %1:gr64 = COPY $rsi
+    ; CHECK-NEXT: %2:gr64 = COPY $rdx
+    ; CHECK-NEXT: %3:gr64 = COPY $rcx
+    ; CHECK-NEXT: %4:vr256 = VMOVUPSYrm %0, 1, $noreg, 0, $noreg :: (load (s256) from %ir.a)
+    ; CHECK-NEXT: %5:vr256 = VMOVUPSYrm %1, 1, $noreg, 0, $noreg :: (load (s256) from %ir.b)
+    ; CHECK-NEXT: %6:vr256 = VMOVUPSYrm %2, 1, $noreg, 0, $noreg :: (load (s256) from %ir.c)
+    ; CHECK-NEXT: %8:vr256 = VFMSUB213PSr %6, %4, %5, 0, implicit $mxcsr, implicit $mxcsr, implicit $mxcsr
+    ; CHECK-NEXT: VMOVUPSYmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s256) into %ir.d)
+    ; CHECK-NEXT: RET64
+
     %0:gr64 = COPY $rdi
     %1:gr64 = COPY $rsi
     %2:gr64 = COPY $rdx
@@ -327,8 +334,8 @@ body:             |
     %8:vr256 = VSUBPSYrr %6:vr256, %7:vr256, implicit $mxcsr
     VMOVUPSYmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s256) into %ir.d, align 32)
     RET64
-
 ---
+# CHECK-LABEL: name: test_avx_memory
 name:            test_avx_memory
 alignment:       16
 exposesReturnsTwice: false
@@ -396,6 +403,17 @@ body:             |
   bb.0.entry:
     liveins: $rdi, $rsi, $rdx, $rcx
 
+    ; CHECK: %0:gr64 = COPY $rdi
+    ; CHECK-NEXT: %1:gr64 = COPY $rsi
+    ; CHECK-NEXT: %2:gr64 = COPY $rdx
+    ; CHECK-NEXT: %3:gr64 = COPY $rcx
+    ; CHECK-NEXT: %4:vr256 = VMOVUPSYrm %0, 1, $noreg, 0, $noreg :: (load (s256) from %ir.a)
+    ; CHECK-NEXT: %6:vr256 = VMULPSYrm %4, %1, 1, $noreg, 0, $noreg, implicit $mxcsr :: (load (s256) from %ir.b)
+    ; CHECK-NEXT: %7:vr256 = VMOVUPSYrm %2, 1, $noreg, 0, $noreg :: (load (s256) from %ir.c)
+    ; CHECK-NEXT: %8:vr256 = VSUBPSYrr %7, %6, implicit $mxcsr
+    ; CHECK-NEXT: VMOVUPSYmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s256) into %ir.d)
+    ; CHECK-NEXT: RET64
+
     %0:gr64 = COPY $rdi
     %1:gr64 = COPY $rsi
     %2:gr64 = COPY $rdx
@@ -406,8 +424,8 @@ body:             |
     %8:vr256 = VSUBPSYrr %7:vr256, %6:vr256, implicit $mxcsr
     VMOVUPSYmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s256) into %ir.d, align 32)
     RET64
-
 ---
+# CHECK-LABEL: name: test_negative
 name:            test_negative
 alignment:       16
 exposesReturnsTwice: false
@@ -472,6 +490,16 @@ machineFunctionInfo:
 body:             |
   bb.0.entry:
     liveins: $rdi, $rsi, $rdx, $rcx
+
+    ; CHEKK: %0:gr64 = COPY $rdi
+    ; CHEKK-NEXT: %1:gr64 = COPY $rsi
+    ; CHEKK-NEXT: %2:gr64 = COPY $rdx
+    ; CHEKK-NEXT: %3:gr64 = COPY $rcx
+    ; CHEKK-NEXT: %4:vr256 = VMOVUPSYrm %0, 1, $noreg, 0, $noreg :: (load (s256) from %ir.a)
+    ; CHEKK-NEXT: %5:vr256 = VMOVUPSYrm %1, 1, $noreg, 0, $noreg :: (load (s256) from %ir.b)
+    ; CHEKK-NEXT: %6:vr256 = VADDPSYrr %4, %5, implicit $mxcsr
+    ; CHEKK-NEXT: VMOVUPSYmr %3, 1, $noreg, 0, $noreg, %6 :: (store (s256) into %ir.d)
+    ; CHEKK-NEXT: RET64
 
     %0:gr64 = COPY $rdi
     %1:gr64 = COPY $rsi

--- a/llvm/test/compiler-course/rezantseva_a_backend_test/rezantseva_test.mir
+++ b/llvm/test/compiler-course/rezantseva_a_backend_test/rezantseva_test.mir
@@ -1,0 +1,484 @@
+# RUN: llc -mtriple=x86_64-unknown-linux-gnu -mattr=+fma \
+# RUN:     --load %llvmshlibdir/MultiplySubtractPass_RezantsevaAnastasia_FIIT1_BACKEND%shlibext \
+# RUN:     -run-pass=mult_sub_pass -o - %s | FileCheck %s
+
+# CHECK-LABEL: name: test_scalar
+# CHECK: %8:vr128 = VFMSUB213SSr %6, %4, %5, 0, implicit $mxcsr, implicit $mxcsr, implicit $mxcsr
+# CHECK-NEXT: MOVSSmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s32) into %ir.d, align 4)
+# CHECK-NEXT: RET64
+
+# CHECK-LABEL: name: test_sse
+# CHECK: %8:vr128 = VFMSUB213PSr %6, %4, %5, 0, implicit $mxcsr, implicit $mxcsr, implicit $mxcsr
+# CHECK-NEXT: MOVUPSmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s128) into %ir.d, align 16)
+# CHECK-NEXT: RET64
+
+# CHECK-LABEL: name: test_avx
+# CHECK: %8:vr256 = VFMSUB213PSr %6, %4, %5, 0, implicit $mxcsr, implicit $mxcsr, implicit $mxcsr
+# CHECK-NEXT: VMOVUPSYmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s256) into %ir.d, align 32)
+# CHECK-NEXT: RET64
+
+# CHECK-LABEL: name: test_avx_memory
+# CHECK: %6:vr256 = VMULPSYrm %4:vr256, %1:gr64, 1, $noreg, 0, $noreg, implicit $mxcsr :: (load (s256) from %ir.b, align 32)
+# CHECK: %8:vr256 = VSUBPSYrr %7:vr256, %6:vr256, implicit $mxcsr
+# CHECK-NEXT: VMOVUPSYmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s256) into %ir.d, align 32)
+# CHECK-NEXT: RET64
+
+# CHECK-LABEL: name: test_negative
+# CHECK: VADDPSYrr
+# CHECK-NOT: VFMSUB213
+# CHECK-NEXT: RET64
+
+--- |
+  ; ModuleID = 'rezantseva_test.mir'
+  source_filename = "test_rezantseva_a.c"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-pc-linux-gnu"
+
+  define void @test_scalar(ptr %a, ptr %b, ptr %c, ptr %d) #0 {
+  entry:
+    %0 = load float, ptr %a, align 4
+    %1 = load float, ptr %b, align 4
+    %2 = load float, ptr %c, align 4
+    %tmp = fmul float %0, %1
+    %res = fsub float %2, %tmp
+    store float %res, ptr %d, align 4
+    ret void
+  }
+
+  define void @test_sse(ptr %a, ptr %b, ptr %c, ptr %d) #0 {
+  entry:
+    %v_a = load <4 x float>, ptr %a, align 16
+    %v_b = load <4 x float>, ptr %b, align 16
+    %v_c = load <4 x float>, ptr %c, align 16
+    %tmp = fmul <4 x float> %v_a, %v_b
+    %res = fsub <4 x float> %v_c, %tmp
+    store <4 x float> %res, ptr %d, align 16
+    ret void
+  }
+
+  define void @test_avx(ptr %a, ptr %b, ptr %c, ptr %d) #0 {
+  entry:
+    %v_a = load <8 x float>, ptr %a, align 32
+    %v_b = load <8 x float>, ptr %b, align 32
+    %v_c = load <8 x float>, ptr %c, align 32
+    %tmp = fmul <8 x float> %v_a, %v_b
+    %res = fsub <8 x float> %v_c, %tmp
+    store <8 x float> %res, ptr %d, align 32
+    ret void
+  }
+
+  define void @test_avx_memory(ptr %a, ptr %b, ptr %c, ptr %d) #0 {
+  entry:
+    %v_a = load <8 x float>, ptr %a, align 32
+    %v_c = load <8 x float>, ptr %c, align 32
+    %tmp = fmul <8 x float> %v_a, %v_c
+    %res = fsub <8 x float> %v_c, %tmp
+    store <8 x float> %res, ptr %d, align 32
+    ret void
+  }
+
+  define void @test_negative(ptr %a, ptr %b, ptr %c, ptr %d) #0 {
+  entry:
+    %v_a = load <8 x float>, ptr %a, align 32
+    %v_b = load <8 x float>, ptr %b, align 32
+    %res = fadd <8 x float> %v_a, %v_b
+    store <8 x float> %res, ptr %d, align 32
+    ret void
+  }
+
+  attributes #0 = { "target-features"="+avx" }
+
+---
+name:            test_scalar
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: gr64, preferred-register: '' }
+  - { id: 1, class: gr64, preferred-register: '' }
+  - { id: 2, class: gr64, preferred-register: '' }
+  - { id: 3, class: gr64, preferred-register: '' }
+  - { id: 4, class: vr128, preferred-register: '' }
+  - { id: 5, class: vr128, preferred-register: '' }
+  - { id: 6, class: vr128, preferred-register: '' }
+  - { id: 7, class: vr128, preferred-register: '' }
+  - { id: 8, class: vr128, preferred-register: '' }
+liveins:
+  - { reg: '$rdi', virtual-reg: '%0' }
+  - { reg: '$rsi', virtual-reg: '%1' }
+  - { reg: '$rdx', virtual-reg: '%2' }
+  - { reg: '$rcx', virtual-reg: '%3' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $rdi, $rsi, $rdx, $rcx
+
+    %0:gr64 = COPY $rdi
+    %1:gr64 = COPY $rsi
+    %2:gr64 = COPY $rdx
+    %3:gr64 = COPY $rcx
+    %4:vr128 = MOVSSrm %0, 1, $noreg, 0, $noreg :: (load (s32) from %ir.a, align 4)
+    %5:vr128 = MOVSSrm %1, 1, $noreg, 0, $noreg :: (load (s32) from %ir.b, align 4)
+    %6:vr128 = MOVSSrm %2, 1, $noreg, 0, $noreg :: (load (s32) from %ir.c, align 4)
+    %7:vr128 = MULSSrr %4:vr128, %5:vr128, implicit $mxcsr
+    %8:vr128 = SUBSSrr %6:vr128, %7:vr128, implicit $mxcsr
+    MOVSSmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s32) into %ir.d, align 4)
+    RET64
+
+---
+name:            test_sse
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: gr64, preferred-register: '' }
+  - { id: 1, class: gr64, preferred-register: '' }
+  - { id: 2, class: gr64, preferred-register: '' }
+  - { id: 3, class: gr64, preferred-register: '' }
+  - { id: 4, class: vr128, preferred-register: '' }
+  - { id: 5, class: vr128, preferred-register: '' }
+  - { id: 6, class: vr128, preferred-register: '' }
+  - { id: 7, class: vr128, preferred-register: '' }
+  - { id: 8, class: vr128, preferred-register: '' }
+liveins:
+  - { reg: '$rdi', virtual-reg: '%0' }
+  - { reg: '$rsi', virtual-reg: '%1' }
+  - { reg: '$rdx', virtual-reg: '%2' }
+  - { reg: '$rcx', virtual-reg: '%3' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $rdi, $rsi, $rdx, $rcx
+
+    %0:gr64 = COPY $rdi
+    %1:gr64 = COPY $rsi
+    %2:gr64 = COPY $rdx
+    %3:gr64 = COPY $rcx
+    %4:vr128 = MOVUPSrm %0, 1, $noreg, 0, $noreg :: (load (s128) from %ir.a, align 16)
+    %5:vr128 = MOVUPSrm %1, 1, $noreg, 0, $noreg :: (load (s128) from %ir.b, align 16)
+    %6:vr128 = MOVUPSrm %2, 1, $noreg, 0, $noreg :: (load (s128) from %ir.c, align 16)
+    %7:vr128 = MULPSrr %4:vr128, %5:vr128, implicit $mxcsr
+    %8:vr128 = SUBPSrr %6:vr128, %7:vr128, implicit $mxcsr
+    MOVUPSmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s128) into %ir.d, align 16)
+    RET64
+
+---
+name:            test_avx
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: gr64, preferred-register: '' }
+  - { id: 1, class: gr64, preferred-register: '' }
+  - { id: 2, class: gr64, preferred-register: '' }
+  - { id: 3, class: gr64, preferred-register: '' }
+  - { id: 4, class: vr256, preferred-register: '' }
+  - { id: 5, class: vr256, preferred-register: '' }
+  - { id: 6, class: vr256, preferred-register: '' }
+  - { id: 7, class: vr256, preferred-register: '' }
+  - { id: 8, class: vr256, preferred-register: '' }
+liveins:
+  - { reg: '$rdi', virtual-reg: '%0' }
+  - { reg: '$rsi', virtual-reg: '%1' }
+  - { reg: '$rdx', virtual-reg: '%2' }
+  - { reg: '$rcx', virtual-reg: '%3' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $rdi, $rsi, $rdx, $rcx
+
+    %0:gr64 = COPY $rdi
+    %1:gr64 = COPY $rsi
+    %2:gr64 = COPY $rdx
+    %3:gr64 = COPY $rcx
+    %4:vr256 = VMOVUPSYrm %0, 1, $noreg, 0, $noreg :: (load (s256) from %ir.a, align 32)
+    %5:vr256 = VMOVUPSYrm %1, 1, $noreg, 0, $noreg :: (load (s256) from %ir.b, align 32)
+    %6:vr256 = VMOVUPSYrm %2, 1, $noreg, 0, $noreg :: (load (s256) from %ir.c, align 32)
+    %7:vr256 = VMULPSYrr %4:vr256, %5:vr256, implicit $mxcsr
+    %8:vr256 = VSUBPSYrr %6:vr256, %7:vr256, implicit $mxcsr
+    VMOVUPSYmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s256) into %ir.d, align 32)
+    RET64
+
+---
+name:            test_avx_memory
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: gr64, preferred-register: '' }
+  - { id: 1, class: gr64, preferred-register: '' }
+  - { id: 2, class: gr64, preferred-register: '' }
+  - { id: 3, class: gr64, preferred-register: '' }
+  - { id: 4, class: vr256, preferred-register: '' }
+  - { id: 5, class: vr256, preferred-register: '' }
+  - { id: 6, class: vr256, preferred-register: '' }
+  - { id: 7, class: vr256, preferred-register: '' }
+  - { id: 8, class: vr256, preferred-register: '' }
+liveins:
+  - { reg: '$rdi', virtual-reg: '%0' }
+  - { reg: '$rsi', virtual-reg: '%1' }
+  - { reg: '$rdx', virtual-reg: '%2' }
+  - { reg: '$rcx', virtual-reg: '%3' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $rdi, $rsi, $rdx, $rcx
+
+    %0:gr64 = COPY $rdi
+    %1:gr64 = COPY $rsi
+    %2:gr64 = COPY $rdx
+    %3:gr64 = COPY $rcx
+    %4:vr256 = VMOVUPSYrm %0, 1, $noreg, 0, $noreg :: (load (s256) from %ir.a, align 32)
+    %6:vr256 = VMULPSYrm %4:vr256, %1:gr64, 1, $noreg, 0, $noreg, implicit $mxcsr :: (load (s256) from %ir.b, align 32)
+    %7:vr256 = VMOVUPSYrm %2, 1, $noreg, 0, $noreg :: (load (s256) from %ir.c, align 32)
+    %8:vr256 = VSUBPSYrr %7:vr256, %6:vr256, implicit $mxcsr
+    VMOVUPSYmr %3, 1, $noreg, 0, $noreg, %8 :: (store (s256) into %ir.d, align 32)
+    RET64
+
+---
+name:            test_negative
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: gr64, preferred-register: '' }
+  - { id: 1, class: gr64, preferred-register: '' }
+  - { id: 2, class: gr64, preferred-register: '' }
+  - { id: 3, class: gr64, preferred-register: '' }
+  - { id: 4, class: vr256, preferred-register: '' }
+  - { id: 5, class: vr256, preferred-register: '' }
+  - { id: 6, class: vr256, preferred-register: '' }
+liveins:
+  - { reg: '$rdi', virtual-reg: '%0' }
+  - { reg: '$rsi', virtual-reg: '%1' }
+  - { reg: '$rdx', virtual-reg: '%2' }
+  - { reg: '$rcx', virtual-reg: '%3' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $rdi, $rsi, $rdx, $rcx
+
+    %0:gr64 = COPY $rdi
+    %1:gr64 = COPY $rsi
+    %2:gr64 = COPY $rdx
+    %3:gr64 = COPY $rcx
+    %4:vr256 = VMOVUPSYrm %0, 1, $noreg, 0, $noreg :: (load (s256) from %ir.a, align 32)
+    %5:vr256 = VMOVUPSYrm %1, 1, $noreg, 0, $noreg :: (load (s256) from %ir.b, align 32)
+    %6:vr256 = VADDPSYrr %4:vr256, %5:vr256, implicit $mxcsr
+    VMOVUPSYmr %3, 1, $noreg, 0, $noreg, %6 :: (store (s256) into %ir.d, align 32)
+    RET64


### PR DESCRIPTION
Цель **MultiplySubtractPass** - оптимизация последовательностей умножения и вычитания в FMA-инструкции на архитектуре x86.

Пасс ищет комбинации MUL + SUB в пределах базового блока. Поддерживает скалярные (SUBSSrr, VSUBSDrr) и векторные (SUBPSrr, VSUBPSYrr, VSUBPDYrr) операции.

**FMA-преобразование:**

Заменяет c - (a * b) на соответствующую FMA-инструкцию:
- VFMSUB213SSr для float
- VFMSUB213SDr для double
- VFMSUB213PSr/VFMSUB213PDYr для векторных операций
