### PR TITLE
Хованский Дмитрий. Лабораторная работа 3: Backend. Вариант 3.

### DIFF
--- a/llvm/compiler-course/backend/khovansky_d_lab3/CMakeLists.txt
+++ b/llvm/compiler-course/backend/khovansky_d_lab3/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(Title "FMAFlatten")
+set(Student "Khovansky_Dmitry")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_BACKEND")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY
+)
+
+target_include_directories(${TARGET_NAME} PUBLIC ${PATH_TO_X86})
+set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
+++ b/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
@@ -123,5 +123,3 @@ char FMAFlatten::ID = 0;
 static llvm::RegisterPass<FMAFlatten>
     X("FMA-flatten-x86", "Decomposes FMA instructions into MUL and ADD", false,
       false);
-
-

--- a/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
+++ b/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
@@ -53,8 +53,8 @@ public:
   }
 
 private:
-  bool identifyFMA(unsigned Op, unsigned &Mul, unsigned &Add, 
-                   unsigned &A_idx, unsigned &B_idx, unsigned &C_idx) {
+  bool identifyFMA(unsigned Op, unsigned &Mul, unsigned &Add, unsigned &A_idx,
+                   unsigned &B_idx, unsigned &C_idx) {
     switch (Op) {
     // Packed single-precision
     case X86::VFMADD132PSr:

--- a/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
+++ b/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
@@ -27,15 +27,16 @@ public:
     for (auto &Block : MF) {
       for (auto Inst = Block.begin(), End = Block.end(); Inst != End;) {
         MachineInstr &MI = *Inst++;
-        unsigned MulOp, AddOp, MulOp1, MulOp2;
+        unsigned MulOp, AddOp;
+        unsigned A_idx, B_idx, C_idx;
 
-        if (!identifyFMA(MI.getOpcode(), MulOp, AddOp, MulOp1, MulOp2))
+        if (!identifyFMA(MI.getOpcode(), MulOp, AddOp, A_idx, B_idx, C_idx))
           continue;
 
         Register Dst = MI.getOperand(0).getReg();
-        Register A = MI.getOperand(1).getReg();
-        Register B = MI.getOperand(2).getReg();
-        Register C = MI.getOperand(3).getReg();
+        Register A = MI.getOperand(A_idx).getReg();
+        Register B = MI.getOperand(B_idx).getReg();
+        Register C = MI.getOperand(C_idx).getReg();
         DebugLoc Loc = MI.getDebugLoc();
 
         const TargetRegisterClass *RegClass = MRI.getRegClass(A);
@@ -52,63 +53,99 @@ public:
   }
 
 private:
-  bool identifyFMA(unsigned Op, unsigned &Mul, unsigned &Add, unsigned &MulOp1,
-                   unsigned &MulOp2) {
+  bool identifyFMA(unsigned Op, unsigned &Mul, unsigned &Add, 
+                   unsigned &A_idx, unsigned &B_idx, unsigned &C_idx) {
     switch (Op) {
     // Packed single-precision
     case X86::VFMADD132PSr:
       Mul = X86::MULPSrr;
       Add = X86::ADDPSrr;
+      A_idx = 1;
+      B_idx = 3;
+      C_idx = 2;
       return true;
     case X86::VFMADD213PSr:
       Mul = X86::MULPSrr;
       Add = X86::ADDPSrr;
+      A_idx = 2;
+      B_idx = 1;
+      C_idx = 3;
       return true;
     case X86::VFMADD231PSr:
       Mul = X86::MULPSrr;
       Add = X86::ADDPSrr;
+      A_idx = 2;
+      B_idx = 3;
+      C_idx = 1;
       return true;
 
     // Packed double-precision
     case X86::VFMADD132PDr:
       Mul = X86::MULPDrr;
       Add = X86::ADDPDrr;
+      A_idx = 1;
+      B_idx = 3;
+      C_idx = 2;
       return true;
     case X86::VFMADD213PDr:
       Mul = X86::MULPDrr;
       Add = X86::ADDPDrr;
+      A_idx = 2;
+      B_idx = 1;
+      C_idx = 3;
       return true;
     case X86::VFMADD231PDr:
       Mul = X86::MULPDrr;
       Add = X86::ADDPDrr;
+      A_idx = 2;
+      B_idx = 3;
+      C_idx = 1;
       return true;
 
     // Scalar single-precision
     case X86::VFMADD132SSr:
       Mul = X86::MULSSrr;
       Add = X86::ADDSSrr;
+      A_idx = 1;
+      B_idx = 3;
+      C_idx = 2;
       return true;
     case X86::VFMADD213SSr:
       Mul = X86::MULSSrr;
       Add = X86::ADDSSrr;
+      A_idx = 2;
+      B_idx = 1;
+      C_idx = 3;
       return true;
     case X86::VFMADD231SSr:
       Mul = X86::MULSSrr;
       Add = X86::ADDSSrr;
+      A_idx = 2;
+      B_idx = 3;
+      C_idx = 1;
       return true;
 
     // Scalar double-precision
     case X86::VFMADD132SDr:
       Mul = X86::MULSDrr;
       Add = X86::ADDSDrr;
+      A_idx = 1;
+      B_idx = 3;
+      C_idx = 2;
       return true;
     case X86::VFMADD213SDr:
       Mul = X86::MULSDrr;
       Add = X86::ADDSDrr;
+      A_idx = 2;
+      B_idx = 1;
+      C_idx = 3;
       return true;
     case X86::VFMADD231SDr:
       Mul = X86::MULSDrr;
       Add = X86::ADDSDrr;
+      A_idx = 2;
+      B_idx = 3;
+      C_idx = 1;
       return true;
 
     default:

--- a/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
+++ b/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
@@ -33,8 +33,8 @@ public:
           continue;
 
         Register Dst = MI.getOperand(0).getReg();
-        Register A = MI.getOperand(MulOp1).getReg();
-        Register B = MI.getOperand(MulOp2).getReg();
+        Register A = MI.getOperand(1).getReg();
+        Register B = MI.getOperand(2).getReg();
         Register C = MI.getOperand(3).getReg();
         DebugLoc Loc = MI.getDebugLoc();
 
@@ -52,52 +52,64 @@ public:
   }
 
 private:
-  bool identifyFMA(unsigned Op, unsigned &Mul, unsigned &Add,
-                   unsigned &MulOp1, unsigned &MulOp2) {
+  bool identifyFMA(unsigned Op, unsigned &Mul, unsigned &Add, unsigned &MulOp1,
+                   unsigned &MulOp2) {
     switch (Op) {
     // Packed single-precision
     case X86::VFMADD132PSr:
-      Mul = X86::MULPSrr; Add = X86::ADDPSrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULPSrr;
+      Add = X86::ADDPSrr;
+      return true;
     case X86::VFMADD213PSr:
-      Mul = X86::MULPSrr; Add = X86::ADDPSrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULPSrr;
+      Add = X86::ADDPSrr;
+      return true;
     case X86::VFMADD231PSr:
-      Mul = X86::MULPSrr; Add = X86::ADDPSrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULPSrr;
+      Add = X86::ADDPSrr;
+      return true;
 
     // Packed double-precision
     case X86::VFMADD132PDr:
-      Mul = X86::MULPDrr; Add = X86::ADDPDrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULPDrr;
+      Add = X86::ADDPDrr;
+      return true;
     case X86::VFMADD213PDr:
-      Mul = X86::MULPDrr; Add = X86::ADDPDrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULPDrr;
+      Add = X86::ADDPDrr;
+      return true;
     case X86::VFMADD231PDr:
-      Mul = X86::MULPDrr; Add = X86::ADDPDrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULPDrr;
+      Add = X86::ADDPDrr;
+      return true;
 
     // Scalar single-precision
     case X86::VFMADD132SSr:
-      Mul = X86::MULSSrr; Add = X86::ADDSSrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULSSrr;
+      Add = X86::ADDSSrr;
+      return true;
     case X86::VFMADD213SSr:
-      Mul = X86::MULSSrr; Add = X86::ADDSSrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULSSrr;
+      Add = X86::ADDSSrr;
+      return true;
     case X86::VFMADD231SSr:
-      Mul = X86::MULSSrr; Add = X86::ADDSSrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULSSrr;
+      Add = X86::ADDSSrr;
+      return true;
 
     // Scalar double-precision
     case X86::VFMADD132SDr:
-      Mul = X86::MULSDrr; Add = X86::ADDSDrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULSDrr;
+      Add = X86::ADDSDrr;
+      return true;
     case X86::VFMADD213SDr:
-      Mul = X86::MULSDrr; Add = X86::ADDSDrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULSDrr;
+      Add = X86::ADDSDrr;
+      return true;
     case X86::VFMADD231SDr:
-      Mul = X86::MULSDrr; Add = X86::ADDSDrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULSDrr;
+      Add = X86::ADDSDrr;
+      return true;
 
     default:
       return false;
@@ -109,5 +121,7 @@ char FMAFlatten::ID = 0;
 } // namespace
 
 static llvm::RegisterPass<FMAFlatten>
-    X("FMA-flatten-x86", "Decomposes FMA instructions into MUL and ADD", false, false);
+    X("FMA-flatten-x86", "Decomposes FMA instructions into MUL and ADD", false,
+      false);
+
 

--- a/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
+++ b/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
@@ -1,0 +1,113 @@
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/Support/Debug.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "fma-decompose"
+
+namespace {
+class FMAFlatten : public MachineFunctionPass {
+public:
+  static char ID;
+  FMAFlatten() : MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    auto &ST = MF.getSubtarget<X86Subtarget>();
+    auto *TII = ST.getInstrInfo();
+    auto &MRI = MF.getRegInfo();
+    bool Changed = false;
+
+    for (auto &Block : MF) {
+      for (auto Inst = Block.begin(), End = Block.end(); Inst != End;) {
+        MachineInstr &MI = *Inst++;
+        unsigned MulOp, AddOp, MulOp1, MulOp2;
+
+        if (!identifyFMA(MI.getOpcode(), MulOp, AddOp, MulOp1, MulOp2))
+          continue;
+
+        Register Dst = MI.getOperand(0).getReg();
+        Register A = MI.getOperand(MulOp1).getReg();
+        Register B = MI.getOperand(MulOp2).getReg();
+        Register C = MI.getOperand(3).getReg();
+        DebugLoc Loc = MI.getDebugLoc();
+
+        const TargetRegisterClass *RegClass = MRI.getRegClass(A);
+        Register Temp = MRI.createVirtualRegister(RegClass);
+
+        BuildMI(Block, MI, Loc, TII->get(MulOp), Temp).addReg(A).addReg(B);
+        BuildMI(Block, MI, Loc, TII->get(AddOp), Dst).addReg(C).addReg(Temp);
+        MI.eraseFromParent();
+        Changed = true;
+      }
+    }
+
+    return Changed;
+  }
+
+private:
+  bool identifyFMA(unsigned Op, unsigned &Mul, unsigned &Add,
+                   unsigned &MulOp1, unsigned &MulOp2) {
+    switch (Op) {
+    // Packed single-precision
+    case X86::VFMADD132PSr:
+      Mul = X86::MULPSrr; Add = X86::ADDPSrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+    case X86::VFMADD213PSr:
+      Mul = X86::MULPSrr; Add = X86::ADDPSrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+    case X86::VFMADD231PSr:
+      Mul = X86::MULPSrr; Add = X86::ADDPSrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+
+    // Packed double-precision
+    case X86::VFMADD132PDr:
+      Mul = X86::MULPDrr; Add = X86::ADDPDrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+    case X86::VFMADD213PDr:
+      Mul = X86::MULPDrr; Add = X86::ADDPDrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+    case X86::VFMADD231PDr:
+      Mul = X86::MULPDrr; Add = X86::ADDPDrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+
+    // Scalar single-precision
+    case X86::VFMADD132SSr:
+      Mul = X86::MULSSrr; Add = X86::ADDSSrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+    case X86::VFMADD213SSr:
+      Mul = X86::MULSSrr; Add = X86::ADDSSrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+    case X86::VFMADD231SSr:
+      Mul = X86::MULSSrr; Add = X86::ADDSSrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+
+    // Scalar double-precision
+    case X86::VFMADD132SDr:
+      Mul = X86::MULSDrr; Add = X86::ADDSDrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+    case X86::VFMADD213SDr:
+      Mul = X86::MULSDrr; Add = X86::ADDSDrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+    case X86::VFMADD231SDr:
+      Mul = X86::MULSDrr; Add = X86::ADDSDrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+
+    default:
+      return false;
+    }
+  }
+};
+
+char FMAFlatten::ID = 0;
+} // namespace
+
+static llvm::RegisterPass<FMAFlatten>
+    X("FMA-flatten-x86", "Decomposes FMA instructions into MUL and ADD", false, false);
+

--- a/llvm/test/compiler-course/khovansky_d_lab3/khovansky_d_lab3.mir
+++ b/llvm/test/compiler-course/khovansky_d_lab3/khovansky_d_lab3.mir
@@ -1,0 +1,73 @@
+# RUN: llc -mtriple x86_64-unknown-linux-gnu --load=%llvmshlibdir/FMAFlatten_Khovansky_Dmitry_FIIT2_BACKEND%shlibext \
+# RUN: -run-pass=FMA-flatten-x86  %s -o - | FileCheck %s
+
+--- |
+  ; ModuleID = 'FMAFlatten.c'
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-pc-linux-gnu"
+
+  declare <4 x float> @llvm.fma.v4f32(<4 x float>, <4 x float>, <4 x float>)
+  declare <2 x double> @llvm.fma.v2f64(<2 x double>, <2 x double>, <2 x double>)
+  declare float @llvm.fma.f32(float, float, float)
+  declare double @llvm.fma.f64(double, double, double)
+
+  define void @FMAFlatten(<4 x float> %a, <2 x double> %b, float %c, double %d) {
+    ret void
+  }
+...
+---
+name:            FMAFlatten
+body:             |
+  bb.0 (%ir-block.0):
+    liveins: $xmm0, $xmm1, $xmm2, $xmm3, $xmm4, $xmm5, $xmm6, $xmm7
+
+    ; 1. VFMADD132PSr (packed float)
+    ; CHECK:      [[MUL1:%[0-9]+]]:vr128 = MULPSrr %0, %0, implicit $mxcsr
+    ; CHECK-NEXT: %0:vr128 = ADDPSrr %0, [[MUL1]], implicit $mxcsr
+    %0:vr128 = COPY $xmm0
+    %0:vr128 = VFMADD132PSr %0, %0, %0, implicit $mxcsr
+
+    ; 2. VFMADD231PDr (packed double)
+    ; CHECK:      [[MUL2:%[0-9]+]]:vr128 = MULPDrr %1, %1, implicit $mxcsr
+    ; CHECK-NEXT: %1:vr128 = ADDPDrr %1, [[MUL2]], implicit $mxcsr
+    %1:vr128 = COPY $xmm1
+    %1:vr128 = VFMADD231PDr %1, %1, %1, implicit $mxcsr
+
+    ; 3. VFMADD213SSr (scalar float)
+    ; CHECK:      [[MUL3:%[0-9]+]]:fr32 = MULSSrr %2, %2, implicit $mxcsr
+    ; CHECK-NEXT: %2:fr32 = ADDSSrr %2, [[MUL3]], implicit $mxcsr
+    %2:fr32 = COPY $xmm2
+    %2:fr32 = VFMADD213SSr %2, %2, %2, implicit $mxcsr
+
+    ; 4. VFMADD132SDr (scalar double)
+    ; CHECK:      [[MUL4:%[0-9]+]]:fr64 = MULSDrr %3, %3, implicit $mxcsr
+    ; CHECK-NEXT: %3:fr64 = ADDSDrr %3, [[MUL4]], implicit $mxcsr
+    %3:fr64 = COPY $xmm3
+    %3:fr64 = VFMADD132SDr %3, %3, %3, implicit $mxcsr
+
+    ; 5. VFMADD132PSr с разными регистрами
+    ; CHECK:      [[MUL5:%[0-9]+]]:vr128 = MULPSrr %4, %5, implicit $mxcsr
+    ; CHECK-NEXT: %6:vr128 = ADDPSrr %6, [[MUL5]], implicit $mxcsr
+    %4:vr128 = COPY $xmm4
+    %5:vr128 = COPY $xmm5
+    %6:vr128 = COPY $xmm6
+    %6:vr128 = VFMADD132PSr %4, %5, %6, implicit $mxcsr
+
+    ; 6. VFMADD213PDr с разными регистрами
+    ; CHECK:      [[MUL6:%[0-9]+]]:vr128 = MULPDrr %7, %5, implicit $mxcsr
+    ; CHECK-NEXT: %5:vr128 = ADDPDrr %5, [[MUL6]], implicit $mxcsr
+    %7:vr128 = COPY $xmm7
+    %5:vr128 = COPY $xmm5
+    %5:vr128 = VFMADD213PDr %7, %5, %5, implicit $mxcsr
+
+    ; 7. VFMADD231SSr с разными регистрами
+    ; CHECK:      [[MUL7:%[0-9]+]]:fr32 = MULSSrr %8, %2, implicit $mxcsr
+    ; CHECK-NEXT: %2:fr32 = ADDSSrr %2, [[MUL7]], implicit $mxcsr
+    %8:fr32 = COPY $xmm3
+    %2:fr32 = COPY $xmm2
+    %2:fr32 = VFMADD231SSr %8, %2, %2, implicit $mxcsr
+
+    ; Общая проверка
+    ; CHECK-NOT: VFMADD
+    RET 0
+

--- a/llvm/test/compiler-course/khovansky_d_lab3/khovansky_d_lab3.mir
+++ b/llvm/test/compiler-course/khovansky_d_lab3/khovansky_d_lab3.mir
@@ -53,14 +53,14 @@ body:             |
     %6:vr128 = COPY $xmm6
     %6:vr128 = VFMADD132PSr %4, %5, %6, implicit $mxcsr
 
-    ; 6. VFMADD213PDr с разными регистрами
+    ; 6. VFMADD213PDr с перекрытием регистров
     ; CHECK:      [[MUL6:%[0-9]+]]:vr128 = MULPDrr %7, %5, implicit $mxcsr
     ; CHECK-NEXT: %5:vr128 = ADDPDrr %5, [[MUL6]], implicit $mxcsr
     %7:vr128 = COPY $xmm7
     %5:vr128 = COPY $xmm5
     %5:vr128 = VFMADD213PDr %7, %5, %5, implicit $mxcsr
 
-    ; 7. VFMADD231SSr с разными регистрами
+    ; 7. VFMADD231SSr со смешанными типами данных
     ; CHECK:      [[MUL7:%[0-9]+]]:fr32 = MULSSrr %8, %2, implicit $mxcsr
     ; CHECK-NEXT: %2:fr32 = ADDSSrr %2, [[MUL7]], implicit $mxcsr
     %8:fr32 = COPY $xmm3

--- a/llvm/test/compiler-course/khovansky_d_lab3/khovansky_d_lab3.mir
+++ b/llvm/test/compiler-course/khovansky_d_lab3/khovansky_d_lab3.mir
@@ -14,65 +14,65 @@
   declare double @llvm.fma.f64(double, double, double)
 
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef float @_Z18test_132_singlefff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
+  define dso_local noundef float @_Z15test_132_singlefff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
     %4 = tail call float @llvm.fma.f32(float %0, float %1, float %2)
     ret float %4
   }
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef float @_Z18test_213_singlefff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
+  define dso_local noundef float @_Z15test_213_singlefff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
     %4 = tail call float @llvm.fma.f32(float %0, float %1, float %2)
     ret float %4
   }
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef float @_Z18test_231_singlefff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
+  define dso_local noundef float @_Z15test_231_singlefff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
     %4 = tail call float @llvm.fma.f32(float %0, float %1, float %2)
     ret float %4
   }
 
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef double @_Z18test_132_doubleddd(double noundef %0, double noundef %1, double noundef %2) local_unnamed_addr #1 {
+  define dso_local noundef double @_Z15test_132_doubleddd(double noundef %0, double noundef %1, double noundef %2) local_unnamed_addr #1 {
     %4 = tail call double @llvm.fma.f64(double %0, double %1, double %2)
     ret double %4
   }
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef double @_Z18test_213_doubleddd(double noundef %0, double noundef %1, double noundef %2) local_unnamed_addr #1 {
+  define dso_local noundef double @_Z15test_213_doubleddd(double noundef %0, double noundef %1, double noundef %2) local_unnamed_addr #1 {
     %4 = tail call double @llvm.fma.f64(double %0, double %1, double %2)
     ret double %4
   }
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef double @_Z18test_231_doubleddd(double noundef %0, double noundef %1, double noundef %2) local_unnamed_addr #1 {
+  define dso_local noundef double @_Z15test_231_doubleddd(double noundef %0, double noundef %1, double noundef %2) local_unnamed_addr #1 {
     %4 = tail call double @llvm.fma.f64(double %0, double %1, double %2)
     ret double %4
   }
 
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef <4 x float> @_Z7test_132_psDv4_fS_S_(<4 x float> noundef %0, <4 x float> noundef %1, <4 x float> noundef %2) local_unnamed_addr #0 {
+  define dso_local noundef <4 x float> @_Z11test_132_psDv4_fS_S_(<4 x float> noundef %0, <4 x float> noundef %1, <4 x float> noundef %2) local_unnamed_addr #0 {
     %4 = tail call noundef <4 x float> @llvm.fma.v4f32(<4 x float> %0, <4 x float> %1, <4 x float> %2)
     ret <4 x float> %4
   }
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef <4 x float> @_Z7test_213_psDv4_fS_S_(<4 x float> noundef %0, <4 x float> noundef %1, <4 x float> noundef %2) local_unnamed_addr #0 {
+  define dso_local noundef <4 x float> @_Z11test_213_psDv4_fS_S_(<4 x float> noundef %0, <4 x float> noundef %1, <4 x float> noundef %2) local_unnamed_addr #0 {
     %4 = tail call noundef <4 x float> @llvm.fma.v4f32(<4 x float> %0, <4 x float> %1, <4 x float> %2)
     ret <4 x float> %4
   }
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef <4 x float> @_Z7test_231_psDv4_fS_S_(<4 x float> noundef %0, <4 x float> noundef %1, <4 x float> noundef %2) local_unnamed_addr #0 {
+  define dso_local noundef <4 x float> @_Z11test_231_psDv4_fS_S_(<4 x float> noundef %0, <4 x float> noundef %1, <4 x float> noundef %2) local_unnamed_addr #0 {
     %4 = tail call noundef <4 x float> @llvm.fma.v4f32(<4 x float> %0, <4 x float> %1, <4 x float> %2)
     ret <4 x float> %4
   }
 
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef <2 x double> @_Z7test_132_pdDv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
+  define dso_local noundef <2 x double> @_Z11test_132_pdDv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
     %4 = tail call noundef <2 x double> @llvm.fma.v2f64(<2 x double> %0, <2 x double> %1, <2 x double> %2)
     ret <2 x double> %4
   }
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef <2 x double> @_Z7test_213_pdDv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
+  define dso_local noundef <2 x double> @_Z11test_213_pdDv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
     %4 = tail call noundef <2 x double> @llvm.fma.v2f64(<2 x double> %0, <2 x double> %1, <2 x double> %2)
     ret <2 x double> %4
   }
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef <2 x double> @_Z7test_231_pdDv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
+  define dso_local noundef <2 x double> @_Z11test_231_pdDv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
     %4 = tail call noundef <2 x double> @llvm.fma.v2f64(<2 x double> %0, <2 x double> %1, <2 x double> %2)
     ret <2 x double> %4
   }
@@ -92,7 +92,7 @@
 
 ...
 ---
-name:            _Z18test_132_singlefff
+name:            _Z15test_132_singlefff
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -169,7 +169,7 @@ body:             |
 
 ...
 ---
-name:            _Z18test_213_singlefff
+name:            _Z15test_213_singlefff
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -246,7 +246,7 @@ body:             |
 
 ...
 ---
-name:            _Z18test_231_singlefff
+name:            _Z15test_231_singlefff
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -323,7 +323,7 @@ body:             |
 
 ...
 ---
-name:            _Z18test_132_doubleddd
+name:            _Z15test_132_doubleddd
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -400,7 +400,7 @@ body:             |
 
 ...
 ---
-name:            _Z18test_213_doubleddd
+name:            _Z15test_213_doubleddd
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -477,7 +477,7 @@ body:             |
 
 ...
 ---
-name:            _Z18test_231_doubleddd
+name:            _Z15test_231_doubleddd
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -554,7 +554,7 @@ body:             |
 
 ...
 ---
-name:            _Z7test_132_psDv4_fS_S_
+name:            _Z11test_132_psDv4_fS_S_
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -631,7 +631,7 @@ body:             |
 
 ...
 ---
-name:            _Z7test_213_psDv4_fS_S_
+name:            _Z11test_213_psDv4_fS_S_
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -708,7 +708,7 @@ body:             |
 
 ...
 ---
-name:            _Z7test_231_psDv4_fS_S_
+name:            _Z11test_231_psDv4_fS_S_
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -785,7 +785,7 @@ body:             |
 
 ...
 ---
-name:            _Z7test_132_pdDv2_dS_S_
+name:            _Z11test_132_pdDv2_dS_S_
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -862,7 +862,7 @@ body:             |
 
 ...
 ---
-name:            _Z7test_213_pdDv2_dS_S_
+name:            _Z11test_213_pdDv2_dS_S_
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -939,7 +939,7 @@ body:             |
 
 ...
 ---
-name:            _Z7test_231_pdDv2_dS_S_
+name:            _Z11test_231_pdDv2_dS_S_
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false

--- a/llvm/test/compiler-course/khovansky_d_lab3/khovansky_d_lab3.mir
+++ b/llvm/test/compiler-course/khovansky_d_lab3/khovansky_d_lab3.mir
@@ -1,8 +1,10 @@
-# RUN: llc -mtriple x86_64-unknown-linux-gnu --load=%llvmshlibdir/FMAFlatten_Khovansky_Dmitry_FIIT2_BACKEND%shlibext \
-# RUN: -run-pass=FMA-flatten-x86  %s -o - | FileCheck %s
+# RUN: llc -mtriple x86_64-unknown-linux-gnu \
+# RUN:     --load=%llvmshlibdir/FMAFlatten_Khovansky_Dmitry_FIIT2_BACKEND%shlibext \
+# RUN:     -run-pass=FMA-flatten-x86 %s -o - | FileCheck %s
 
 --- |
-  ; ModuleID = 'FMAFlatten.c'
+  ; ModuleID = 'FMAFlatten.ll'
+  source_filename = "khovansky_d_lab3.cpp"
   target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
   target triple = "x86_64-pc-linux-gnu"
 
@@ -11,63 +13,1006 @@
   declare float @llvm.fma.f32(float, float, float)
   declare double @llvm.fma.f64(double, double, double)
 
-  define void @FMAFlatten(<4 x float> %a, <2 x double> %b, float %c, double %d) {
-    ret void
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef float @_Z18test_132_singlefff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
+    %4 = tail call float @llvm.fma.f32(float %0, float %1, float %2)
+    ret float %4
   }
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef float @_Z18test_213_singlefff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
+    %4 = tail call float @llvm.fma.f32(float %0, float %1, float %2)
+    ret float %4
+  }
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef float @_Z18test_231_singlefff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
+    %4 = tail call float @llvm.fma.f32(float %0, float %1, float %2)
+    ret float %4
+  }
+
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef double @_Z18test_132_doubleddd(double noundef %0, double noundef %1, double noundef %2) local_unnamed_addr #1 {
+    %4 = tail call double @llvm.fma.f64(double %0, double %1, double %2)
+    ret double %4
+  }
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef double @_Z18test_213_doubleddd(double noundef %0, double noundef %1, double noundef %2) local_unnamed_addr #1 {
+    %4 = tail call double @llvm.fma.f64(double %0, double %1, double %2)
+    ret double %4
+  }
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef double @_Z18test_231_doubleddd(double noundef %0, double noundef %1, double noundef %2) local_unnamed_addr #1 {
+    %4 = tail call double @llvm.fma.f64(double %0, double %1, double %2)
+    ret double %4
+  }
+
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <4 x float> @_Z7test_132_psDv4_fS_S_(<4 x float> noundef %0, <4 x float> noundef %1, <4 x float> noundef %2) local_unnamed_addr #0 {
+    %4 = tail call noundef <4 x float> @llvm.fma.v4f32(<4 x float> %0, <4 x float> %1, <4 x float> %2)
+    ret <4 x float> %4
+  }
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <4 x float> @_Z7test_213_psDv4_fS_S_(<4 x float> noundef %0, <4 x float> noundef %1, <4 x float> noundef %2) local_unnamed_addr #0 {
+    %4 = tail call noundef <4 x float> @llvm.fma.v4f32(<4 x float> %0, <4 x float> %1, <4 x float> %2)
+    ret <4 x float> %4
+  }
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <4 x float> @_Z7test_231_psDv4_fS_S_(<4 x float> noundef %0, <4 x float> noundef %1, <4 x float> noundef %2) local_unnamed_addr #0 {
+    %4 = tail call noundef <4 x float> @llvm.fma.v4f32(<4 x float> %0, <4 x float> %1, <4 x float> %2)
+    ret <4 x float> %4
+  }
+
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <2 x double> @_Z7test_132_pdDv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
+    %4 = tail call noundef <2 x double> @llvm.fma.v2f64(<2 x double> %0, <2 x double> %1, <2 x double> %2)
+    ret <2 x double> %4
+  }
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <2 x double> @_Z7test_213_pdDv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
+    %4 = tail call noundef <2 x double> @llvm.fma.v2f64(<2 x double> %0, <2 x double> %1, <2 x double> %2)
+    ret <2 x double> %4
+  }
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <2 x double> @_Z7test_231_pdDv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
+    %4 = tail call noundef <2 x double> @llvm.fma.v2f64(<2 x double> %0, <2 x double> %1, <2 x double> %2)
+    ret <2 x double> %4
+  }
+
+  attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable "min-legal-vector-width"="128" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+avx,+cmov,+crc32,+cx8,+fma,+fxsr,+mmx,+popcnt,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3,+x87,+xsave" "tune-cpu"="generic" }
+  attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+avx,+cmov,+crc32,+cx8,+fma,+fxsr,+mmx,+popcnt,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3,+x87,+xsave" "tune-cpu"="generic" }
+  attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+
+  !llvm.module.flags = !{!0, !1, !2, !3}
+  !llvm.ident = !{!4}
+
+  !0 = !{i32 1, !"wchar_size", i32 4}
+  !1 = !{i32 8, !"PIC Level", i32 2}
+  !2 = !{i32 7, !"PIE Level", i32 2}
+  !3 = !{i32 7, !"uwtable", i32 2}
+  !4 = !{!"Ubuntu clang version 18.1.3 (1ubuntu1)"}
+
 ...
 ---
-name:            FMAFlatten
+name:            _Z18test_132_singlefff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
 body:             |
-  bb.0 (%ir-block.0):
-    liveins: $xmm0, $xmm1, $xmm2, $xmm3, $xmm4, $xmm5, $xmm6, $xmm7
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:fr32 = COPY $xmm2
+    ; CHECK-NEXT: %1:fr32 = COPY $xmm1
+    ; CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ; CHECK-NEXT: %4:fr32 = MULSSrr %0, %2, implicit $mxcsr
+    ; CHECK-NEXT: %3:fr32 = ADDSSrr %1, %4, implicit $mxcsr
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
 
-    ; 1. VFMADD132PSr (packed float)
-    ; CHECK:      [[MUL1:%[0-9]+]]:vr128 = MULPSrr %0, %0, implicit $mxcsr
-    ; CHECK-NEXT: %0:vr128 = ADDPSrr %0, [[MUL1]], implicit $mxcsr
-    %0:vr128 = COPY $xmm0
-    %0:vr128 = VFMADD132PSr %0, %0, %0, implicit $mxcsr
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VFMADD132SSr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
 
-    ; 2. VFMADD231PDr (packed double)
-    ; CHECK:      [[MUL2:%[0-9]+]]:vr128 = MULPDrr %1, %1, implicit $mxcsr
-    ; CHECK-NEXT: %1:vr128 = ADDPDrr %1, [[MUL2]], implicit $mxcsr
+...
+---
+name:            _Z18test_213_singlefff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:fr32 = COPY $xmm2
+    ; CHECK-NEXT: %1:fr32 = COPY $xmm1
+    ; CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ; CHECK-NEXT: %4:fr32 = MULSSrr %1, %0, implicit $mxcsr
+    ; CHECK-NEXT: %3:fr32 = ADDSSrr %2, %4, implicit $mxcsr
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VFMADD213SSr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+name:            _Z18test_231_singlefff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32 }
+  - { id: 1, class: fr32 }
+  - { id: 2, class: fr32 }
+  - { id: 3, class: fr32 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:fr32 = COPY $xmm2
+    ; CHECK-NEXT: %1:fr32 = COPY $xmm1
+    ; CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ; CHECK-NEXT: %4:fr32 = MULSSrr %1, %2, implicit $mxcsr
+    ; CHECK-NEXT: %3:fr32 = ADDSSrr %0, %4, implicit $mxcsr
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VFMADD231SSr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+name:            _Z18test_132_doubleddd
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr64 }
+  - { id: 1, class: fr64 }
+  - { id: 2, class: fr64 }
+  - { id: 3, class: fr64 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:fr64 = COPY $xmm2
+    ; CHECK-NEXT: %1:fr64 = COPY $xmm1
+    ; CHECK-NEXT: %0:fr64 = COPY $xmm0
+    ; CHECK-NEXT: %4:fr64 = MULSDrr %0, %2, implicit $mxcsr
+    ; CHECK-NEXT: %3:fr64 = ADDSDrr %1, %4, implicit $mxcsr
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+
+    %2:fr64 = COPY $xmm2
+    %1:fr64 = COPY $xmm1
+    %0:fr64 = COPY $xmm0
+    %3:fr64 = nofpexcept VFMADD132SDr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+name:            _Z18test_213_doubleddd
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr64 }
+  - { id: 1, class: fr64 }
+  - { id: 2, class: fr64 }
+  - { id: 3, class: fr64 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:fr64 = COPY $xmm2
+    ; CHECK-NEXT: %1:fr64 = COPY $xmm1
+    ; CHECK-NEXT: %0:fr64 = COPY $xmm0
+    ; CHECK-NEXT: %4:fr64 = MULSDrr %1, %0, implicit $mxcsr
+    ; CHECK-NEXT: %3:fr64 = ADDSDrr %2, %4, implicit $mxcsr
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+
+    %2:fr64 = COPY $xmm2
+    %1:fr64 = COPY $xmm1
+    %0:fr64 = COPY $xmm0
+    %3:fr64 = nofpexcept VFMADD213SDr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+name:            _Z18test_231_doubleddd
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr64 }
+  - { id: 1, class: fr64 }
+  - { id: 2, class: fr64 }
+  - { id: 3, class: fr64 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:fr64 = COPY $xmm2
+    ; CHECK-NEXT: %1:fr64 = COPY $xmm1
+    ; CHECK-NEXT: %0:fr64 = COPY $xmm0
+    ; CHECK-NEXT: %4:fr64 = MULSDrr %1, %2, implicit $mxcsr
+    ; CHECK-NEXT: %3:fr64 = ADDSDrr %0, %4, implicit $mxcsr
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+
+    %2:fr64 = COPY $xmm2
+    %1:fr64 = COPY $xmm1
+    %0:fr64 = COPY $xmm0
+    %3:fr64 = nofpexcept VFMADD231SDr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+name:            _Z7test_132_psDv4_fS_S_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128 }
+  - { id: 1, class: vr128 }
+  - { id: 2, class: vr128 }
+  - { id: 3, class: vr128 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:vr128 = COPY $xmm2
+    ; CHECK-NEXT: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %4:vr128 = MULPSrr %0, %2
+    ; CHECK-NEXT: %3:vr128 = ADDPSrr %1, %4
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+
+    %2:vr128 = COPY $xmm2
     %1:vr128 = COPY $xmm1
-    %1:vr128 = VFMADD231PDr %1, %1, %1, implicit $mxcsr
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept VFMADD132PSr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
 
-    ; 3. VFMADD213SSr (scalar float)
-    ; CHECK:      [[MUL3:%[0-9]+]]:fr32 = MULSSrr %2, %2, implicit $mxcsr
-    ; CHECK-NEXT: %2:fr32 = ADDSSrr %2, [[MUL3]], implicit $mxcsr
-    %2:fr32 = COPY $xmm2
-    %2:fr32 = VFMADD213SSr %2, %2, %2, implicit $mxcsr
+...
+---
+name:            _Z7test_213_psDv4_fS_S_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128 }
+  - { id: 1, class: vr128 }
+  - { id: 2, class: vr128 }
+  - { id: 3, class: vr128 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:vr128 = COPY $xmm2
+    ; CHECK-NEXT: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %4:vr128 = MULPSrr %1, %0
+    ; CHECK-NEXT: %3:vr128 = ADDPSrr %2, %4
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
 
-    ; 4. VFMADD132SDr (scalar double)
-    ; CHECK:      [[MUL4:%[0-9]+]]:fr64 = MULSDrr %3, %3, implicit $mxcsr
-    ; CHECK-NEXT: %3:fr64 = ADDSDrr %3, [[MUL4]], implicit $mxcsr
-    %3:fr64 = COPY $xmm3
-    %3:fr64 = VFMADD132SDr %3, %3, %3, implicit $mxcsr
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept VFMADD213PSr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
 
-    ; 5. VFMADD132PSr с разными регистрами
-    ; CHECK:      [[MUL5:%[0-9]+]]:vr128 = MULPSrr %4, %5, implicit $mxcsr
-    ; CHECK-NEXT: %6:vr128 = ADDPSrr %6, [[MUL5]], implicit $mxcsr
-    %4:vr128 = COPY $xmm4
-    %5:vr128 = COPY $xmm5
-    %6:vr128 = COPY $xmm6
-    %6:vr128 = VFMADD132PSr %4, %5, %6, implicit $mxcsr
+...
+---
+name:            _Z7test_231_psDv4_fS_S_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128 }
+  - { id: 1, class: vr128 }
+  - { id: 2, class: vr128 }
+  - { id: 3, class: vr128 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:vr128 = COPY $xmm2
+    ; CHECK-NEXT: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %4:vr128 = MULPSrr %1, %2
+    ; CHECK-NEXT: %3:vr128 = ADDPSrr %0, %4
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
 
-    ; 6. VFMADD213PDr с перекрытием регистров
-    ; CHECK:      [[MUL6:%[0-9]+]]:vr128 = MULPDrr %7, %5, implicit $mxcsr
-    ; CHECK-NEXT: %5:vr128 = ADDPDrr %5, [[MUL6]], implicit $mxcsr
-    %7:vr128 = COPY $xmm7
-    %5:vr128 = COPY $xmm5
-    %5:vr128 = VFMADD213PDr %7, %5, %5, implicit $mxcsr
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept VFMADD231PSr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
 
-    ; 7. VFMADD231SSr со смешанными типами данных
-    ; CHECK:      [[MUL7:%[0-9]+]]:fr32 = MULSSrr %8, %2, implicit $mxcsr
-    ; CHECK-NEXT: %2:fr32 = ADDSSrr %2, [[MUL7]], implicit $mxcsr
-    %8:fr32 = COPY $xmm3
-    %2:fr32 = COPY $xmm2
-    %2:fr32 = VFMADD231SSr %8, %2, %2, implicit $mxcsr
+...
+---
+name:            _Z7test_132_pdDv2_dS_S_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128 }
+  - { id: 1, class: vr128 }
+  - { id: 2, class: vr128 }
+  - { id: 3, class: vr128 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:vr128 = COPY $xmm2
+    ; CHECK-NEXT: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %4:vr128 = MULPDrr %0, %2
+    ; CHECK-NEXT: %3:vr128 = ADDPDrr %1, %4
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
 
-    ; Общая проверка
-    ; CHECK-NOT: VFMADD
-    RET 0
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept VFMADD132PDr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+name:            _Z7test_213_pdDv2_dS_S_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128 }
+  - { id: 1, class: vr128 }
+  - { id: 2, class: vr128 }
+  - { id: 3, class: vr128 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:vr128 = COPY $xmm2
+    ; CHECK-NEXT: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %4:vr128 = MULPDrr %1, %0
+    ; CHECK-NEXT: %3:vr128 = ADDPDrr %2, %4
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept VFMADD213PDr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+name:            _Z7test_231_pdDv2_dS_S_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128 }
+  - { id: 1, class: vr128 }
+  - { id: 2, class: vr128 }
+  - { id: 3, class: vr128 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:vr128 = COPY $xmm2
+    ; CHECK-NEXT: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %4:vr128 = MULPDrr %1, %2
+    ; CHECK-NEXT: %3:vr128 = ADDPDrr %0, %4
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept VFMADD231PDr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
 


### PR DESCRIPTION
Пасс FMAFlatten предназначен для разложения инструкций объединённого умножения и сложения (Fused Multiply-Add, FMA) архитектуры x86 в эквивалентную последовательность из двух отдельных машинных инструкций: умножения и сложения. Он реализован как MachineFunctionPass и работает на уровне машинных инструкций после формирования MachineFunction.

Во время выполнения пасс обходит все базовые блоки и анализирует каждую инструкцию на предмет принадлежности к семейству VFMADD* — как скалярных, так и векторных вариантов для одинарной (SS, PS) и двойной (SD, PD) точности. Для подходящих инструкций определяется порядок операндов и подбираются соответствующие инструкции MUL* и ADD*. Затем создаётся временный виртуальный регистр, в который записывается результат умножения, и на его основе формируется инструкция сложения. После вставки новых инструкций оригинальная FMA-инструкция удаляется.