### PR TITLE
Созонов Илья. Лабораторная работа 3. Backend. Вариант 1. 

### DIFF
--- a/llvm/compiler-course/backend/sozonov_i_logical_combiner/CMakeLists.txt
+++ b/llvm/compiler-course/backend/sozonov_i_logical_combiner/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(Title "LogicalCombinerPass")
+set(Student "Sozonov_Ilya")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_BACKEND")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY
+)
+
+target_include_directories(${TARGET_NAME} PUBLIC ${PATH_TO_X86})
+set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/compiler-course/backend/sozonov_i_logical_combiner/LogicalCombinerPass.cpp
+++ b/llvm/compiler-course/backend/sozonov_i_logical_combiner/LogicalCombinerPass.cpp
@@ -1,0 +1,98 @@
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+
+namespace {
+class LogicalCombinerPass : public MachineFunctionPass {
+public:
+  static char ID;
+  LogicalCombinerPass() : MachineFunctionPass(ID) {}
+  bool runOnMachineFunction(MachineFunction &MF) override;
+};
+
+char LogicalCombinerPass::ID = 0;
+
+bool LogicalCombinerPass::runOnMachineFunction(MachineFunction &MF) {
+  llvm::outs() << MF.getName() << '\n';
+
+  const X86Subtarget &STI = MF.getSubtarget<X86Subtarget>();
+  const X86InstrInfo *TII = STI.getInstrInfo();
+  MachineRegisterInfo &MRI = MF.getRegInfo();
+  bool Changed = false;
+
+  for (auto &MBB : MF) {
+    for (auto MI = MBB.begin(); MI != MBB.end();) {
+      MachineInstr &AndInstr = *MI;
+      unsigned AndOpc = AndInstr.getOpcode();
+
+      if (AndOpc != X86::ANDPSrr && AndOpc != X86::VPANDrr) {
+        ++MI;
+        continue;
+      }
+
+      if (!AndInstr.getOperand(0).isReg() || !AndInstr.getOperand(1).isReg() ||
+          !AndInstr.getOperand(2).isReg()) {
+        ++MI;
+        continue;
+      }
+
+      Register AndDst = AndInstr.getOperand(0).getReg();
+      Register AndOp1 = AndInstr.getOperand(1).getReg();
+      Register AndOp2 = AndInstr.getOperand(2).getReg();
+
+      auto NextMI = std::next(MI);
+      if (NextMI == MBB.end()) {
+        ++MI;
+        continue;
+      }
+
+      MachineInstr &OrInstr = *NextMI;
+      unsigned OrOpc = OrInstr.getOpcode();
+
+      if ((OrOpc != X86::ORPSrr && OrOpc != X86::VPORrr) ||
+          !OrInstr.getOperand(1).isReg() ||
+          OrInstr.getOperand(1).getReg() != AndDst ||
+          !OrInstr.getOperand(0).isReg() || !OrInstr.getOperand(2).isReg()) {
+        ++MI;
+        continue;
+      }
+
+      Register OrDst = OrInstr.getOperand(0).getReg();
+      Register OrOther = OrInstr.getOperand(2).getReg();
+
+      DebugLoc DL = AndInstr.getDebugLoc();
+
+      const TargetRegisterClass *RC = MRI.getRegClass(AndOp1);
+      if (!RC)
+        RC = MRI.getRegClass(AndOp2);
+      if (!RC)
+        continue;
+
+      Register TmpReg = MRI.createVirtualRegister(RC);
+
+      BuildMI(MBB, AndInstr, DL, TII->get(X86::VPANDrr), TmpReg)
+          .addReg(AndOp1)
+          .addReg(AndOp2);
+
+      BuildMI(MBB, OrInstr, DL, TII->get(X86::VPORrr), OrDst)
+          .addReg(TmpReg)
+          .addReg(OrOther);
+
+      MI = MBB.erase(MI);
+      MBB.erase(NextMI);
+
+      Changed = true;
+    }
+  }
+
+  return Changed;
+}
+} // namespace
+
+static RegisterPass<LogicalCombinerPass>
+    X("logical-combiner-x86", "Combine logical ops into AVX", false, false);

--- a/llvm/compiler-course/llvm-ir/sozonov_i_llvm_fmuladd/CMakeLists.txt
+++ b/llvm/compiler-course/llvm-ir/sozonov_i_llvm_fmuladd/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(Title "FmulFaddPass")
+set(Student "Sozonov_Ilya")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_LLVM_IR")
+
+if (NOT WIN32 AND NOT CYGWIN)
+    file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+    add_llvm_pass_plugin(${TARGET_NAME} ${SOURCES}
+        DEPENDS
+        intrinsics_gen
+        BUILDTREE_ONLY
+    )
+    set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)
+endif()

--- a/llvm/compiler-course/llvm-ir/sozonov_i_llvm_fmuladd/FmulFaddPass.cpp
+++ b/llvm/compiler-course/llvm-ir/sozonov_i_llvm_fmuladd/FmulFaddPass.cpp
@@ -34,7 +34,7 @@ struct FmulFaddPass : llvm::PassInfoMixin<FmulFaddPass> {
               B = Mul->getOperand(1);
               C = Operands[1 - i];
               MulInst = Mul;
-              break;
+              break; //hasOneUse
             }
           }
         }

--- a/llvm/compiler-course/llvm-ir/sozonov_i_llvm_fmuladd/FmulFaddPass.cpp
+++ b/llvm/compiler-course/llvm-ir/sozonov_i_llvm_fmuladd/FmulFaddPass.cpp
@@ -1,0 +1,87 @@
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstrTypes.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+struct FmulFaddPass : llvm::PassInfoMixin<FmulFaddPass> {
+  llvm::PreservedAnalyses run(llvm::Function &func,
+                              llvm::FunctionAnalysisManager &) {
+    bool isModified = false;
+    llvm::SmallVector<llvm::Instruction *, 4> instructionsToRemove;
+
+    for (llvm::BasicBlock &BB : func) {
+      for (llvm::Instruction &I : llvm::make_early_inc_range(BB)) {
+        if (I.getOpcode() != llvm::Instruction::FAdd)
+          continue;
+
+        llvm::Value *Op1 = I.getOperand(0);
+        llvm::Value *Op2 = I.getOperand(1);
+
+        llvm::Instruction *MulInst = nullptr;
+        llvm::Value *A = nullptr, *B = nullptr, *C = nullptr;
+
+        if (auto *Mul = llvm::dyn_cast<llvm::Instruction>(Op1)) {
+          if (Mul->getOpcode() == llvm::Instruction::FMul) {
+            A = Mul->getOperand(0);
+            B = Mul->getOperand(1);
+            C = Op2;
+            MulInst = Mul;
+          }
+        }
+
+        if (!MulInst) {
+          if (auto *Mul = llvm::dyn_cast<llvm::Instruction>(Op2)) {
+            if (Mul->getOpcode() == llvm::Instruction::FMul) {
+              A = Mul->getOperand(0);
+              B = Mul->getOperand(1);
+              C = Op1;
+              MulInst = Mul;
+            }
+          }
+        }
+
+        if (MulInst) {
+          llvm::IRBuilder<> builder(&I);
+          llvm::Function *FmaFunc = llvm::Intrinsic::getDeclaration(
+              func.getParent(), llvm::Intrinsic::fmuladd, I.getType());
+
+          llvm::Value *Fma = builder.CreateCall(FmaFunc, {A, B, C});
+          I.replaceAllUsesWith(Fma);
+          instructionsToRemove.push_back(&I);
+          instructionsToRemove.push_back(MulInst);
+          isModified = true;
+        }
+      }
+    }
+
+    for (llvm::Instruction *I : instructionsToRemove)
+      I->eraseFromParent();
+
+    return isModified ? llvm::PreservedAnalyses::none()
+                      : llvm::PreservedAnalyses::all();
+  }
+
+  static bool isRequired() { return true; }
+};
+} // namespace
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "FmulFaddPass", "0.1",
+          [](llvm::PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](llvm::StringRef name, llvm::FunctionPassManager &FPM,
+                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) -> bool {
+                  if (name == "FmulFaddPass") {
+                    FPM.addPass(FmulFaddPass{});
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}

--- a/llvm/compiler-course/llvm-ir/sozonov_i_llvm_fmuladd/FmulFaddPass.cpp
+++ b/llvm/compiler-course/llvm-ir/sozonov_i_llvm_fmuladd/FmulFaddPass.cpp
@@ -40,18 +40,18 @@ struct FmulFaddPass : llvm::PassInfoMixin<FmulFaddPass> {
         }
 
         if (MulInst) {
+          if (!MulInst->hasOneUse())
+            continue;
+
           llvm::IRBuilder<> builder(&I);
           llvm::Function *FmaFunc = llvm::Intrinsic::getDeclaration(
               func.getParent(), llvm::Intrinsic::fmuladd, I.getType());
-        
+
           llvm::Value *Fma = builder.CreateCall(FmaFunc, {A, B, C});
           I.replaceAllUsesWith(Fma);
           instructionsToRemove.push_back(&I);
-        
-          if (MulInst->hasOneUse()) {
-            instructionsToRemove.push_back(MulInst);
-          }
-        
+          instructionsToRemove.push_back(MulInst);
+
           isModified = true;
         }
       }

--- a/llvm/compiler-course/llvm-ir/sozonov_i_llvm_fmuladd/FmulFaddPass.cpp
+++ b/llvm/compiler-course/llvm-ir/sozonov_i_llvm_fmuladd/FmulFaddPass.cpp
@@ -25,22 +25,16 @@ struct FmulFaddPass : llvm::PassInfoMixin<FmulFaddPass> {
         llvm::Instruction *MulInst = nullptr;
         llvm::Value *A = nullptr, *B = nullptr, *C = nullptr;
 
-        if (auto *Mul = llvm::dyn_cast<llvm::Instruction>(Op1)) {
-          if (Mul->getOpcode() == llvm::Instruction::FMul) {
-            A = Mul->getOperand(0);
-            B = Mul->getOperand(1);
-            C = Op2;
-            MulInst = Mul;
-          }
-        }
+        llvm::Value *Operands[2] = {Op1, Op2};
 
-        if (!MulInst) {
-          if (auto *Mul = llvm::dyn_cast<llvm::Instruction>(Op2)) {
+        for (int i = 0; i < 2; ++i) {
+          if (auto *Mul = llvm::dyn_cast<llvm::Instruction>(Operands[i])) {
             if (Mul->getOpcode() == llvm::Instruction::FMul) {
               A = Mul->getOperand(0);
               B = Mul->getOperand(1);
-              C = Op1;
+              C = Operands[1 - i];
               MulInst = Mul;
+              break;
             }
           }
         }
@@ -49,11 +43,15 @@ struct FmulFaddPass : llvm::PassInfoMixin<FmulFaddPass> {
           llvm::IRBuilder<> builder(&I);
           llvm::Function *FmaFunc = llvm::Intrinsic::getDeclaration(
               func.getParent(), llvm::Intrinsic::fmuladd, I.getType());
-
+        
           llvm::Value *Fma = builder.CreateCall(FmaFunc, {A, B, C});
           I.replaceAllUsesWith(Fma);
           instructionsToRemove.push_back(&I);
-          instructionsToRemove.push_back(MulInst);
+        
+          if (MulInst->hasOneUse()) {
+            instructionsToRemove.push_back(MulInst);
+          }
+        
           isModified = true;
         }
       }

--- a/llvm/test/compiler-course/sozonov_i_llvm_fmuladd/lit_test_llvm_ir_.ll
+++ b/llvm/test/compiler-course/sozonov_i_llvm_fmuladd/lit_test_llvm_ir_.ll
@@ -1,0 +1,41 @@
+; RUN: opt -load-pass-plugin %llvmshlibdir/FmulFaddPass_Sozonov_Ilya_FIIT3_LLVM_IR%pluginext -passes=FmulFaddPass -S %s | FileCheck %s
+
+; Test 1: (a * b) + c - should be replaced with llvm.fmuladd(a, b, c)
+; CHECK-LABEL: @mul_add_direct
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+; CHECK-NEXT: ret float %0
+
+define float @mul_add_direct(float %a, float %b, float %c) {
+entry:
+  %mul = fmul float %a, %b
+  %add = fadd float %mul, %c
+  ret float %add
+}
+
+; Test 2: c + (a * b) - should also be replaced with llvm.fmuladd(a, b, c)
+; CHECK-LABEL: @add_commuted_mul
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+; CHECK-NEXT: ret float %0
+
+define float @add_commuted_mul(float %a, float %b, float %c) {
+entry:
+  %mul = fmul float %a, %b
+  %add = fadd float %c, %mul
+  ret float %add
+}
+
+; Test 3: non-pattern input - should NOT be replaced
+; CHECK-LABEL: @no_pattern
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %add = fadd float %c, %b
+; CHECK-NEXT: %mul = fmul float %a, %add
+; CHECK-NEXT: ret float %mul
+
+define float @no_pattern(float %a, float %b, float %c) {
+entry:
+  %add = fadd float %c, %b
+  %mul = fmul float %a, %add
+  ret float %mul
+}

--- a/llvm/test/compiler-course/sozonov_i_llvm_fmuladd/lit_test_llvm_ir_.ll
+++ b/llvm/test/compiler-course/sozonov_i_llvm_fmuladd/lit_test_llvm_ir_.ll
@@ -1,12 +1,11 @@
 ; RUN: opt -load-pass-plugin %llvmshlibdir/FmulFaddPass_Sozonov_Ilya_FIIT3_LLVM_IR%pluginext -passes=FmulFaddPass -S %s | FileCheck %s
 
 ; Test 1: (a * b) + c - should be replaced with llvm.fmuladd(a, b, c)
-; CHECK-LABEL: @mul_add_direct
+; CHECK-LABEL: @fmul_fadd_ab_c
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT: %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
 ; CHECK-NEXT: ret float %0
-
-define float @mul_add_direct(float %a, float %b, float %c) {
+define float @fmul_fadd_ab_c(float %a, float %b, float %c) {
 entry:
   %mul = fmul float %a, %b
   %add = fadd float %mul, %c
@@ -14,28 +13,112 @@ entry:
 }
 
 ; Test 2: c + (a * b) - should also be replaced with llvm.fmuladd(a, b, c)
-; CHECK-LABEL: @add_commuted_mul
+; CHECK-LABEL: @fadd_c_fmul_ab
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT: %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
 ; CHECK-NEXT: ret float %0
-
-define float @add_commuted_mul(float %a, float %b, float %c) {
+define float @fadd_c_fmul_ab(float %a, float %b, float %c) {
 entry:
   %mul = fmul float %a, %b
   %add = fadd float %c, %mul
   ret float %add
 }
 
-; Test 3: non-pattern input - should NOT be replaced
-; CHECK-LABEL: @no_pattern
+; Test 3: (c + b) * a - addition first (no matching pattern)
+; CHECK-LABEL: @no_match_fadd_then_fmul
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT: %add = fadd float %c, %b
 ; CHECK-NEXT: %mul = fmul float %a, %add
 ; CHECK-NEXT: ret float %mul
-
-define float @no_pattern(float %a, float %b, float %c) {
+define float @no_match_fadd_then_fmul(float %a, float %b, float %c) {
 entry:
   %add = fadd float %c, %b
   %mul = fmul float %a, %add
   ret float %mul
+}
+
+; Test 4: (a + b) * c — addition comes first (should not match)
+; CHECK-LABEL: @no_match_add_then_mul
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %add = fadd float %a, %b
+; CHECK-NEXT: %mul = fmul float %add, %c
+; CHECK-NEXT: ret float %mul
+define float @no_match_add_then_mul(float %a, float %b, float %c) {
+entry:
+  %add = fadd float %a, %b
+  %mul = fmul float %add, %c
+  ret float %mul
+}
+
+; Test 5: (a * a) + a - same operand used in multiple places (should still replace)
+; CHECK-LABEL: @fmul_fadd_reuse
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %0 = call float @llvm.fmuladd.f32(float %a, float %a, float %a)
+; CHECK-NEXT: ret float %0
+define float @fmul_fadd_reuse(float %a) {
+entry:
+  %mul = fmul float %a, %a
+  %add = fadd float %mul, %a
+  ret float %add
+}
+
+; Test 6: ((a * b) + c) + d - nested expression (should replace inner only)
+; CHECK-LABEL: @nested_fmul_fadd_then_add
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+; CHECK-NEXT: %add2 = fadd float %0, %d
+; CHECK-NEXT: ret float %add2
+define float @nested_fmul_fadd_then_add(float %a, float %b, float %c, float %d) {
+entry:
+  %mul = fmul float %a, %b
+  %add1 = fadd float %mul, %c
+  %add2 = fadd float %add1, %d
+  ret float %add2
+}
+
+; Test 7: (a * b) + c — double precision (should replace)
+; CHECK-LABEL: @fmul_fadd_double
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %0 = call double @llvm.fmuladd.f64(double %a, double %b, double %c)
+; CHECK-NEXT: ret double %0
+define double @fmul_fadd_double(double %a, double %b, double %c) {
+entry:
+  %mul = fmul double %a, %b
+  %add = fadd double %mul, %c
+  ret double %add
+}
+
+; Test 8: (2.0 * a) + 1.0 - used constants (should replace)
+; CHECK-LABEL: @fmul_fadd_with_constants
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %0 = call float @llvm.fmuladd.f32(float 2.000000e+00, float %a, float 1.000000e+00)
+; CHECK-NEXT: ret float %0
+define float @fmul_fadd_with_constants(float %a) {
+entry:
+  %mul = fmul float 2.0, %a
+  %add = fadd float %mul, 1.0
+  ret float %add
+}
+
+; Test 9: (x * x) + y - one operand used multiple times (should replace)
+; CHECK-LABEL: @fmul_fadd_duplicate_operand
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %0 = call float @llvm.fmuladd.f32(float %x, float %x, float %y)
+; CHECK-NEXT: ret float %0
+define float @fmul_fadd_duplicate_operand(float %x, float %y) {
+entry:
+  %mul = fmul float %x, %x
+  %add = fadd float %mul, %y
+  ret float %add
+}
+
+; Test 10: already fused with llvm.fmuladd
+; CHECK-LABEL: @already_fused_fmuladd
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %fma = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+; CHECK-NEXT: ret float %fma
+define float @already_fused_fmuladd(float %a, float %b, float %c) {
+entry:
+  %fma = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+  ret float %fma
 }

--- a/llvm/test/compiler-course/sozonov_i_llvm_fmuladd/lit_test_llvm_ir_.ll
+++ b/llvm/test/compiler-course/sozonov_i_llvm_fmuladd/lit_test_llvm_ir_.ll
@@ -91,6 +91,8 @@ entry:
 ; Test 8: (2.0 * a) + 1.0 - used constants (should replace)
 ; CHECK-LABEL: @fmul_fadd_with_constants
 ; CHECK-NEXT: entry:
+; CHECK-NOT: %mul = fmul float 2.0, %a
+; CHECK-NOT: %add = fadd float %mul, 1.0
 ; CHECK-NEXT: %0 = call float @llvm.fmuladd.f32(float 2.000000e+00, float %a, float 1.000000e+00)
 ; CHECK-NEXT: ret float %0
 define float @fmul_fadd_with_constants(float %a) {
@@ -136,4 +138,14 @@ define float @already_fused_fmuladd(float %a, float %b, float %c) {
 entry:
   %fma = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
   ret float %fma
+}
+
+
+define float @fmul_used_multiple_times_3(float %a, float %b, float %c, float %d) {
+entry:
+  %mul1 = fmul float %a, %b
+  %mul2 = fmul float %c, %d
+  %add = fadd float %mul1, %mul2
+  %add2 = fadd float %mul1, %add
+  ret float %add2
 }

--- a/llvm/test/compiler-course/sozonov_i_llvm_fmuladd/lit_test_llvm_ir_.ll
+++ b/llvm/test/compiler-course/sozonov_i_llvm_fmuladd/lit_test_llvm_ir_.ll
@@ -24,7 +24,7 @@ entry:
   ret float %add
 }
 
-; Test 3: (c + b) * a - addition first (no matching pattern)
+; Test 3: a * (c + b) - addition first (no matching pattern)
 ; CHECK-LABEL: @no_match_fadd_then_fmul
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT: %add = fadd float %c, %b
@@ -112,7 +112,23 @@ entry:
   ret float %add
 }
 
-; Test 10: already fused with llvm.fmuladd
+; Test 10: (x = a * b; y = x + c; return x + y) - use of intermediate result
+; CHECK-LABEL: @fmul_used_multiple_times
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %mul = fmul float %a, %b
+; CHECK-NEXT: %add = fadd float %mul, %c
+; CHECK-NEXT: %add2 = fadd float %mul, %add
+; CHECK-NEXT: ret float %add2
+
+define float @fmul_used_multiple_times(float %a, float %b, float %c) {
+entry:
+  %mul = fmul float %a, %b
+  %add = fadd float %mul, %c
+  %add2 = fadd float %mul, %add
+  ret float %add2
+}
+
+; Test 11: already fused with llvm.fmuladd
 ; CHECK-LABEL: @already_fused_fmuladd
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT: %fma = call float @llvm.fmuladd.f32(float %a, float %b, float %c)

--- a/llvm/test/compiler-course/sozonov_i_llvm_fmuladd/lit_test_llvm_ir_.ll
+++ b/llvm/test/compiler-course/sozonov_i_llvm_fmuladd/lit_test_llvm_ir_.ll
@@ -119,7 +119,6 @@ entry:
 ; CHECK-NEXT: %add = fadd float %mul, %c
 ; CHECK-NEXT: %add2 = fadd float %mul, %add
 ; CHECK-NEXT: ret float %add2
-
 define float @fmul_used_multiple_times(float %a, float %b, float %c) {
 entry:
   %mul = fmul float %a, %b

--- a/llvm/test/compiler-course/sozonov_i_logical_combiner/test_backend.mir
+++ b/llvm/test/compiler-course/sozonov_i_logical_combiner/test_backend.mir
@@ -1,0 +1,1461 @@
+# RUN: llc -mtriple x86_64-unknown-linux-gnu --load=%llvmshlibdir/LogicalCombinerPass_Sozonov_Ilya_FIIT3_BACKEND%shlibext \
+# RUN: -run-pass=logical-combiner-x86  %s -o - | FileCheck %s
+
+--- |
+  ; ModuleID = 'llvm/test/compiler-course/sozonov_i_logical_combiner/test.ll'
+  source_filename = "test.cpp"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-pc-linux-gnu"
+  
+  module asm ".globl _ZSt21ios_base_library_initv"
+  
+  %"class.std::basic_ostream" = type { ptr, %"class.std::basic_ios" }
+  %"class.std::basic_ios" = type { %"class.std::ios_base", ptr, i8, i8, ptr, ptr, ptr, ptr }
+  %"class.std::ios_base" = type { ptr, i64, i64, i32, i32, i32, ptr, %"struct.std::ios_base::_Words", [8 x %"struct.std::ios_base::_Words"], i32, ptr, %"class.std::locale" }
+  %"struct.std::ios_base::_Words" = type { ptr, i64 }
+  %"class.std::locale" = type { ptr }
+  %"class.std::ctype" = type <{ %"class.std::locale::facet.base", [4 x i8], ptr, i8, [7 x i8], ptr, ptr, ptr, i8, [256 x i8], [256 x i8], i8, [6 x i8] }>
+  %"class.std::locale::facet.base" = type <{ ptr, i32 }>
+  
+  @_ZSt4cout = external global %"class.std::basic_ostream", align 8
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef zeroext i1 @_Z11and_or_testiii(i32 noundef %0, i32 noundef %1, i32 noundef %2) local_unnamed_addr #0 {
+    %4 = and i32 %1, %0
+    %5 = icmp ne i32 %4, 0
+    %6 = zext i1 %5 to i32
+    %7 = or i32 %6, %2
+    %8 = icmp ne i32 %7, 0
+    ret i1 %8
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef zeroext i1 @_Z11or_xor_testiii(i32 noundef %0, i32 noundef %1, i32 noundef %2) local_unnamed_addr #0 {
+    %4 = or i32 %1, %0
+    %5 = icmp ne i32 %4, 0
+    %6 = zext i1 %5 to i32
+    %7 = icmp ne i32 %6, %2
+    ret i1 %7
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef zeroext i1 @_Z12and_xor_testiii(i32 noundef %0, i32 noundef %1, i32 noundef %2) local_unnamed_addr #0 {
+    %4 = and i32 %1, %0
+    %5 = icmp ne i32 %4, 0
+    %6 = zext i1 %5 to i32
+    %7 = icmp ne i32 %6, %2
+    ret i1 %7
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef zeroext i1 @_Z15and_or_xor_testiiii(i32 noundef %0, i32 noundef %1, i32 noundef %2, i32 noundef %3) local_unnamed_addr #0 {
+    %5 = and i32 %1, %0
+    %6 = icmp ne i32 %5, 0
+    %7 = zext i1 %6 to i32
+    %8 = or i32 %7, %2
+    %9 = icmp ne i32 %8, 0
+    %10 = zext i1 %9 to i32
+    %11 = icmp ne i32 %10, %3
+    ret i1 %11
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef zeroext i1 @_Z12and_and_testiii(i32 noundef %0, i32 noundef %1, i32 noundef %2) local_unnamed_addr #0 {
+    %4 = and i32 %1, %0
+    %5 = icmp ne i32 %4, 0
+    %6 = and i32 %2, 1
+    %7 = icmp ne i32 %6, 0
+    %8 = and i1 %5, %7
+    ret i1 %8
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef zeroext i1 @_Z12xor_xor_testiii(i32 noundef %0, i32 noundef %1, i32 noundef %2) local_unnamed_addr #0 {
+    %4 = icmp ne i32 %0, %1
+    %5 = zext i1 %4 to i32
+    %6 = icmp ne i32 %5, %2
+    ret i1 %6
+  }
+  
+  ; Function Attrs: mustprogress norecurse uwtable
+  define dso_local noundef i32 @main() local_unnamed_addr #1 {
+    %1 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo9_M_insertIbEERSoT_(ptr noundef nonnull align 8 dereferenceable(8) @_ZSt4cout, i1 noundef zeroext true)
+    %2 = load ptr, ptr %1, align 8, !tbaa !5
+    %3 = getelementptr i8, ptr %2, i64 -24
+    %4 = load i64, ptr %3, align 8
+    %5 = getelementptr inbounds i8, ptr %1, i64 %4
+    %6 = getelementptr inbounds %"class.std::basic_ios", ptr %5, i64 0, i32 5
+    %7 = load ptr, ptr %6, align 8, !tbaa !8
+    %8 = icmp eq ptr %7, null
+    br i1 %8, label %9, label %10
+  
+  9:                                                ; preds = %0
+    tail call void @_ZSt16__throw_bad_castv() #4
+    unreachable
+  
+  10:                                               ; preds = %0
+    %11 = getelementptr inbounds %"class.std::ctype", ptr %7, i64 0, i32 8
+    %12 = load i8, ptr %11, align 8, !tbaa !20
+    %13 = icmp eq i8 %12, 0
+    br i1 %13, label %17, label %14
+  
+  14:                                               ; preds = %10
+    %15 = getelementptr inbounds %"class.std::ctype", ptr %7, i64 0, i32 9, i64 10
+    %16 = load i8, ptr %15, align 1, !tbaa !23
+    br label %22
+  
+  17:                                               ; preds = %10
+    tail call void @_ZNKSt5ctypeIcE13_M_widen_initEv(ptr noundef nonnull align 8 dereferenceable(570) %7)
+    %18 = load ptr, ptr %7, align 8, !tbaa !5
+    %19 = getelementptr inbounds ptr, ptr %18, i64 6
+    %20 = load ptr, ptr %19, align 8
+    %21 = tail call noundef signext i8 %20(ptr noundef nonnull align 8 dereferenceable(570) %7, i8 noundef signext 10)
+    br label %22
+  
+  22:                                               ; preds = %17, %14
+    %23 = phi i8 [ %16, %14 ], [ %21, %17 ]
+    %24 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo3putEc(ptr noundef nonnull align 8 dereferenceable(8) %1, i8 noundef signext %23)
+    %25 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo5flushEv(ptr noundef nonnull align 8 dereferenceable(8) %24)
+    %26 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo9_M_insertIbEERSoT_(ptr noundef nonnull align 8 dereferenceable(8) @_ZSt4cout, i1 noundef zeroext false)
+    %27 = load ptr, ptr %26, align 8, !tbaa !5
+    %28 = getelementptr i8, ptr %27, i64 -24
+    %29 = load i64, ptr %28, align 8
+    %30 = getelementptr inbounds i8, ptr %26, i64 %29
+    %31 = getelementptr inbounds %"class.std::basic_ios", ptr %30, i64 0, i32 5
+    %32 = load ptr, ptr %31, align 8, !tbaa !8
+    %33 = icmp eq ptr %32, null
+    br i1 %33, label %34, label %35
+  
+  34:                                               ; preds = %22
+    tail call void @_ZSt16__throw_bad_castv() #4
+    unreachable
+  
+  35:                                               ; preds = %22
+    %36 = getelementptr inbounds %"class.std::ctype", ptr %32, i64 0, i32 8
+    %37 = load i8, ptr %36, align 8, !tbaa !20
+    %38 = icmp eq i8 %37, 0
+    br i1 %38, label %42, label %39
+  
+  39:                                               ; preds = %35
+    %40 = getelementptr inbounds %"class.std::ctype", ptr %32, i64 0, i32 9, i64 10
+    %41 = load i8, ptr %40, align 1, !tbaa !23
+    br label %47
+  
+  42:                                               ; preds = %35
+    tail call void @_ZNKSt5ctypeIcE13_M_widen_initEv(ptr noundef nonnull align 8 dereferenceable(570) %32)
+    %43 = load ptr, ptr %32, align 8, !tbaa !5
+    %44 = getelementptr inbounds ptr, ptr %43, i64 6
+    %45 = load ptr, ptr %44, align 8
+    %46 = tail call noundef signext i8 %45(ptr noundef nonnull align 8 dereferenceable(570) %32, i8 noundef signext 10)
+    br label %47
+  
+  47:                                               ; preds = %42, %39
+    %48 = phi i8 [ %41, %39 ], [ %46, %42 ]
+    %49 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo3putEc(ptr noundef nonnull align 8 dereferenceable(8) %26, i8 noundef signext %48)
+    %50 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo5flushEv(ptr noundef nonnull align 8 dereferenceable(8) %49)
+    %51 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo9_M_insertIbEERSoT_(ptr noundef nonnull align 8 dereferenceable(8) @_ZSt4cout, i1 noundef zeroext true)
+    %52 = load ptr, ptr %51, align 8, !tbaa !5
+    %53 = getelementptr i8, ptr %52, i64 -24
+    %54 = load i64, ptr %53, align 8
+    %55 = getelementptr inbounds i8, ptr %51, i64 %54
+    %56 = getelementptr inbounds %"class.std::basic_ios", ptr %55, i64 0, i32 5
+    %57 = load ptr, ptr %56, align 8, !tbaa !8
+    %58 = icmp eq ptr %57, null
+    br i1 %58, label %59, label %60
+  
+  59:                                               ; preds = %47
+    tail call void @_ZSt16__throw_bad_castv() #4
+    unreachable
+  
+  60:                                               ; preds = %47
+    %61 = getelementptr inbounds %"class.std::ctype", ptr %57, i64 0, i32 8
+    %62 = load i8, ptr %61, align 8, !tbaa !20
+    %63 = icmp eq i8 %62, 0
+    br i1 %63, label %67, label %64
+  
+  64:                                               ; preds = %60
+    %65 = getelementptr inbounds %"class.std::ctype", ptr %57, i64 0, i32 9, i64 10
+    %66 = load i8, ptr %65, align 1, !tbaa !23
+    br label %72
+  
+  67:                                               ; preds = %60
+    tail call void @_ZNKSt5ctypeIcE13_M_widen_initEv(ptr noundef nonnull align 8 dereferenceable(570) %57)
+    %68 = load ptr, ptr %57, align 8, !tbaa !5
+    %69 = getelementptr inbounds ptr, ptr %68, i64 6
+    %70 = load ptr, ptr %69, align 8
+    %71 = tail call noundef signext i8 %70(ptr noundef nonnull align 8 dereferenceable(570) %57, i8 noundef signext 10)
+    br label %72
+  
+  72:                                               ; preds = %67, %64
+    %73 = phi i8 [ %66, %64 ], [ %71, %67 ]
+    %74 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo3putEc(ptr noundef nonnull align 8 dereferenceable(8) %51, i8 noundef signext %73)
+    %75 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo5flushEv(ptr noundef nonnull align 8 dereferenceable(8) %74)
+    %76 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo9_M_insertIbEERSoT_(ptr noundef nonnull align 8 dereferenceable(8) @_ZSt4cout, i1 noundef zeroext true)
+    %77 = load ptr, ptr %76, align 8, !tbaa !5
+    %78 = getelementptr i8, ptr %77, i64 -24
+    %79 = load i64, ptr %78, align 8
+    %80 = getelementptr inbounds i8, ptr %76, i64 %79
+    %81 = getelementptr inbounds %"class.std::basic_ios", ptr %80, i64 0, i32 5
+    %82 = load ptr, ptr %81, align 8, !tbaa !8
+    %83 = icmp eq ptr %82, null
+    br i1 %83, label %84, label %85
+  
+  84:                                               ; preds = %72
+    tail call void @_ZSt16__throw_bad_castv() #4
+    unreachable
+  
+  85:                                               ; preds = %72
+    %86 = getelementptr inbounds %"class.std::ctype", ptr %82, i64 0, i32 8
+    %87 = load i8, ptr %86, align 8, !tbaa !20
+    %88 = icmp eq i8 %87, 0
+    br i1 %88, label %92, label %89
+  
+  89:                                               ; preds = %85
+    %90 = getelementptr inbounds %"class.std::ctype", ptr %82, i64 0, i32 9, i64 10
+    %91 = load i8, ptr %90, align 1, !tbaa !23
+    br label %97
+  
+  92:                                               ; preds = %85
+    tail call void @_ZNKSt5ctypeIcE13_M_widen_initEv(ptr noundef nonnull align 8 dereferenceable(570) %82)
+    %93 = load ptr, ptr %82, align 8, !tbaa !5
+    %94 = getelementptr inbounds ptr, ptr %93, i64 6
+    %95 = load ptr, ptr %94, align 8
+    %96 = tail call noundef signext i8 %95(ptr noundef nonnull align 8 dereferenceable(570) %82, i8 noundef signext 10)
+    br label %97
+  
+  97:                                               ; preds = %92, %89
+    %98 = phi i8 [ %91, %89 ], [ %96, %92 ]
+    %99 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo3putEc(ptr noundef nonnull align 8 dereferenceable(8) %76, i8 noundef signext %98)
+    %100 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo5flushEv(ptr noundef nonnull align 8 dereferenceable(8) %99)
+    %101 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo9_M_insertIbEERSoT_(ptr noundef nonnull align 8 dereferenceable(8) @_ZSt4cout, i1 noundef zeroext false)
+    %102 = load ptr, ptr %101, align 8, !tbaa !5
+    %103 = getelementptr i8, ptr %102, i64 -24
+    %104 = load i64, ptr %103, align 8
+    %105 = getelementptr inbounds i8, ptr %101, i64 %104
+    %106 = getelementptr inbounds %"class.std::basic_ios", ptr %105, i64 0, i32 5
+    %107 = load ptr, ptr %106, align 8, !tbaa !8
+    %108 = icmp eq ptr %107, null
+    br i1 %108, label %109, label %110
+  
+  109:                                              ; preds = %97
+    tail call void @_ZSt16__throw_bad_castv() #4
+    unreachable
+  
+  110:                                              ; preds = %97
+    %111 = getelementptr inbounds %"class.std::ctype", ptr %107, i64 0, i32 8
+    %112 = load i8, ptr %111, align 8, !tbaa !20
+    %113 = icmp eq i8 %112, 0
+    br i1 %113, label %117, label %114
+  
+  114:                                              ; preds = %110
+    %115 = getelementptr inbounds %"class.std::ctype", ptr %107, i64 0, i32 9, i64 10
+    %116 = load i8, ptr %115, align 1, !tbaa !23
+    br label %122
+  
+  117:                                              ; preds = %110
+    tail call void @_ZNKSt5ctypeIcE13_M_widen_initEv(ptr noundef nonnull align 8 dereferenceable(570) %107)
+    %118 = load ptr, ptr %107, align 8, !tbaa !5
+    %119 = getelementptr inbounds ptr, ptr %118, i64 6
+    %120 = load ptr, ptr %119, align 8
+    %121 = tail call noundef signext i8 %120(ptr noundef nonnull align 8 dereferenceable(570) %107, i8 noundef signext 10)
+    br label %122
+  
+  122:                                              ; preds = %117, %114
+    %123 = phi i8 [ %116, %114 ], [ %121, %117 ]
+    %124 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo3putEc(ptr noundef nonnull align 8 dereferenceable(8) %101, i8 noundef signext %123)
+    %125 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo5flushEv(ptr noundef nonnull align 8 dereferenceable(8) %124)
+    %126 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo9_M_insertIbEERSoT_(ptr noundef nonnull align 8 dereferenceable(8) @_ZSt4cout, i1 noundef zeroext false)
+    %127 = load ptr, ptr %126, align 8, !tbaa !5
+    %128 = getelementptr i8, ptr %127, i64 -24
+    %129 = load i64, ptr %128, align 8
+    %130 = getelementptr inbounds i8, ptr %126, i64 %129
+    %131 = getelementptr inbounds %"class.std::basic_ios", ptr %130, i64 0, i32 5
+    %132 = load ptr, ptr %131, align 8, !tbaa !8
+    %133 = icmp eq ptr %132, null
+    br i1 %133, label %134, label %135
+  
+  134:                                              ; preds = %122
+    tail call void @_ZSt16__throw_bad_castv() #4
+    unreachable
+  
+  135:                                              ; preds = %122
+    %136 = getelementptr inbounds %"class.std::ctype", ptr %132, i64 0, i32 8
+    %137 = load i8, ptr %136, align 8, !tbaa !20
+    %138 = icmp eq i8 %137, 0
+    br i1 %138, label %142, label %139
+  
+  139:                                              ; preds = %135
+    %140 = getelementptr inbounds %"class.std::ctype", ptr %132, i64 0, i32 9, i64 10
+    %141 = load i8, ptr %140, align 1, !tbaa !23
+    br label %147
+  
+  142:                                              ; preds = %135
+    tail call void @_ZNKSt5ctypeIcE13_M_widen_initEv(ptr noundef nonnull align 8 dereferenceable(570) %132)
+    %143 = load ptr, ptr %132, align 8, !tbaa !5
+    %144 = getelementptr inbounds ptr, ptr %143, i64 6
+    %145 = load ptr, ptr %144, align 8
+    %146 = tail call noundef signext i8 %145(ptr noundef nonnull align 8 dereferenceable(570) %132, i8 noundef signext 10)
+    br label %147
+  
+  147:                                              ; preds = %142, %139
+    %148 = phi i8 [ %141, %139 ], [ %146, %142 ]
+    %149 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo3putEc(ptr noundef nonnull align 8 dereferenceable(8) %126, i8 noundef signext %148)
+    %150 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo5flushEv(ptr noundef nonnull align 8 dereferenceable(8) %149)
+    ret i32 0
+  }
+  
+  declare noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo9_M_insertIbEERSoT_(ptr noundef nonnull align 8 dereferenceable(8), i1 noundef zeroext) local_unnamed_addr #2
+  
+  declare noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo3putEc(ptr noundef nonnull align 8 dereferenceable(8), i8 noundef signext) local_unnamed_addr #2
+  
+  declare noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo5flushEv(ptr noundef nonnull align 8 dereferenceable(8)) local_unnamed_addr #2
+  
+  ; Function Attrs: noreturn
+  declare void @_ZSt16__throw_bad_castv() local_unnamed_addr #3
+  
+  declare void @_ZNKSt5ctypeIcE13_M_widen_initEv(ptr noundef nonnull align 8 dereferenceable(570)) local_unnamed_addr #2
+  
+  attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+  attributes #1 = { mustprogress norecurse uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+  attributes #2 = { "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+  attributes #3 = { noreturn "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+  attributes #4 = { noreturn }
+  
+  !llvm.module.flags = !{!0, !1, !2, !3}
+  !llvm.ident = !{!4}
+  
+  !0 = !{i32 1, !"wchar_size", i32 4}
+  !1 = !{i32 8, !"PIC Level", i32 2}
+  !2 = !{i32 7, !"PIE Level", i32 2}
+  !3 = !{i32 7, !"uwtable", i32 2}
+  !4 = !{!"Ubuntu clang version 18.1.3 (1ubuntu1)"}
+  !5 = !{!6, !6, i64 0}
+  !6 = !{!"vtable pointer", !7, i64 0}
+  !7 = !{!"Simple C++ TBAA"}
+  !8 = !{!9, !15, i64 240}
+  !9 = !{!"_ZTSSt9basic_iosIcSt11char_traitsIcEE", !10, i64 0, !15, i64 216, !12, i64 224, !19, i64 225, !15, i64 232, !15, i64 240, !15, i64 248, !15, i64 256}
+  !10 = !{!"_ZTSSt8ios_base", !11, i64 8, !11, i64 16, !13, i64 24, !14, i64 28, !14, i64 32, !15, i64 40, !16, i64 48, !12, i64 64, !17, i64 192, !15, i64 200, !18, i64 208}
+  !11 = !{!"long", !12, i64 0}
+  !12 = !{!"omnipotent char", !7, i64 0}
+  !13 = !{!"_ZTSSt13_Ios_Fmtflags", !12, i64 0}
+  !14 = !{!"_ZTSSt12_Ios_Iostate", !12, i64 0}
+  !15 = !{!"any pointer", !12, i64 0}
+  !16 = !{!"_ZTSNSt8ios_base6_WordsE", !15, i64 0, !11, i64 8}
+  !17 = !{!"int", !12, i64 0}
+  !18 = !{!"_ZTSSt6locale", !15, i64 0}
+  !19 = !{!"bool", !12, i64 0}
+  !20 = !{!21, !12, i64 56}
+  !21 = !{!"_ZTSSt5ctypeIcE", !22, i64 0, !15, i64 16, !19, i64 24, !15, i64 32, !15, i64 40, !15, i64 48, !12, i64 56, !12, i64 57, !12, i64 313, !12, i64 569}
+  !22 = !{!"_ZTSNSt6locale5facetE", !17, i64 8}
+  !23 = !{!12, !12, i64 0}
+
+...
+---
+name:            _Z11and_or_testiii
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: gr32, preferred-register: '' }
+  - { id: 1, class: gr32, preferred-register: '' }
+  - { id: 2, class: gr32, preferred-register: '' }
+  - { id: 3, class: gr8, preferred-register: '' }
+  - { id: 4, class: gr32, preferred-register: '' }
+  - { id: 5, class: gr32, preferred-register: '' }
+  - { id: 6, class: gr8, preferred-register: '' }
+liveins:
+  - { reg: '$edi', virtual-reg: '%0' }
+  - { reg: '$esi', virtual-reg: '%1' }
+  - { reg: '$edx', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $edi, $esi, $edx
+
+    ; CHECK: %2:gr32 = COPY $edx
+    ; CHECK-NEXT: %1:gr32 = COPY $esi
+    ; CHECK-NEXT: %0:gr32 = COPY $edi
+    ; CHECK-NEXT: TEST32rr %1, %0, implicit-def $eflags
+    ; CHECK-NEXT: %3:gr8 = SETCCr 5, implicit $eflags
+    ; CHECK-NEXT: %4:gr32 = MOVZX32rr8 killed %3
+    ; CHECK-NEXT: %5:gr32 = OR32rr %4, %2, implicit-def $eflags
+    ; CHECK-NEXT: %6:gr8 = SETCCr 5, implicit $eflags
+    ; CHECK-NEXT: $al = COPY %6
+    ; CHECK-NEXT: RET 0, $al
+  
+    %2:gr32 = COPY $edx
+    %1:gr32 = COPY $esi
+    %0:gr32 = COPY $edi
+    TEST32rr %1, %0, implicit-def $eflags
+    %3:gr8 = SETCCr 5, implicit $eflags
+    %4:gr32 = MOVZX32rr8 killed %3
+    %5:gr32 = OR32rr %4, %2, implicit-def $eflags
+    %6:gr8 = SETCCr 5, implicit $eflags
+    $al = COPY %6
+    RET 0, $al
+
+...
+---
+name:            _Z11or_xor_testiii
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: gr32, preferred-register: '' }
+  - { id: 1, class: gr32, preferred-register: '' }
+  - { id: 2, class: gr32, preferred-register: '' }
+  - { id: 3, class: gr32, preferred-register: '' }
+  - { id: 4, class: gr8, preferred-register: '' }
+  - { id: 5, class: gr32, preferred-register: '' }
+  - { id: 6, class: gr32, preferred-register: '' }
+  - { id: 7, class: gr8, preferred-register: '' }
+liveins:
+  - { reg: '$edi', virtual-reg: '%0' }
+  - { reg: '$esi', virtual-reg: '%1' }
+  - { reg: '$edx', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $edi, $esi, $edx
+  
+    ; CHECK: %2:gr32 = COPY $edx
+    ; CHECK-NEXT: %1:gr32 = COPY $esi
+    ; CHECK-NEXT: %0:gr32 = COPY $edi
+    ; CHECK-NEXT: %3:gr32 = OR32rr %1, %0, implicit-def $eflags
+    ; CHECK-NEXT: %4:gr8 = SETCCr 5, implicit $eflags
+    ; CHECK-NEXT: %5:gr32 = MOVZX32rr8 killed %4
+    ; CHECK-NEXT: %6:gr32 = SUB32rr %5, %2, implicit-def $eflags
+    ; CHECK-NEXT: %7:gr8 = SETCCr 5, implicit $eflags
+    ; CHECK-NEXT: $al = COPY %7
+    ; CHECK-NEXT: RET 0, $al
+
+    %2:gr32 = COPY $edx
+    %1:gr32 = COPY $esi
+    %0:gr32 = COPY $edi
+    %3:gr32 = OR32rr %1, %0, implicit-def $eflags
+    %4:gr8 = SETCCr 5, implicit $eflags
+    %5:gr32 = MOVZX32rr8 killed %4
+    %6:gr32 = SUB32rr %5, %2, implicit-def $eflags
+    %7:gr8 = SETCCr 5, implicit $eflags
+    $al = COPY %7
+    RET 0, $al
+
+...
+---
+name:            _Z12and_xor_testiii
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: gr32, preferred-register: '' }
+  - { id: 1, class: gr32, preferred-register: '' }
+  - { id: 2, class: gr32, preferred-register: '' }
+  - { id: 3, class: gr8, preferred-register: '' }
+  - { id: 4, class: gr32, preferred-register: '' }
+  - { id: 5, class: gr32, preferred-register: '' }
+  - { id: 6, class: gr8, preferred-register: '' }
+liveins:
+  - { reg: '$edi', virtual-reg: '%0' }
+  - { reg: '$esi', virtual-reg: '%1' }
+  - { reg: '$edx', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $edi, $esi, $edx
+  
+    ; CHECK: %2:gr32 = COPY $edx
+    ; CHECK-NEXT: %1:gr32 = COPY $esi
+    ; CHECK-NEXT: %0:gr32 = COPY $edi
+    ; CHECK-NEXT: TEST32rr %1, %0, implicit-def $eflags
+    ; CHECK-NEXT: %3:gr8 = SETCCr 5, implicit $eflags
+    ; CHECK-NEXT: %4:gr32 = MOVZX32rr8 killed %3
+    ; CHECK-NEXT: %5:gr32 = SUB32rr %4, %2, implicit-def $eflags
+    ; CHECK-NEXT: %6:gr8 = SETCCr 5, implicit $eflags
+    ; CHECK-NEXT: $al = COPY %6
+    ; CHECK-NEXT: RET 0, $al
+
+    %2:gr32 = COPY $edx
+    %1:gr32 = COPY $esi
+    %0:gr32 = COPY $edi
+    TEST32rr %1, %0, implicit-def $eflags
+    %3:gr8 = SETCCr 5, implicit $eflags
+    %4:gr32 = MOVZX32rr8 killed %3
+    %5:gr32 = SUB32rr %4, %2, implicit-def $eflags
+    %6:gr8 = SETCCr 5, implicit $eflags
+    $al = COPY %6
+    RET 0, $al
+
+...
+---
+name:            _Z15and_or_xor_testiiii
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: gr32, preferred-register: '' }
+  - { id: 1, class: gr32, preferred-register: '' }
+  - { id: 2, class: gr32, preferred-register: '' }
+  - { id: 3, class: gr32, preferred-register: '' }
+  - { id: 4, class: gr8, preferred-register: '' }
+  - { id: 5, class: gr32, preferred-register: '' }
+  - { id: 6, class: gr32, preferred-register: '' }
+  - { id: 7, class: gr8, preferred-register: '' }
+  - { id: 8, class: gr32, preferred-register: '' }
+  - { id: 9, class: gr32, preferred-register: '' }
+  - { id: 10, class: gr8, preferred-register: '' }
+liveins:
+  - { reg: '$edi', virtual-reg: '%0' }
+  - { reg: '$esi', virtual-reg: '%1' }
+  - { reg: '$edx', virtual-reg: '%2' }
+  - { reg: '$ecx', virtual-reg: '%3' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0 (%ir-block.4):
+    liveins: $edi, $esi, $edx, $ecx
+  
+    ; CHECK: %3:gr32 = COPY $ecx
+    ; CHECK-NEXT: %2:gr32 = COPY $edx
+    ; CHECK-NEXT: %1:gr32 = COPY $esi
+    ; CHECK-NEXT: %0:gr32 = COPY $edi
+    ; CHECK-NEXT: TEST32rr %1, %0, implicit-def $eflags
+    ; CHECK-NEXT: %4:gr8 = SETCCr 5, implicit $eflags
+    ; CHECK-NEXT: %5:gr32 = MOVZX32rr8 killed %4
+    ; CHECK-NEXT: %6:gr32 = OR32rr %5, %2, implicit-def $eflags
+    ; CHECK-NEXT: %7:gr8 = SETCCr 5, implicit $eflags
+    ; CHECK-NEXT: %8:gr32 = MOVZX32rr8 killed %7
+    ; CHECK-NEXT: %9:gr32 = SUB32rr %8, %3, implicit-def $eflags
+    ; CHECK-NEXT: %10:gr8 = SETCCr 5, implicit $eflags
+    ; CHECK-NEXT: $al = COPY %10
+    ; CHECK-NEXT: RET 0, $al
+
+    %3:gr32 = COPY $ecx
+    %2:gr32 = COPY $edx
+    %1:gr32 = COPY $esi
+    %0:gr32 = COPY $edi
+    TEST32rr %1, %0, implicit-def $eflags
+    %4:gr8 = SETCCr 5, implicit $eflags
+    %5:gr32 = MOVZX32rr8 killed %4
+    %6:gr32 = OR32rr %5, %2, implicit-def $eflags
+    %7:gr8 = SETCCr 5, implicit $eflags
+    %8:gr32 = MOVZX32rr8 killed %7
+    %9:gr32 = SUB32rr %8, %3, implicit-def $eflags
+    %10:gr8 = SETCCr 5, implicit $eflags
+    $al = COPY %10
+    RET 0, $al
+
+...
+---
+name:            _Z12and_and_testiii
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: gr32, preferred-register: '' }
+  - { id: 1, class: gr32, preferred-register: '' }
+  - { id: 2, class: gr32, preferred-register: '' }
+  - { id: 3, class: gr8, preferred-register: '' }
+  - { id: 4, class: gr8, preferred-register: '' }
+  - { id: 5, class: gr8, preferred-register: '' }
+liveins:
+  - { reg: '$edi', virtual-reg: '%0' }
+  - { reg: '$esi', virtual-reg: '%1' }
+  - { reg: '$edx', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $edi, $esi, $edx
+  
+    ; CHECK: %2:gr32 = COPY $edx
+    ; CHECK-NEXT: %1:gr32 = COPY $esi
+    ; CHECK-NEXT: %0:gr32 = COPY $edi
+    ; CHECK-NEXT: TEST32rr %1, %0, implicit-def $eflags
+    ; CHECK-NEXT: %3:gr8 = SETCCr 5, implicit $eflags
+    ; CHECK-NEXT: %4:gr8 = COPY %2.sub_8bit
+    ; CHECK-NEXT: %5:gr8 = AND8rr %3, killed %4, implicit-def dead $eflags
+    ; CHECK-NEXT: $al = COPY %5
+    ; CHECK-NEXT: RET 0, $al
+
+    %2:gr32 = COPY $edx
+    %1:gr32 = COPY $esi
+    %0:gr32 = COPY $edi
+    TEST32rr %1, %0, implicit-def $eflags
+    %3:gr8 = SETCCr 5, implicit $eflags
+    %4:gr8 = COPY %2.sub_8bit
+    %5:gr8 = AND8rr %3, killed %4, implicit-def dead $eflags
+    $al = COPY %5
+    RET 0, $al
+
+...
+---
+name:            _Z12xor_xor_testiii
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: gr32, preferred-register: '' }
+  - { id: 1, class: gr32, preferred-register: '' }
+  - { id: 2, class: gr32, preferred-register: '' }
+  - { id: 3, class: gr32, preferred-register: '' }
+  - { id: 4, class: gr8, preferred-register: '' }
+  - { id: 5, class: gr32, preferred-register: '' }
+  - { id: 6, class: gr32, preferred-register: '' }
+  - { id: 7, class: gr8, preferred-register: '' }
+liveins:
+  - { reg: '$edi', virtual-reg: '%0' }
+  - { reg: '$esi', virtual-reg: '%1' }
+  - { reg: '$edx', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $edi, $esi, $edx
+  
+    ; CHECK: %2:gr32 = COPY $edx
+    ; CHECK-NEXT: %1:gr32 = COPY $esi
+    ; CHECK-NEXT: %0:gr32 = COPY $edi
+    ; CHECK-NEXT: %3:gr32 = SUB32rr %0, %1, implicit-def $eflags
+    ; CHECK-NEXT: %4:gr8 = SETCCr 5, implicit $eflags
+    ; CHECK-NEXT: %5:gr32 = MOVZX32rr8 killed %4
+    ; CHECK-NEXT: %6:gr32 = SUB32rr %5, %2, implicit-def $eflags
+    ; CHECK-NEXT: %7:gr8 = SETCCr 5, implicit $eflags
+    ; CHECK-NEXT: $al = COPY %7
+    ; CHECK-NEXT: RET 0, $al
+
+    %2:gr32 = COPY $edx
+    %1:gr32 = COPY $esi
+    %0:gr32 = COPY $edi
+    %3:gr32 = SUB32rr %0, %1, implicit-def $eflags
+    %4:gr8 = SETCCr 5, implicit $eflags
+    %5:gr32 = MOVZX32rr8 killed %4
+    %6:gr32 = SUB32rr %5, %2, implicit-def $eflags
+    %7:gr8 = SETCCr 5, implicit $eflags
+    $al = COPY %7
+    RET 0, $al
+
+...
+---
+name:            main
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: gr64, preferred-register: '' }
+  - { id: 1, class: gr64, preferred-register: '' }
+  - { id: 2, class: gr8, preferred-register: '' }
+  - { id: 3, class: gr8, preferred-register: '' }
+  - { id: 4, class: gr8, preferred-register: '' }
+  - { id: 5, class: gr64, preferred-register: '' }
+  - { id: 6, class: gr64, preferred-register: '' }
+  - { id: 7, class: gr8, preferred-register: '' }
+  - { id: 8, class: gr8, preferred-register: '' }
+  - { id: 9, class: gr8, preferred-register: '' }
+  - { id: 10, class: gr64, preferred-register: '' }
+  - { id: 11, class: gr64, preferred-register: '' }
+  - { id: 12, class: gr8, preferred-register: '' }
+  - { id: 13, class: gr8, preferred-register: '' }
+  - { id: 14, class: gr8, preferred-register: '' }
+  - { id: 15, class: gr64, preferred-register: '' }
+  - { id: 16, class: gr64, preferred-register: '' }
+  - { id: 17, class: gr8, preferred-register: '' }
+  - { id: 18, class: gr8, preferred-register: '' }
+  - { id: 19, class: gr8, preferred-register: '' }
+  - { id: 20, class: gr64, preferred-register: '' }
+  - { id: 21, class: gr64, preferred-register: '' }
+  - { id: 22, class: gr8, preferred-register: '' }
+  - { id: 23, class: gr8, preferred-register: '' }
+  - { id: 24, class: gr8, preferred-register: '' }
+  - { id: 25, class: gr64, preferred-register: '' }
+  - { id: 26, class: gr64, preferred-register: '' }
+  - { id: 27, class: gr8, preferred-register: '' }
+  - { id: 28, class: gr8, preferred-register: '' }
+  - { id: 29, class: gr8, preferred-register: '' }
+  - { id: 30, class: gr64, preferred-register: '' }
+  - { id: 31, class: gr32, preferred-register: '' }
+  - { id: 32, class: gr64, preferred-register: '' }
+  - { id: 33, class: gr64, preferred-register: '' }
+  - { id: 34, class: gr64_nosp, preferred-register: '' }
+  - { id: 35, class: gr64, preferred-register: '' }
+  - { id: 36, class: gr32, preferred-register: '' }
+  - { id: 37, class: gr8, preferred-register: '' }
+  - { id: 38, class: gr32, preferred-register: '' }
+  - { id: 39, class: gr64, preferred-register: '' }
+  - { id: 40, class: gr64, preferred-register: '' }
+  - { id: 41, class: gr64, preferred-register: '' }
+  - { id: 42, class: gr32, preferred-register: '' }
+  - { id: 43, class: gr64, preferred-register: '' }
+  - { id: 44, class: gr64, preferred-register: '' }
+  - { id: 45, class: gr64_nosp, preferred-register: '' }
+  - { id: 46, class: gr64, preferred-register: '' }
+  - { id: 47, class: gr32, preferred-register: '' }
+  - { id: 48, class: gr8, preferred-register: '' }
+  - { id: 49, class: gr32, preferred-register: '' }
+  - { id: 50, class: gr64, preferred-register: '' }
+  - { id: 51, class: gr64, preferred-register: '' }
+  - { id: 52, class: gr64, preferred-register: '' }
+  - { id: 53, class: gr32, preferred-register: '' }
+  - { id: 54, class: gr64, preferred-register: '' }
+  - { id: 55, class: gr64, preferred-register: '' }
+  - { id: 56, class: gr64_nosp, preferred-register: '' }
+  - { id: 57, class: gr64, preferred-register: '' }
+  - { id: 58, class: gr32, preferred-register: '' }
+  - { id: 59, class: gr8, preferred-register: '' }
+  - { id: 60, class: gr32, preferred-register: '' }
+  - { id: 61, class: gr64, preferred-register: '' }
+  - { id: 62, class: gr64, preferred-register: '' }
+  - { id: 63, class: gr64, preferred-register: '' }
+  - { id: 64, class: gr32, preferred-register: '' }
+  - { id: 65, class: gr64, preferred-register: '' }
+  - { id: 66, class: gr64, preferred-register: '' }
+  - { id: 67, class: gr64_nosp, preferred-register: '' }
+  - { id: 68, class: gr64, preferred-register: '' }
+  - { id: 69, class: gr32, preferred-register: '' }
+  - { id: 70, class: gr8, preferred-register: '' }
+  - { id: 71, class: gr32, preferred-register: '' }
+  - { id: 72, class: gr64, preferred-register: '' }
+  - { id: 73, class: gr64, preferred-register: '' }
+  - { id: 74, class: gr64, preferred-register: '' }
+  - { id: 75, class: gr32, preferred-register: '' }
+  - { id: 76, class: gr64, preferred-register: '' }
+  - { id: 77, class: gr64, preferred-register: '' }
+  - { id: 78, class: gr64_nosp, preferred-register: '' }
+  - { id: 79, class: gr64, preferred-register: '' }
+  - { id: 80, class: gr32, preferred-register: '' }
+  - { id: 81, class: gr8, preferred-register: '' }
+  - { id: 82, class: gr32, preferred-register: '' }
+  - { id: 83, class: gr64, preferred-register: '' }
+  - { id: 84, class: gr64, preferred-register: '' }
+  - { id: 85, class: gr64, preferred-register: '' }
+  - { id: 86, class: gr32, preferred-register: '' }
+  - { id: 87, class: gr64, preferred-register: '' }
+  - { id: 88, class: gr64, preferred-register: '' }
+  - { id: 89, class: gr64_nosp, preferred-register: '' }
+  - { id: 90, class: gr64, preferred-register: '' }
+  - { id: 91, class: gr32, preferred-register: '' }
+  - { id: 92, class: gr8, preferred-register: '' }
+  - { id: 93, class: gr32, preferred-register: '' }
+  - { id: 94, class: gr64, preferred-register: '' }
+  - { id: 95, class: gr64, preferred-register: '' }
+  - { id: 96, class: gr32, preferred-register: '' }
+liveins:         []
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    true
+  hasCalls:        true
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0 (%ir-block.0):
+    successors: %bb.1(0x00000800), %bb.2(0x7ffff800)
+  
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %30:gr64 = MOV64rm $rip, 1, $noreg, target-flags(x86-gotpcrel) @_ZSt4cout, $noreg :: (load (s64) from got)
+    %31:gr32 = MOV32ri 1
+    $rdi = COPY %30
+    $esi = COPY %31
+    CALL64pcrel32 target-flags(x86-plt) @_ZNSo9_M_insertIbEERSoT_, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $esi, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %32:gr64 = COPY $rax
+    %0:gr64 = COPY %32
+    %33:gr64 = MOV64rm %32, 1, $noreg, 0, $noreg :: (dereferenceable load (s64) from %ir.1, !tbaa !5)
+    %34:gr64_nosp = MOV64rm killed %33, 1, $noreg, -24, $noreg :: (load (s64) from %ir.3)
+    %1:gr64 = MOV64rm %32, 1, killed %34, 240, $noreg :: (load (s64) from %ir.6, !tbaa !8)
+    TEST64rr %1, %1, implicit-def $eflags
+    JCC_1 %bb.2, 5, implicit $eflags
+    JMP_1 %bb.1
+  
+  bb.1 (%ir-block.9):
+    successors:
+  
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    CALL64pcrel32 target-flags(x86-plt) @_ZSt16__throw_bad_castv, csr_64, implicit $rsp, implicit $ssp, implicit-def $rsp, implicit-def $ssp
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+  
+  bb.2 (%ir-block.10):
+    successors: %bb.4(0x30000000), %bb.3(0x50000000)
+  
+    CMP8mi %1, 1, $noreg, 56, $noreg, 0, implicit-def $eflags :: (load (s8) from %ir.11, align 8, !tbaa !20)
+    JCC_1 %bb.4, 4, implicit $eflags
+    JMP_1 %bb.3
+  
+  bb.3 (%ir-block.14):
+    successors: %bb.5(0x80000000)
+  
+    %2:gr8 = MOV8rm %1, 1, $noreg, 67, $noreg :: (load (s8) from %ir.15, !tbaa !23)
+    JMP_1 %bb.5
+  
+  bb.4 (%ir-block.17):
+    successors: %bb.5(0x80000000)
+  
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    $rdi = COPY %1
+    CALL64pcrel32 target-flags(x86-plt) @_ZNKSt5ctypeIcE13_M_widen_initEv, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit-def $rsp, implicit-def $ssp
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %35:gr64 = MOV64rm %1, 1, $noreg, 0, $noreg :: (load (s64) from %ir.7, !tbaa !5)
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %36:gr32 = MOV32ri 10
+    $rdi = COPY %1
+    $esi = COPY %36
+    CALL64m killed %35, 1, $noreg, 48, $noreg, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $esi, implicit-def $rsp, implicit-def $ssp, implicit-def $al :: (load (s64) from %ir.19)
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %37:gr8 = COPY $al
+    %3:gr8 = COPY %37
+  
+  bb.5 (%ir-block.22):
+    successors: %bb.6(0x00000800), %bb.7(0x7ffff800)
+  
+    %4:gr8 = PHI %2, %bb.3, %3, %bb.4
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %38:gr32 = MOVSX32rr8 %4
+    $rdi = COPY %0
+    $esi = COPY %38
+    CALL64pcrel32 target-flags(x86-plt) @_ZNSo3putEc, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $esi, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %39:gr64 = COPY $rax
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    $rdi = COPY %39
+    CALL64pcrel32 target-flags(x86-plt) @_ZNSo5flushEv, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %40:gr64 = COPY $rax
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %41:gr64 = MOV64rm $rip, 1, $noreg, target-flags(x86-gotpcrel) @_ZSt4cout, $noreg :: (load (s64) from got)
+    %42:gr32 = MOV32r0 implicit-def dead $eflags
+    $rdi = COPY %41
+    $esi = COPY %42
+    CALL64pcrel32 target-flags(x86-plt) @_ZNSo9_M_insertIbEERSoT_, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $esi, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %43:gr64 = COPY $rax
+    %5:gr64 = COPY %43
+    %44:gr64 = MOV64rm %43, 1, $noreg, 0, $noreg :: (dereferenceable load (s64) from %ir.26, !tbaa !5)
+    %45:gr64_nosp = MOV64rm killed %44, 1, $noreg, -24, $noreg :: (load (s64) from %ir.28)
+    %6:gr64 = MOV64rm %43, 1, killed %45, 240, $noreg :: (load (s64) from %ir.31, !tbaa !8)
+    TEST64rr %6, %6, implicit-def $eflags
+    JCC_1 %bb.7, 5, implicit $eflags
+    JMP_1 %bb.6
+  
+  bb.6 (%ir-block.34):
+    successors:
+  
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    CALL64pcrel32 target-flags(x86-plt) @_ZSt16__throw_bad_castv, csr_64, implicit $rsp, implicit $ssp, implicit-def $rsp, implicit-def $ssp
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+  
+  bb.7 (%ir-block.35):
+    successors: %bb.9(0x30000000), %bb.8(0x50000000)
+  
+    CMP8mi %6, 1, $noreg, 56, $noreg, 0, implicit-def $eflags :: (load (s8) from %ir.36, align 8, !tbaa !20)
+    JCC_1 %bb.9, 4, implicit $eflags
+    JMP_1 %bb.8
+  
+  bb.8 (%ir-block.39):
+    successors: %bb.10(0x80000000)
+  
+    %7:gr8 = MOV8rm %6, 1, $noreg, 67, $noreg :: (load (s8) from %ir.40, !tbaa !23)
+    JMP_1 %bb.10
+  
+  bb.9 (%ir-block.42):
+    successors: %bb.10(0x80000000)
+  
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    $rdi = COPY %6
+    CALL64pcrel32 target-flags(x86-plt) @_ZNKSt5ctypeIcE13_M_widen_initEv, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit-def $rsp, implicit-def $ssp
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %46:gr64 = MOV64rm %6, 1, $noreg, 0, $noreg :: (load (s64) from %ir.32, !tbaa !5)
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %47:gr32 = MOV32ri 10
+    $rdi = COPY %6
+    $esi = COPY %47
+    CALL64m killed %46, 1, $noreg, 48, $noreg, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $esi, implicit-def $rsp, implicit-def $ssp, implicit-def $al :: (load (s64) from %ir.44)
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %48:gr8 = COPY $al
+    %8:gr8 = COPY %48
+  
+  bb.10 (%ir-block.47):
+    successors: %bb.11(0x00000800), %bb.12(0x7ffff800)
+  
+    %9:gr8 = PHI %7, %bb.8, %8, %bb.9
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %49:gr32 = MOVSX32rr8 %9
+    $rdi = COPY %5
+    $esi = COPY %49
+    CALL64pcrel32 target-flags(x86-plt) @_ZNSo3putEc, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $esi, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %50:gr64 = COPY $rax
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    $rdi = COPY %50
+    CALL64pcrel32 target-flags(x86-plt) @_ZNSo5flushEv, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %51:gr64 = COPY $rax
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %52:gr64 = MOV64rm $rip, 1, $noreg, target-flags(x86-gotpcrel) @_ZSt4cout, $noreg :: (load (s64) from got)
+    %53:gr32 = MOV32ri 1
+    $rdi = COPY %52
+    $esi = COPY %53
+    CALL64pcrel32 target-flags(x86-plt) @_ZNSo9_M_insertIbEERSoT_, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $esi, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %54:gr64 = COPY $rax
+    %10:gr64 = COPY %54
+    %55:gr64 = MOV64rm %54, 1, $noreg, 0, $noreg :: (dereferenceable load (s64) from %ir.51, !tbaa !5)
+    %56:gr64_nosp = MOV64rm killed %55, 1, $noreg, -24, $noreg :: (load (s64) from %ir.53)
+    %11:gr64 = MOV64rm %54, 1, killed %56, 240, $noreg :: (load (s64) from %ir.56, !tbaa !8)
+    TEST64rr %11, %11, implicit-def $eflags
+    JCC_1 %bb.12, 5, implicit $eflags
+    JMP_1 %bb.11
+  
+  bb.11 (%ir-block.59):
+    successors:
+  
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    CALL64pcrel32 target-flags(x86-plt) @_ZSt16__throw_bad_castv, csr_64, implicit $rsp, implicit $ssp, implicit-def $rsp, implicit-def $ssp
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+  
+  bb.12 (%ir-block.60):
+    successors: %bb.14(0x30000000), %bb.13(0x50000000)
+  
+    CMP8mi %11, 1, $noreg, 56, $noreg, 0, implicit-def $eflags :: (load (s8) from %ir.61, align 8, !tbaa !20)
+    JCC_1 %bb.14, 4, implicit $eflags
+    JMP_1 %bb.13
+  
+  bb.13 (%ir-block.64):
+    successors: %bb.15(0x80000000)
+  
+    %12:gr8 = MOV8rm %11, 1, $noreg, 67, $noreg :: (load (s8) from %ir.65, !tbaa !23)
+    JMP_1 %bb.15
+  
+  bb.14 (%ir-block.67):
+    successors: %bb.15(0x80000000)
+  
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    $rdi = COPY %11
+    CALL64pcrel32 target-flags(x86-plt) @_ZNKSt5ctypeIcE13_M_widen_initEv, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit-def $rsp, implicit-def $ssp
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %57:gr64 = MOV64rm %11, 1, $noreg, 0, $noreg :: (load (s64) from %ir.57, !tbaa !5)
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %58:gr32 = MOV32ri 10
+    $rdi = COPY %11
+    $esi = COPY %58
+    CALL64m killed %57, 1, $noreg, 48, $noreg, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $esi, implicit-def $rsp, implicit-def $ssp, implicit-def $al :: (load (s64) from %ir.69)
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %59:gr8 = COPY $al
+    %13:gr8 = COPY %59
+  
+  bb.15 (%ir-block.72):
+    successors: %bb.16(0x00000800), %bb.17(0x7ffff800)
+  
+    %14:gr8 = PHI %12, %bb.13, %13, %bb.14
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %60:gr32 = MOVSX32rr8 %14
+    $rdi = COPY %10
+    $esi = COPY %60
+    CALL64pcrel32 target-flags(x86-plt) @_ZNSo3putEc, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $esi, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %61:gr64 = COPY $rax
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    $rdi = COPY %61
+    CALL64pcrel32 target-flags(x86-plt) @_ZNSo5flushEv, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %62:gr64 = COPY $rax
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %63:gr64 = MOV64rm $rip, 1, $noreg, target-flags(x86-gotpcrel) @_ZSt4cout, $noreg :: (load (s64) from got)
+    %64:gr32 = MOV32ri 1
+    $rdi = COPY %63
+    $esi = COPY %64
+    CALL64pcrel32 target-flags(x86-plt) @_ZNSo9_M_insertIbEERSoT_, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $esi, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %65:gr64 = COPY $rax
+    %15:gr64 = COPY %65
+    %66:gr64 = MOV64rm %65, 1, $noreg, 0, $noreg :: (dereferenceable load (s64) from %ir.76, !tbaa !5)
+    %67:gr64_nosp = MOV64rm killed %66, 1, $noreg, -24, $noreg :: (load (s64) from %ir.78)
+    %16:gr64 = MOV64rm %65, 1, killed %67, 240, $noreg :: (load (s64) from %ir.81, !tbaa !8)
+    TEST64rr %16, %16, implicit-def $eflags
+    JCC_1 %bb.17, 5, implicit $eflags
+    JMP_1 %bb.16
+  
+  bb.16 (%ir-block.84):
+    successors:
+  
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    CALL64pcrel32 target-flags(x86-plt) @_ZSt16__throw_bad_castv, csr_64, implicit $rsp, implicit $ssp, implicit-def $rsp, implicit-def $ssp
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+  
+  bb.17 (%ir-block.85):
+    successors: %bb.19(0x30000000), %bb.18(0x50000000)
+  
+    CMP8mi %16, 1, $noreg, 56, $noreg, 0, implicit-def $eflags :: (load (s8) from %ir.86, align 8, !tbaa !20)
+    JCC_1 %bb.19, 4, implicit $eflags
+    JMP_1 %bb.18
+  
+  bb.18 (%ir-block.89):
+    successors: %bb.20(0x80000000)
+  
+    %17:gr8 = MOV8rm %16, 1, $noreg, 67, $noreg :: (load (s8) from %ir.90, !tbaa !23)
+    JMP_1 %bb.20
+  
+  bb.19 (%ir-block.92):
+    successors: %bb.20(0x80000000)
+  
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    $rdi = COPY %16
+    CALL64pcrel32 target-flags(x86-plt) @_ZNKSt5ctypeIcE13_M_widen_initEv, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit-def $rsp, implicit-def $ssp
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %68:gr64 = MOV64rm %16, 1, $noreg, 0, $noreg :: (load (s64) from %ir.82, !tbaa !5)
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %69:gr32 = MOV32ri 10
+    $rdi = COPY %16
+    $esi = COPY %69
+    CALL64m killed %68, 1, $noreg, 48, $noreg, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $esi, implicit-def $rsp, implicit-def $ssp, implicit-def $al :: (load (s64) from %ir.94)
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %70:gr8 = COPY $al
+    %18:gr8 = COPY %70
+  
+  bb.20 (%ir-block.97):
+    successors: %bb.21(0x00000800), %bb.22(0x7ffff800)
+  
+    %19:gr8 = PHI %17, %bb.18, %18, %bb.19
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %71:gr32 = MOVSX32rr8 %19
+    $rdi = COPY %15
+    $esi = COPY %71
+    CALL64pcrel32 target-flags(x86-plt) @_ZNSo3putEc, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $esi, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %72:gr64 = COPY $rax
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    $rdi = COPY %72
+    CALL64pcrel32 target-flags(x86-plt) @_ZNSo5flushEv, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %73:gr64 = COPY $rax
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %74:gr64 = MOV64rm $rip, 1, $noreg, target-flags(x86-gotpcrel) @_ZSt4cout, $noreg :: (load (s64) from got)
+    %75:gr32 = MOV32r0 implicit-def dead $eflags
+    $rdi = COPY %74
+    $esi = COPY %75
+    CALL64pcrel32 target-flags(x86-plt) @_ZNSo9_M_insertIbEERSoT_, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $esi, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %76:gr64 = COPY $rax
+    %20:gr64 = COPY %76
+    %77:gr64 = MOV64rm %76, 1, $noreg, 0, $noreg :: (dereferenceable load (s64) from %ir.101, !tbaa !5)
+    %78:gr64_nosp = MOV64rm killed %77, 1, $noreg, -24, $noreg :: (load (s64) from %ir.103)
+    %21:gr64 = MOV64rm %76, 1, killed %78, 240, $noreg :: (load (s64) from %ir.106, !tbaa !8)
+    TEST64rr %21, %21, implicit-def $eflags
+    JCC_1 %bb.22, 5, implicit $eflags
+    JMP_1 %bb.21
+  
+  bb.21 (%ir-block.109):
+    successors:
+  
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    CALL64pcrel32 target-flags(x86-plt) @_ZSt16__throw_bad_castv, csr_64, implicit $rsp, implicit $ssp, implicit-def $rsp, implicit-def $ssp
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+  
+  bb.22 (%ir-block.110):
+    successors: %bb.24(0x30000000), %bb.23(0x50000000)
+  
+    CMP8mi %21, 1, $noreg, 56, $noreg, 0, implicit-def $eflags :: (load (s8) from %ir.111, align 8, !tbaa !20)
+    JCC_1 %bb.24, 4, implicit $eflags
+    JMP_1 %bb.23
+  
+  bb.23 (%ir-block.114):
+    successors: %bb.25(0x80000000)
+  
+    %22:gr8 = MOV8rm %21, 1, $noreg, 67, $noreg :: (load (s8) from %ir.115, !tbaa !23)
+    JMP_1 %bb.25
+  
+  bb.24 (%ir-block.117):
+    successors: %bb.25(0x80000000)
+  
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    $rdi = COPY %21
+    CALL64pcrel32 target-flags(x86-plt) @_ZNKSt5ctypeIcE13_M_widen_initEv, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit-def $rsp, implicit-def $ssp
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %79:gr64 = MOV64rm %21, 1, $noreg, 0, $noreg :: (load (s64) from %ir.107, !tbaa !5)
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %80:gr32 = MOV32ri 10
+    $rdi = COPY %21
+    $esi = COPY %80
+    CALL64m killed %79, 1, $noreg, 48, $noreg, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $esi, implicit-def $rsp, implicit-def $ssp, implicit-def $al :: (load (s64) from %ir.119)
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %81:gr8 = COPY $al
+    %23:gr8 = COPY %81
+  
+  bb.25 (%ir-block.122):
+    successors: %bb.26(0x00000800), %bb.27(0x7ffff800)
+  
+    %24:gr8 = PHI %22, %bb.23, %23, %bb.24
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %82:gr32 = MOVSX32rr8 %24
+    $rdi = COPY %20
+    $esi = COPY %82
+    CALL64pcrel32 target-flags(x86-plt) @_ZNSo3putEc, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $esi, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %83:gr64 = COPY $rax
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    $rdi = COPY %83
+    CALL64pcrel32 target-flags(x86-plt) @_ZNSo5flushEv, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %84:gr64 = COPY $rax
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %85:gr64 = MOV64rm $rip, 1, $noreg, target-flags(x86-gotpcrel) @_ZSt4cout, $noreg :: (load (s64) from got)
+    %86:gr32 = MOV32r0 implicit-def dead $eflags
+    $rdi = COPY %85
+    $esi = COPY %86
+    CALL64pcrel32 target-flags(x86-plt) @_ZNSo9_M_insertIbEERSoT_, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $esi, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %87:gr64 = COPY $rax
+    %25:gr64 = COPY %87
+    %88:gr64 = MOV64rm %87, 1, $noreg, 0, $noreg :: (dereferenceable load (s64) from %ir.126, !tbaa !5)
+    %89:gr64_nosp = MOV64rm killed %88, 1, $noreg, -24, $noreg :: (load (s64) from %ir.128)
+    %26:gr64 = MOV64rm %87, 1, killed %89, 240, $noreg :: (load (s64) from %ir.131, !tbaa !8)
+    TEST64rr %26, %26, implicit-def $eflags
+    JCC_1 %bb.27, 5, implicit $eflags
+    JMP_1 %bb.26
+  
+  bb.26 (%ir-block.134):
+    successors:
+  
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    CALL64pcrel32 target-flags(x86-plt) @_ZSt16__throw_bad_castv, csr_64, implicit $rsp, implicit $ssp, implicit-def $rsp, implicit-def $ssp
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+  
+  bb.27 (%ir-block.135):
+    successors: %bb.29(0x30000000), %bb.28(0x50000000)
+  
+    CMP8mi %26, 1, $noreg, 56, $noreg, 0, implicit-def $eflags :: (load (s8) from %ir.136, align 8, !tbaa !20)
+    JCC_1 %bb.29, 4, implicit $eflags
+    JMP_1 %bb.28
+  
+  bb.28 (%ir-block.139):
+    successors: %bb.30(0x80000000)
+  
+    %27:gr8 = MOV8rm %26, 1, $noreg, 67, $noreg :: (load (s8) from %ir.140, !tbaa !23)
+    JMP_1 %bb.30
+  
+  bb.29 (%ir-block.142):
+    successors: %bb.30(0x80000000)
+  
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    $rdi = COPY %26
+    CALL64pcrel32 target-flags(x86-plt) @_ZNKSt5ctypeIcE13_M_widen_initEv, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit-def $rsp, implicit-def $ssp
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %90:gr64 = MOV64rm %26, 1, $noreg, 0, $noreg :: (load (s64) from %ir.132, !tbaa !5)
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %91:gr32 = MOV32ri 10
+    $rdi = COPY %26
+    $esi = COPY %91
+    CALL64m killed %90, 1, $noreg, 48, $noreg, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $esi, implicit-def $rsp, implicit-def $ssp, implicit-def $al :: (load (s64) from %ir.144)
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %92:gr8 = COPY $al
+    %28:gr8 = COPY %92
+  
+  bb.30 (%ir-block.147):
+    %29:gr8 = PHI %27, %bb.28, %28, %bb.29
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %93:gr32 = MOVSX32rr8 %29
+    $rdi = COPY %25
+    $esi = COPY %93
+    CALL64pcrel32 target-flags(x86-plt) @_ZNSo3putEc, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $esi, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %94:gr64 = COPY $rax
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    $rdi = COPY %94
+    CALL64pcrel32 target-flags(x86-plt) @_ZNSo5flushEv, csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    %95:gr64 = COPY $rax
+    %96:gr32 = MOV32r0 implicit-def dead $eflags
+    $eax = COPY %96
+    RET 0, $eax
+
+...


### PR DESCRIPTION
This LLVM backend plugin performs an optimization that targets x86 machine instructions. Specifically, it detects and replaces certain sequences of scalar logical operations (`ANDPSrr` followed by `ORPSrr`) with their AVX (vector) equivalents `(VPANDrr` and `VPORrr`). This transformation leverages SIMD (Single Instruction, Multiple Data) instructions for potentially better performance on AVX-capable processors.

**1. Traversal of Instructions in a Machine Function:**
The pass iterates through all machine basic blocks (`MachineBasicBlock`) in a machine function (`MachineFunction`). For each instruction, it looks for a pair where an `ANDPSrr` (or `VPANDrr`) instruction is immediately followed by an `ORPSrr` (or `VPORrr`) that uses the result of the `AND` as one of its operands.

**2. Replacement with AVX Instructions:**
When such a pattern is found, the plugin generates a `VPANDrr` instruction into a new temporary register and then creates a `VPORrr` instruction using that temporary result and the second operand of the original `OR`. This effectively fuses the logical operations into their vector equivalents.

**3. Removing Redundant Instructions:**
The original scalar `AND` and `OR` instructions are removed from the machine function, as they are now replaced by their more efficient AVX counterparts.

**4. Returning the Result:**
The plugin returns `true` to indicate that modifications were made to the machine function, enabling LLVM to update any necessary analysis information.