### PR TITLE
Бесхмельнова Ксения. Лабораторная работа 4: MLIR. Вариант 3.

### DIFF
--- a/mlir/compiler-course/beskhmelnova_k_lower_rem_ops/CMakeLists.txt
+++ b/mlir/compiler-course/beskhmelnova_k_lower_rem_ops/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(Title "LowerRemOpsPass")
+set(Student "Beskhmelnova_Kseniya")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_MLIR")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    MLIRBuiltinLocationAttributesIncGen
+    BUILDTREE_ONLY
+)
+
+set(MLIR_TEST_DEPENDS ${TARGET_NAME} ${MLIR_TEST_DEPENDS} PARENT_SCOPE)

--- a/mlir/compiler-course/beskhmelnova_k_lower_rem_ops/LowerRemOpsPass.cpp
+++ b/mlir/compiler-course/beskhmelnova_k_lower_rem_ops/LowerRemOpsPass.cpp
@@ -1,0 +1,66 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Tools/Plugins/PassPlugin.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+
+namespace {
+template <typename RemOp, typename DivOp>
+struct RemRewritePattern : public OpRewritePattern<RemOp> {
+  using OpRewritePattern<RemOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(RemOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Value lhs = op.getLhs();
+    Value rhs = op.getRhs();
+
+    Value div = rewriter.create<DivOp>(loc, lhs, rhs);
+    Value mul = rewriter.create<arith::MulIOp>(loc, div, rhs);
+    Value res = rewriter.create<arith::SubIOp>(loc, lhs, mul);
+
+    rewriter.replaceOp(op, res);
+    return success();
+  }
+};
+
+using RemSIRewritePattern = RemRewritePattern<arith::RemSIOp, arith::DivSIOp>;
+using RemUIRewritePattern = RemRewritePattern<arith::RemUIOp, arith::DivUIOp>;
+
+class LowerRemOpsPass
+    : public PassWrapper<LowerRemOpsPass, OperationPass<ModuleOp>> {
+public:
+  StringRef getArgument() const final {
+    return "LowerRemOpsPass_Beskhmelnova_Kseniya_FIIT1_MLIR";
+  }
+
+  StringRef getDescription() const final {
+    return "Lower arith.rem{si,ui} to arithmetic expressions";
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    MLIRContext *ctx = module.getContext();
+    RewritePatternSet patterns(ctx);
+
+    patterns.add<RemSIRewritePattern, RemUIRewritePattern>(ctx);
+    (void)applyPatternsAndFoldGreedily(module, std::move(patterns));
+  }
+};
+
+} // namespace
+
+MLIR_DECLARE_EXPLICIT_TYPE_ID(LowerRemOpsPass)
+MLIR_DEFINE_EXPLICIT_TYPE_ID(LowerRemOpsPass)
+
+mlir::PassPluginLibraryInfo getLowerRemOpsPassPluginInfo() {
+  return {MLIR_PLUGIN_API_VERSION, "LowerRemOpsPass", "1.0",
+          []() { PassRegistration<LowerRemOpsPass>(); }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo
+mlirGetPassPluginInfo() {
+  return getLowerRemOpsPassPluginInfo();
+}

--- a/mlir/test/compiler-course/beskhmelnova_k_lower_rem_ops/test.mlir
+++ b/mlir/test/compiler-course/beskhmelnova_k_lower_rem_ops/test.mlir
@@ -1,9 +1,7 @@
 // RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/LowerRemOpsPass_Beskhmelnova_Kseniya_FIIT1_MLIR%shlibext \
 // RUN: --pass-pipeline="builtin.module(LowerRemOpsPass_Beskhmelnova_Kseniya_FIIT1_MLIR)" %s | FileCheck %s
 
-// CHECK: module attributes {{.*}} {
-module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f64, dense<64> : vector<2xi64>>, #dlti.dl_entry<f16, dense<16> : vector<2xi64>>, #dlti.dl_entry<f128, dense<128> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr<270>, dense<32> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<271>, dense<32> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<272>, dense<64> : vector<4xi64>>, #dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i128, dense<128> : vector<2xi64>>, #dlti.dl_entry<f80, dense<128> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<i1, dense<8> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<i16, dense<16> : vector<2xi64>>, #dlti.dl_entry<i32, dense<32> : vector<2xi64>>, #dlti.dl_entry<"dlti.endianness", "little">, #dlti.dl_entry<"dlti.stack_alignment", 128 : i64>>} {
-
+module {
   // Test 1: Signed remainder
   // CHECK-LABEL: func.func @test_signed
   // CHECK-NEXT:     %[[DIV:.*]] = arith.divsi %arg0, %arg1 : i32

--- a/mlir/test/compiler-course/beskhmelnova_k_lower_rem_ops/test.mlir
+++ b/mlir/test/compiler-course/beskhmelnova_k_lower_rem_ops/test.mlir
@@ -1,0 +1,45 @@
+// RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/LowerRemOpsPass_Beskhmelnova_Kseniya_FIIT1_MLIR%shlibext \
+// RUN: --pass-pipeline="builtin.module(LowerRemOpsPass_Beskhmelnova_Kseniya_FIIT1_MLIR)" %s | FileCheck %s
+
+// CHECK: module attributes {{.*}} {
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f64, dense<64> : vector<2xi64>>, #dlti.dl_entry<f16, dense<16> : vector<2xi64>>, #dlti.dl_entry<f128, dense<128> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr<270>, dense<32> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<271>, dense<32> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<272>, dense<64> : vector<4xi64>>, #dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i128, dense<128> : vector<2xi64>>, #dlti.dl_entry<f80, dense<128> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<i1, dense<8> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<i16, dense<16> : vector<2xi64>>, #dlti.dl_entry<i32, dense<32> : vector<2xi64>>, #dlti.dl_entry<"dlti.endianness", "little">, #dlti.dl_entry<"dlti.stack_alignment", 128 : i64>>} {
+
+  // Test 1: Signed remainder
+  // CHECK-LABEL: func.func @test_signed
+  // CHECK-NEXT:     %[[DIV:.*]] = arith.divsi %arg0, %arg1 : i32
+  // CHECK-NEXT:     %[[MUL:.*]] = arith.muli %[[DIV]], %arg1 : i32
+  // CHECK-NEXT:     %[[RES:.*]] = arith.subi %arg0, %[[MUL]] : i32
+  // CHECK-NEXT:     return %[[RES]] : i32
+  func.func @test_signed(%a: i32, %b: i32) -> i32 {
+    %0 = arith.remsi %a, %b : i32
+    return %0 : i32
+  }
+
+  // Test 2: Unsigned remainder
+  // CHECK-LABEL: func.func @test_unsigned
+  // CHECK-NEXT:     %[[DIV:.*]] = arith.divui %arg0, %arg1 : i32
+  // CHECK-NEXT:     %[[MUL:.*]] = arith.muli %[[DIV]], %arg1 : i32
+  // CHECK-NEXT:     %[[RES:.*]] = arith.subi %arg0, %[[MUL]] : i32
+  // CHECK-NEXT:     return %[[RES]] : i32
+  func.func @test_unsigned(%x: i32, %y: i32) -> i32 {
+    %1 = arith.remui %x, %y : i32
+    return %1 : i32
+  }
+
+  // Test 3: Two remainders in one function
+  // CHECK-LABEL: func.func @test_both
+  // CHECK-NEXT:     %[[DIV1:.*]] = arith.divsi %arg0, %arg1 : i32
+  // CHECK-NEXT:     %[[MUL1:.*]] = arith.muli %[[DIV1]], %arg1 : i32
+  // CHECK-NEXT:     %[[RES1:.*]] = arith.subi %arg0, %[[MUL1]] : i32
+  // CHECK-NEXT:     %[[DIV2:.*]] = arith.divui %arg0, %arg1 : i32
+  // CHECK-NEXT:     %[[MUL2:.*]] = arith.muli %[[DIV2]], %arg1 : i32
+  // CHECK-NEXT:     %[[RES2:.*]] = arith.subi %arg0, %[[MUL2]] : i32
+  // CHECK-NEXT:     %[[SUM:.*]] = arith.addi %[[RES1]], %[[RES2]] : i32
+  // CHECK-NEXT:     return %[[SUM]] : i32
+  func.func @test_both(%m: i32, %n: i32) -> i32 {
+    %2 = arith.remsi %m, %n : i32
+    %3 = arith.remui %m, %n : i32
+    %4 = arith.addi %2, %3 : i32
+    return %4 : i32
+  }
+}


### PR DESCRIPTION
MLIR-пасс, понижающий операции arith.remsi и arith.remui до эквивалентных арифметических выражений по формуле: rem(a, b) = a - (a // b) * b. Преобразование реализовано с помощью паттернов, заменяющих остаток от деления на последовательность деления, умножения и вычитания. Пасс использует шаблонный OpRewritePattern и applyPatternsAndFoldGreedily для надёжного преобразования. Включены тесты для проверок на знаковых, беззнаковых и смешанных операциях остатка.