### PR TITLE
Седова Ольга. Лабораторная 1. Вариант 3.

### DIFF
--- a/clang/compiler-course/sedova_o_lab1/CMakeLists.txt
+++ b/clang/compiler-course/sedova_o_lab1/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "Lab1")
+set(Student "Sedova_Olga")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/sedova_o_lab1/example.cpp
+++ b/clang/compiler-course/sedova_o_lab1/example.cpp
@@ -25,17 +25,33 @@ protected:
     return true;
   }
 
-  void PrintHelp(llvm::raw_ostream &ros) { ros << "Help for Lab1 plugin\n"; }
+  void PrintHelp(llvm::raw_ostream &ros) {
+    ros << "Lab1 plugin: This pass analyzes the source code to identify and "
+           "count implicit type casts "
+           "within functions. It helps developers understand where and how "
+           "often implicit conversions "
+           "occur, which can be useful for debugging, optimization, and code "
+           "quality improvements.\n";
+  }
 
 private:
   class ImplicitCastVisitor : public RecursiveASTVisitor<ImplicitCastVisitor> {
   public:
     explicit ImplicitCastVisitor(ASTContext *Context)
-        : Context(Context), CurrentFunction(nullptr) {}
+        : Context(Context), CurrentFunction(nullptr), ImplicitCastCount(0),
+          TotalImplicitCastCount(0) {}
 
     bool VisitFunctionDecl(FunctionDecl *FD) {
       if (FD->hasBody()) {
-        FD->dump();
+        CurrentFunction = FD;
+        ImplicitCastCount = 0;
+        TraverseStmt(FD->getBody());
+        llvm::outs() << "Function '"
+                     << FD->getNameInfo().getName().getAsString()
+                     << "' contains " << ImplicitCastCount
+                     << " implicit casts.\n";
+        TotalImplicitCastCount += ImplicitCastCount;
+        CurrentFunction = nullptr;
       }
       return true;
     }
@@ -60,12 +76,25 @@ private:
       std::string key = srcTypeStr + " -> " + dstTypeStr;
       CastCounts[key]++;
 
+      ++ImplicitCastCount;
       return true;
+    }
+
+    void PrintTotalStatistics() const {
+      llvm::outs() << "Total implicit casts in translation unit: "
+                   << TotalImplicitCastCount << "\n";
+
+      llvm::outs() << "Implicit cast breakdown by type:\n";
+      for (const auto &pair : CastCounts) {
+        llvm::outs() << "  " << pair.first << ": " << pair.second << "\n";
+      }
     }
 
   private:
     ASTContext *Context;
     FunctionDecl *CurrentFunction;
+    unsigned ImplicitCastCount;
+    unsigned TotalImplicitCastCount;
     std::map<std::string, unsigned> CastCounts;
 
     std::string castKindToString(CastKind kind) {
@@ -90,8 +119,9 @@ private:
   public:
     explicit ImplicitCastConsumer(ASTContext *Context) : Visitor(Context) {}
 
-    virtual void HandleTranslationUnit(ASTContext &Context) override {
+    void HandleTranslationUnit(ASTContext &Context) override {
       Visitor.TraverseDecl(Context.getTranslationUnitDecl());
+      Visitor.PrintTotalStatistics();
     }
 
   private:

--- a/clang/compiler-course/sedova_o_lab1/example.cpp
+++ b/clang/compiler-course/sedova_o_lab1/example.cpp
@@ -1,0 +1,105 @@
+#include "clang/AST/AST.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendAction.h"
+#include "clang/Frontend/FrontendActions.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <map>
+#include <string>
+
+using namespace clang;
+
+namespace {
+
+class ExampleAction : public PluginASTAction {
+protected:
+  std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
+                                                 llvm::StringRef) override {
+    return std::make_unique<ImplicitCastConsumer>(&CI.getASTContext());
+  }
+
+  bool ParseArgs(const CompilerInstance &CI,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+
+  void PrintHelp(llvm::raw_ostream &ros) { ros << "Help for Lab1 plugin\n"; }
+
+private:
+  class ImplicitCastVisitor : public RecursiveASTVisitor<ImplicitCastVisitor> {
+  public:
+    explicit ImplicitCastVisitor(ASTContext *Context)
+        : Context(Context), CurrentFunction(nullptr) {}
+
+    bool VisitFunctionDecl(FunctionDecl *FD) {
+      if (FD->hasBody()) {
+        FD->dump();
+      }
+      return true;
+    }
+
+    bool VisitImplicitCastExpr(ImplicitCastExpr *ICE) {
+      if (!CurrentFunction)
+        return true;
+
+      auto castKind = ICE->getCastKind();
+      std::string castStr = castKindToString(castKind);
+      if (castStr.empty())
+        return true;
+
+      QualType srcType = ICE->getSubExpr()->getType();
+      QualType dstType = ICE->getType();
+      if (Context->hasSameType(srcType, dstType))
+        return true;
+
+      std::string srcTypeStr = srcType.getAsString();
+      std::string dstTypeStr = dstType.getAsString();
+
+      std::string key = srcTypeStr + " -> " + dstTypeStr;
+      CastCounts[key]++;
+
+      return true;
+    }
+
+  private:
+    ASTContext *Context;
+    FunctionDecl *CurrentFunction;
+    std::map<std::string, unsigned> CastCounts;
+
+    std::string castKindToString(CastKind kind) {
+      switch (kind) {
+      case CK_IntegralToFloating:
+        return "IntegralToFloating";
+      case CK_FloatingToIntegral:
+        return "FloatingToIntegral";
+      case CK_FloatingCast:
+        return "FloatingCast";
+      case CK_IntegralCast:
+        return "IntegralCast";
+      case CK_NoOp:
+        return "";
+      default:
+        return "";
+      }
+    }
+  };
+
+  class ImplicitCastConsumer : public ASTConsumer {
+  public:
+    explicit ImplicitCastConsumer(ASTContext *Context) : Visitor(Context) {}
+
+    virtual void HandleTranslationUnit(ASTContext &Context) override {
+      Visitor.TraverseDecl(Context.getTranslationUnitDecl());
+    }
+
+  private:
+    ImplicitCastVisitor Visitor;
+  };
+};
+
+} // namespace
+
+static FrontendPluginRegistry::Add<ExampleAction> X("Lab1",
+                                                    "Description plugin");

--- a/clang/test/compiler-course/sedova_o_lab1/test.cpp
+++ b/clang/test/compiler-course/sedova_o_lab1/test.cpp
@@ -1,71 +1,36 @@
 // RUN: %clang_cc1 -load %llvmshlibdir/Lab1_Sedova_Olga_FIIT1_ClangAST%pluginext -plugin Lab1 -fsyntax-only %s 2>&1 | FileCheck %s
 
-// CHECK-LABEL: FunctionDecl {{.*}} isPositive 'bool (int)'
-// CHECK: ParmVarDecl {{.*}} 'int'
-// CHECK: BinaryOperator {{.*}} 'bool' '>'
+// CHECK-LABEL: Function 'isPositive' contains 0 implicit casts.
+
+// CHECK-LABEL: Function 'compute' contains 2 implicit casts.
+
+// CHECK-LABEL: Function 'process' contains 3 implicit casts.
+
+// CHECK-LABEL: Function 'identity' contains 0 implicit casts.
+
+// CHECK-LABEL: Function 'explicitCast' contains 1 implicit casts.
+
+// CHECK-LABEL: Function 'returnFloat' contains 0 implicit casts.
 
 bool isPositive(int a) {
   return a > 0;
 }
 
-// CHECK-LABEL: FunctionDecl {{.*}} compute 'double (int, float)'
-// CHECK: ParmVarDecl {{.*}} 'int'
-// CHECK: ParmVarDecl {{.*}} 'float'
-// CHECK: ReturnStmt
-// CHECK: ImplicitCastExpr {{.*}} 'double' <FloatingCast>
-// CHECK: BinaryOperator {{.*}} 'float' '+'
-// CHECK: ImplicitCastExpr {{.*}} 'float' <IntegralToFloating>
-// CHECK: 'int' lvalue ParmVar
-// CHECK: ImplicitCastExpr {{.*}} 'float' <LValueToRValue>
-// CHECK: 'float' lvalue ParmVar
-
 double compute(int x, float y) {
   return x + y;
 }
-
-// CHECK-LABEL: FunctionDecl {{.*}} process 'int (float, float)'
-// CHECK: ParmVarDecl {{.*}} 'float'
-// CHECK: ParmVarDecl {{.*}} 'float'
-// CHECK: ReturnStmt
-// CHECK: ImplicitCastExpr {{.*}} 'int' <FloatingToIntegral>
-// CHECK: BinaryOperator {{.*}} 'double' '+'
-// CHECK: ImplicitCastExpr {{.*}} 'double' <FloatingCast>
-// CHECK: CallExpr
-// CHECK: ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
-// CHECK: 'double (int, float)' lvalue Function
-// CHECK: ImplicitCastExpr {{.*}} 'int' <FloatingToIntegral>
-// CHECK: 'float' lvalue ParmVar
 
 int process(float a, float b) {
   return a + compute(a, b);
 }
 
-// CHECK-LABEL: FunctionDecl {{.*}} identity 'int (int)'
-// CHECK: ParmVarDecl {{.*}} 'int'
-// CHECK: ReturnStmt
-// CHECK: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
-// CHECK: 'int' lvalue ParmVar
-
 int identity(int v) {
   return v;
 }
 
-// CHECK-LABEL: FunctionDecl {{.*}} explicitCast 'float (int)'
-// CHECK: ParmVarDecl {{.*}} 'int'
-// CHECK: ReturnStmt
-// CHECK: CStyleCastExpr {{.*}} 'float'
-// CHECK: ImplicitCastExpr {{.*}} 'float' <IntegralToFloating>
-// CHECK: 'int' lvalue ParmVar
-
 float explicitCast(int a) {
   return (float)a;
 }
-
-// CHECK-LABEL: FunctionDecl {{.*}} returnFloat 'float (float)'
-// CHECK: ParmVarDecl {{.*}} 'float'
-// CHECK: ReturnStmt
-// CHECK: ImplicitCastExpr {{.*}} 'float' <LValueToRValue>
-// CHECK: 'float' lvalue ParmVar
 
 float returnFloat(float f) {
   return f;

--- a/clang/test/compiler-course/sedova_o_lab1/test.cpp
+++ b/clang/test/compiler-course/sedova_o_lab1/test.cpp
@@ -1,0 +1,72 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/Lab1_Sedova_Olga_FIIT1_ClangAST%pluginext -plugin Lab1 -fsyntax-only %s 2>&1 | FileCheck %s
+
+// CHECK-LABEL: FunctionDecl {{.*}} isPositive 'bool (int)'
+// CHECK: ParmVarDecl {{.*}} 'int'
+// CHECK: BinaryOperator {{.*}} 'bool' '>'
+
+bool isPositive(int a) {
+  return a > 0;
+}
+
+// CHECK-LABEL: FunctionDecl {{.*}} compute 'double (int, float)'
+// CHECK: ParmVarDecl {{.*}} 'int'
+// CHECK: ParmVarDecl {{.*}} 'float'
+// CHECK: ReturnStmt
+// CHECK: ImplicitCastExpr {{.*}} 'double' <FloatingCast>
+// CHECK: BinaryOperator {{.*}} 'float' '+'
+// CHECK: ImplicitCastExpr {{.*}} 'float' <IntegralToFloating>
+// CHECK: 'int' lvalue ParmVar
+// CHECK: ImplicitCastExpr {{.*}} 'float' <LValueToRValue>
+// CHECK: 'float' lvalue ParmVar
+
+double compute(int x, float y) {
+  return x + y;
+}
+
+// CHECK-LABEL: FunctionDecl {{.*}} process 'int (float, float)'
+// CHECK: ParmVarDecl {{.*}} 'float'
+// CHECK: ParmVarDecl {{.*}} 'float'
+// CHECK: ReturnStmt
+// CHECK: ImplicitCastExpr {{.*}} 'int' <FloatingToIntegral>
+// CHECK: BinaryOperator {{.*}} 'double' '+'
+// CHECK: ImplicitCastExpr {{.*}} 'double' <FloatingCast>
+// CHECK: CallExpr
+// CHECK: ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
+// CHECK: 'double (int, float)' lvalue Function
+// CHECK: ImplicitCastExpr {{.*}} 'int' <FloatingToIntegral>
+// CHECK: 'float' lvalue ParmVar
+
+int process(float a, float b) {
+  return a + compute(a, b);
+}
+
+// CHECK-LABEL: FunctionDecl {{.*}} identity 'int (int)'
+// CHECK: ParmVarDecl {{.*}} 'int'
+// CHECK: ReturnStmt
+// CHECK: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
+// CHECK: 'int' lvalue ParmVar
+
+int identity(int v) {
+  return v;
+}
+
+// CHECK-LABEL: FunctionDecl {{.*}} explicitCast 'float (int)'
+// CHECK: ParmVarDecl {{.*}} 'int'
+// CHECK: ReturnStmt
+// CHECK: CStyleCastExpr {{.*}} 'float'
+// CHECK: ImplicitCastExpr {{.*}} 'float' <IntegralToFloating>
+// CHECK: 'int' lvalue ParmVar
+
+float explicitCast(int a) {
+  return (float)a;
+}
+
+// CHECK-LABEL: FunctionDecl {{.*}} returnFloat 'float (float)'
+// CHECK: ParmVarDecl {{.*}} 'float'
+// CHECK: ReturnStmt
+// CHECK: ImplicitCastExpr {{.*}} 'float' <LValueToRValue>
+// CHECK: 'float' lvalue ParmVar
+
+float returnFloat(float f) {
+  return f;
+}


### PR DESCRIPTION
Патч реализует плагин для Clang, анализирующий неявные преобразования типов в функциях.
Основная цель: подсчёт количества неявных кастов (например, int → float) для каждой функции в коде.

Ключевые компоненты:
1. ImplicitCastVisitor
Наследуется от RecursiveASTVisitor для обхода AST.
В методе VisitFunctionDecl запускает обход тела функции и выводит статистику по кастам.
В VisitImplicitCastExpr определяет тип преобразования и обновляет счётчики.

2. castKindToString
Преобразует CastKind в строковое представление (например, CK_IntegralToFloating → "IntegralToFloating").
Учитывает только интересующие касты:
IntegralToFloating, FloatingToIntegral, FloatingCast, IntegralCast

3. ImplicitCastConsumer
ASTConsumer, запускающий обход AST с помощью ImplicitCastVisitor.

4. ExampleAction
Регистрирует плагин через FrontendPluginRegistry.
Создаёт ASTConsumer для анализа кода.

Логика работы
Для каждой функции с телом:
Обходит все её выражения.
Для каждого ImplicitCastExpr:
-Определяет исходный и целевой типы.
-Фильтрует касты без изменения типа (например, LValueToRValue).
-Формирует ключ в формате тип_источника -> тип_цели.
-Увеличивает счётчик для этого ключа.