### PR TITLE
Шульпин Илья. Лабораторная работа 4: MLIR. Вариант 3.

### DIFF
--- a/mlir/compiler-course/shulpin_i_lowering_rem/CMakeLists.txt
+++ b/mlir/compiler-course/shulpin_i_lowering_rem/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(Title "LowerRemPass")
+set(Student "ShulpinIlya")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_MLIR")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    MLIRBuiltinLocationAttributesIncGen
+    BUILDTREE_ONLY
+)
+
+set(MLIR_TEST_DEPENDS ${TARGET_NAME} ${MLIR_TEST_DEPENDS} PARENT_SCOPE)

--- a/mlir/compiler-course/shulpin_i_lowering_rem/LowerRemPass.cpp
+++ b/mlir/compiler-course/shulpin_i_lowering_rem/LowerRemPass.cpp
@@ -1,0 +1,83 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Tools/Plugins/PassPlugin.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+class LowerRemPass
+    : public mlir::PassWrapper<LowerRemPass,
+                               mlir::OperationPass<mlir::ModuleOp>> {
+public:
+  mlir::StringRef getArgument() const final {
+    return "LowerRemPass_ShulpinIlya_FIIT1_MLIR";
+  }
+
+  mlir::StringRef getDescription() const final {
+    return "Lower arith.remsi and arith.remui into a - (a // b) * b";
+  }
+
+  void runOnOperation() override {
+    mlir::ModuleOp module = getOperation();
+
+    RemSILowering silower;
+    RemUILowering uilower;
+
+    module.walk([&](mlir::arith::RemSIOp remOp) { silower.lower(remOp); });
+
+    module.walk([&](mlir::arith::RemUIOp remOp) { uilower.lower(remOp); });
+  }
+
+private:
+  struct RemSILowering {
+    void lower(mlir::arith::RemSIOp remOp) {
+      mlir::OpBuilder builder(remOp);
+      mlir::Value lhs = remOp.getLhs();
+      mlir::Value rhs = remOp.getRhs();
+
+      mlir::Value div =
+          builder.create<mlir::arith::DivSIOp>(remOp.getLoc(), lhs, rhs);
+      mlir::Value mul =
+          builder.create<mlir::arith::MulIOp>(remOp.getLoc(), div, rhs);
+      mlir::Value result =
+          builder.create<mlir::arith::SubIOp>(remOp.getLoc(), lhs, mul);
+
+      remOp.replaceAllUsesWith(result);
+      remOp.erase();
+    }
+  };
+
+  struct RemUILowering {
+    void lower(mlir::arith::RemUIOp remOp) {
+      mlir::OpBuilder builder(remOp);
+      mlir::Value lhs = remOp.getLhs();
+      mlir::Value rhs = remOp.getRhs();
+
+      mlir::Value div =
+          builder.create<mlir::arith::DivUIOp>(remOp.getLoc(), lhs, rhs);
+      mlir::Value mul =
+          builder.create<mlir::arith::MulIOp>(remOp.getLoc(), div, rhs);
+      mlir::Value result =
+          builder.create<mlir::arith::SubIOp>(remOp.getLoc(), lhs, mul);
+
+      remOp.replaceAllUsesWith(result);
+      remOp.erase();
+    }
+  };
+};
+} // namespace
+
+MLIR_DECLARE_EXPLICIT_TYPE_ID(LowerRemPass)
+MLIR_DEFINE_EXPLICIT_TYPE_ID(LowerRemPass)
+
+mlir::PassPluginLibraryInfo getLowerRemPassPluginInfo() {
+  return {MLIR_PLUGIN_API_VERSION, "LowerRemPass", "1.0",
+          []() { mlir::PassRegistration<LowerRemPass>(); }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo
+mlirGetPassPluginInfo() {
+  return getLowerRemPassPluginInfo();
+}

--- a/mlir/compiler-course/shulpin_i_lowering_rem/LowerRemPass.cpp
+++ b/mlir/compiler-course/shulpin_i_lowering_rem/LowerRemPass.cpp
@@ -22,41 +22,24 @@ public:
   void runOnOperation() override {
     mlir::ModuleOp module = getOperation();
 
-    RemSILowering silower;
-    RemUILowering uilower;
+    module.walk([&](mlir::arith::RemSIOp remOp) {
+      RemLowering<mlir::arith::RemSIOp, mlir::arith::DivSIOp>().lower(remOp);
+    });
 
-    module.walk([&](mlir::arith::RemSIOp remOp) { silower.lower(remOp); });
-
-    module.walk([&](mlir::arith::RemUIOp remOp) { uilower.lower(remOp); });
+    module.walk([&](mlir::arith::RemUIOp remOp) {
+      RemLowering<mlir::arith::RemUIOp, mlir::arith::DivUIOp>().lower(remOp);
+    });
   }
 
 private:
-  struct RemSILowering {
-    void lower(mlir::arith::RemSIOp remOp) {
+  template <typename RemOp, typename DivOp>
+  struct RemLowering {
+    void lower(RemOp remOp) {
       mlir::OpBuilder builder(remOp);
       mlir::Value lhs = remOp.getLhs();
       mlir::Value rhs = remOp.getRhs();
 
-      mlir::Value div =
-          builder.create<mlir::arith::DivSIOp>(remOp.getLoc(), lhs, rhs);
-      mlir::Value mul =
-          builder.create<mlir::arith::MulIOp>(remOp.getLoc(), div, rhs);
-      mlir::Value result =
-          builder.create<mlir::arith::SubIOp>(remOp.getLoc(), lhs, mul);
-
-      remOp.replaceAllUsesWith(result);
-      remOp.erase();
-    }
-  };
-
-  struct RemUILowering {
-    void lower(mlir::arith::RemUIOp remOp) {
-      mlir::OpBuilder builder(remOp);
-      mlir::Value lhs = remOp.getLhs();
-      mlir::Value rhs = remOp.getRhs();
-
-      mlir::Value div =
-          builder.create<mlir::arith::DivUIOp>(remOp.getLoc(), lhs, rhs);
+      mlir::Value div = builder.create<DivOp>(remOp.getLoc(), lhs, rhs);
       mlir::Value mul =
           builder.create<mlir::arith::MulIOp>(remOp.getLoc(), div, rhs);
       mlir::Value result =

--- a/mlir/test/compiler-course/shulpin_i_lowering_rem/shulpin_i_mlir_pass_test.mlir
+++ b/mlir/test/compiler-course/shulpin_i_lowering_rem/shulpin_i_mlir_pass_test.mlir
@@ -1,0 +1,98 @@
+// RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/LowerRemPass_ShulpinIlya_FIIT1_MLIR%shlibext \
+// RUN: --pass-pipeline="builtin.module(LowerRemPass_ShulpinIlya_FIIT1_MLIR)" %s | FileCheck %s
+
+// -----------------------------------------------------------------------------
+// 1) Cyclic remainder: compute rem(addi(arg0, arg1), arg2)
+// -----------------------------------------------------------------------------
+// CHECK-LABEL: func.func @test_cyclic_remainder
+// CHECK-NEXT: %[[SUM:.*]] = arith.addi %arg0, %arg1 : i32
+// CHECK-NEXT: %[[DIV:.*]] = arith.divsi %[[SUM]], %arg2 : i32
+// CHECK-NEXT: %[[MUL:.*]] = arith.muli %[[DIV]], %arg2 : i32
+// CHECK-NEXT: %[[SUB:.*]] = arith.subi %[[SUM]], %[[MUL]] : i32
+// CHECK-NEXT: return %[[SUB]] : i32
+func.func @test_cyclic_remainder(%arg0: i32, %arg1: i32, %arg2: i32) -> i32 {
+  %sum = arith.addi %arg0, %arg1 : i32
+  %remainder = arith.remsi %sum, %arg2 : i32
+  return %remainder : i32
+}
+
+// -----------------------------------------------------------------------------
+// 2) Combined signed and unsigned remainder addition
+// -----------------------------------------------------------------------------
+// CHECK-LABEL: func.func @test_both
+// CHECK-NEXT:     %[[DIV1:.*]] = arith.divsi %arg0, %arg1 : i32
+// CHECK-NEXT:     %[[MUL1:.*]] = arith.muli %[[DIV1]], %arg1 : i32
+// CHECK-NEXT:     %[[RES1:.*]] = arith.subi %arg0, %[[MUL1]] : i32
+// CHECK-NEXT:     %[[DIV2:.*]] = arith.divui %arg0, %arg1 : i32
+// CHECK-NEXT:     %[[MUL2:.*]] = arith.muli %[[DIV2]], %arg1 : i32
+// CHECK-NEXT:     %[[RES2:.*]] = arith.subi %arg0, %[[MUL2]] : i32
+// CHECK-NEXT:     %[[SUM:.*]] = arith.addi %[[RES1]], %[[RES2]] : i32
+// CHECK-NEXT:     return %[[SUM]] : i32
+func.func @test_both(%m: i32, %n: i32) -> i32 {
+  %2 = arith.remsi %m, %n : i32
+  %3 = arith.remui %m, %n : i32
+  %4 = arith.addi %2, %3 : i32
+  return %4 : i32
+}
+
+// -----------------------------------------------------------------------------
+// 3) Divisibility check: select 1 if signed remainder is zero, else 0
+// -----------------------------------------------------------------------------
+// CHECK-LABEL: func.func @test_remainder_condition
+// CHECK: %[[DIV:.*]] = arith.divsi %arg1, %arg0 : i32
+// CHECK-NEXT: %[[MUL:.*]] = arith.muli %[[DIV]], %arg0 : i32
+// CHECK-NEXT: %[[SUB:.*]] = arith.subi %arg1, %[[MUL]] : i32
+// CHECK-NEXT: %[[CMP:.*]] = arith.cmpi eq, %[[SUB]], %c0{{.*}} : i32
+// CHECK-NEXT: %[[RESULT:.*]] = arith.select %[[CMP]], %c1{{.*}}, %c0{{.*}} : i32
+// CHECK-NEXT: return %[[RESULT]] : i32
+func.func @test_remainder_condition(%arg0: i32, %arg1: i32) -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %remainder = arith.remsi %arg1, %arg0 : i32
+  %is_divisible = arith.cmpi eq, %remainder, %c0 : i32
+  %result = arith.select %is_divisible, %c1, %c0 : i32
+  return %result : i32
+}
+
+// -----------------------------------------------------------------------------
+// 4) Nested rem inside further multiplication chain
+// -----------------------------------------------------------------------------
+ // CHECK-LABEL: func.func @test_mul_remsi_mul
+// CHECK-NEXT: %[[PROD1:.*]] = arith.muli %arg0, %arg1 : i32
+// CHECK-NEXT: %[[DIV:.*]]   = arith.divsi %[[PROD1]], %arg2 : i32
+// CHECK-NEXT: %[[MUL:.*]]   = arith.muli %[[DIV]], %arg2 : i32
+// CHECK-NEXT: %[[SUB:.*]]   = arith.subi %[[PROD1]], %[[MUL]] : i32
+// CHECK-NEXT: %[[PROD2:.*]] = arith.muli %[[SUB]], %arg3 : i32
+// CHECK-NEXT: return %[[PROD2]] : i32
+func.func @test_mul_remsi_mul(%arg0: i32, %arg1: i32, %arg2: i32, %arg3: i32) -> i32 {
+  %prod = arith.muli %arg0, %arg1 : i32
+  %rem  = arith.remsi %prod, %arg2   : i32
+  %res  = arith.muli %rem, %arg3     : i32
+  return %res : i32
+}
+
+// -----------------------------------------------------------------------------
+// 5) Expand signed remainder operation
+// -----------------------------------------------------------------------------
+// CHECK-LABEL: func.func @test_signed
+// CHECK-NEXT:     %[[DIV:.*]] = arith.divsi %arg0, %arg1 : i32
+// CHECK-NEXT:     %[[MUL:.*]] = arith.muli %[[DIV]], %arg1 : i32
+// CHECK-NEXT:     %[[RES:.*]] = arith.subi %arg0, %[[MUL]] : i32
+// CHECK-NEXT:     return %[[RES]] : i32
+func.func @test_signed(%a: i32, %b: i32) -> i32 {
+  %0 = arith.remsi %a, %b : i32
+  return %0 : i32
+}
+
+// -----------------------------------------------------------------------------
+// 6) Expand unsigned remainder operation
+// -----------------------------------------------------------------------------
+// CHECK-LABEL: func.func @test_unsigned
+// CHECK-NEXT:     %[[DIV:.*]] = arith.divui %arg0, %arg1 : i32
+// CHECK-NEXT:     %[[MUL:.*]] = arith.muli %[[DIV]], %arg1 : i32
+// CHECK-NEXT:     %[[RES:.*]] = arith.subi %arg0, %[[MUL]] : i32
+// CHECK-NEXT:     return %[[RES]] : i32
+func.func @test_unsigned(%x: i32, %y: i32) -> i32 {
+  %1 = arith.remui %x, %y : i32
+  return %1 : i32
+}


### PR DESCRIPTION
Плагинный MLIR-пасс, заменяющий операции остатка arith.remsi и arith.remui на эквивалентную последовательность из трёх более простых арифметических операций, чтобы повысить портируемость и упростить бэкенд-оптимизации.
Для a % b создаётся:
1. div = a // b (DivSIOp или DivUIOp)
2. mul = div * b (MulIOp) 
3. sub = a - mul (SubIOp)
