### PR TITLE
Миронов Арсений. 3822Б1ФИ1. Лабораторная работа 4. Вариант 3.

### DIFF
--- a/mlir/compiler-course/mironov_a_lab4/CMakeLists.txt
+++ b/mlir/compiler-course/mironov_a_lab4/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(Title "rem_pass")
+set(Student "Mironov_Arseniy")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_MLIR")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    MLIRBuiltinLocationAttributesIncGen
+    BUILDTREE_ONLY
+)
+
+set(MLIR_TEST_DEPENDS ${TARGET_NAME} ${MLIR_TEST_DEPENDS} PARENT_SCOPE)

--- a/mlir/compiler-course/mironov_a_lab4/rem_pass.cpp
+++ b/mlir/compiler-course/mironov_a_lab4/rem_pass.cpp
@@ -12,18 +12,8 @@ namespace {
 
 class RemPass : public PassWrapper<RemPass, OperationPass<ModuleOp>> {
 private:
-  template <typename RemOpType>
+  template <typename RemOpType, typename DivOp>
   struct RemXIOpRewrite : public OpRewritePattern<RemOpType> {
-
-    template <typename RemXIOp>
-    struct DivOpType {
-      using Type = DivSIOp;
-    };
-
-    template <>
-    struct DivOpType<RemUIOp> {
-      using Type = DivUIOp;
-    };
 
     using OpRewritePattern<RemOpType>::OpRewritePattern;
     LogicalResult matchAndRewrite(RemOpType operation,
@@ -32,7 +22,6 @@ private:
       Value val1 = operation.getLhs();
       Value val2 = operation.getRhs();
 
-      using DivOp = typename DivOpType<RemOpType>::Type;
       Value division = rw.create<DivOp>(location, val1, val2);
       Value multiplication = rw.create<MulIOp>(location, division, val2);
       Value substract = rw.create<SubIOp>(location, val1, multiplication);
@@ -53,8 +42,8 @@ public:
   }
 
   void runOnOperation() override {
-    using RemSIRewritePattern = RemXIOpRewrite<RemSIOp>;
-    using RemUIRewritePattern = RemXIOpRewrite<RemUIOp>;
+    using RemSIRewritePattern = RemXIOpRewrite<RemSIOp, DivSIOp>;
+    using RemUIRewritePattern = RemXIOpRewrite<RemUIOp, DivUIOp>;
     RewritePatternSet rewrite_patterns(&getContext());
     rewrite_patterns.add<RemSIRewritePattern>(&getContext());
     rewrite_patterns.add<RemUIRewritePattern>(&getContext());

--- a/mlir/compiler-course/mironov_a_lab4/rem_pass.cpp
+++ b/mlir/compiler-course/mironov_a_lab4/rem_pass.cpp
@@ -12,34 +12,29 @@ namespace {
 
 class RemPass : public PassWrapper<RemPass, OperationPass<ModuleOp>> {
 private:
-  struct RemSIOpRewrite : public OpRewritePattern<RemSIOp> {
-    using OpRewritePattern::OpRewritePattern;
+  template <typename RemOpType>
+  struct RemXIOpRewrite : public OpRewritePattern<RemOpType> {
 
-    LogicalResult matchAndRewrite(RemSIOp operation,
+    template <typename RemXIOp>
+    struct DivOpType {
+      using Type = DivSIOp;
+    };
+
+    template <>
+    struct DivOpType<RemUIOp> {
+      using Type = DivUIOp;
+    };
+
+    using OpRewritePattern<RemOpType>::OpRewritePattern;
+    LogicalResult matchAndRewrite(RemOpType operation,
                                   PatternRewriter &rw) const override {
       Location location = operation.getLoc();
-
       Value val1 = operation.getLhs();
       Value val2 = operation.getRhs();
-      Value division = rw.create<DivSIOp>(location, val1, val2);
-      Value multiplication = rw.create<MulIOp>(location, division, val2);
-      Value substract = rw.create<SubIOp>(location, val1, multiplication);
 
-      rw.replaceOp(operation, substract);
-      return success();
-    }
-  };
-
-  struct RemUIOpRewrite : public OpRewritePattern<RemUIOp> {
-    using OpRewritePattern::OpRewritePattern;
-
-    LogicalResult matchAndRewrite(RemUIOp operation,
-                                  PatternRewriter &rw) const override {
-      Location location = operation.getLoc();
-
-      Value val1 = operation.getLhs();
-      Value val2 = operation.getRhs();
-      Value division = rw.create<DivUIOp>(location, val1, val2);
+      // Use the appropriate division operation based on the type
+      Value division =
+          rw.create<typename DivOpType<RemOpType>::Type>(location, val1, val2);
       Value multiplication = rw.create<MulIOp>(location, division, val2);
       Value substract = rw.create<SubIOp>(location, val1, multiplication);
 
@@ -59,12 +54,14 @@ public:
   }
 
   void runOnOperation() override {
+    using RemSIRewritePattern = RemXIOpRewrite<RemSIOp>;
+    using RemUIRewritePattern = RemXIOpRewrite<RemUIOp>;
     RewritePatternSet rewrite_patterns(&getContext());
-    rewrite_patterns.add<RemSIOpRewrite, RemUIOpRewrite>(&getContext());
+    rewrite_patterns.add<RemSIRewritePattern>(&getContext());
+    rewrite_patterns.add<RemUIRewritePattern>(&getContext());
     LogicalResult result = applyPatternsAndFoldGreedily(
         getOperation(), std::move(rewrite_patterns), GreedyRewriteConfig(),
         nullptr);
-
     if (failed(result)) {
       llvm::errs() << "Something went wrong.\n";
     }

--- a/mlir/compiler-course/mironov_a_lab4/rem_pass.cpp
+++ b/mlir/compiler-course/mironov_a_lab4/rem_pass.cpp
@@ -32,9 +32,8 @@ private:
       Value val1 = operation.getLhs();
       Value val2 = operation.getRhs();
 
-      // Use the appropriate division operation based on the type
-      Value division =
-          rw.create<typename DivOpType<RemOpType>::Type>(location, val1, val2);
+      using DivOp = typename DivOpType<RemOpType>::Type;
+      Value division = rw.create<DivOp>(location, val1, val2);
       Value multiplication = rw.create<MulIOp>(location, division, val2);
       Value substract = rw.create<SubIOp>(location, val1, multiplication);
 

--- a/mlir/compiler-course/mironov_a_lab4/rem_pass.cpp
+++ b/mlir/compiler-course/mironov_a_lab4/rem_pass.cpp
@@ -1,0 +1,87 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Tools/Plugins/PassPlugin.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir;
+using namespace arith;
+
+namespace {
+
+class RemPass : public PassWrapper<RemPass, OperationPass<ModuleOp>> {
+private:
+  struct RemSIOpRewrite : public OpRewritePattern<RemSIOp> {
+    using OpRewritePattern::OpRewritePattern;
+
+    LogicalResult matchAndRewrite(RemSIOp operation,
+                                  PatternRewriter &rw) const override {
+      Location location = operation.getLoc();
+
+      Value val1 = operation.getLhs();
+      Value val2 = operation.getRhs();
+      Value division = rw.create<DivSIOp>(location, val1, val2);
+      Value multiplication = rw.create<MulIOp>(location, division, val2);
+      Value substract = rw.create<SubIOp>(location, val1, multiplication);
+
+      rw.replaceOp(operation, substract);
+      return success();
+    }
+  };
+
+  struct RemUIOpRewrite : public OpRewritePattern<RemUIOp> {
+    using OpRewritePattern::OpRewritePattern;
+
+    LogicalResult matchAndRewrite(RemUIOp operation,
+                                  PatternRewriter &rw) const override {
+      Location location = operation.getLoc();
+
+      Value val1 = operation.getLhs();
+      Value val2 = operation.getRhs();
+      Value division = rw.create<DivUIOp>(location, val1, val2);
+      Value multiplication = rw.create<MulIOp>(location, division, val2);
+      Value substract = rw.create<SubIOp>(location, val1, multiplication);
+
+      rw.replaceOp(operation, substract);
+      return success();
+    }
+  };
+
+public:
+  StringRef getArgument() const final {
+    return "rem_pass_Mironov_Arseniy_FIIT1_MLIR";
+  }
+
+  StringRef getDescription() const final {
+    return "This pass breaks operations arith.remsi and arith.remui into "
+           "calculation following the rule:\n rem(a, b) = a - (a / b) * b";
+  }
+
+  void runOnOperation() override {
+    RewritePatternSet rewrite_patterns(&getContext());
+    rewrite_patterns.add<RemSIOpRewrite, RemUIOpRewrite>(&getContext());
+    LogicalResult result = applyPatternsAndFoldGreedily(
+        getOperation(), std::move(rewrite_patterns), GreedyRewriteConfig(),
+        nullptr);
+
+    if (failed(result)) {
+      llvm::errs() << "Something went wrong.\n";
+    }
+  }
+};
+
+} // namespace
+
+MLIR_DECLARE_EXPLICIT_TYPE_ID(RemPass)
+MLIR_DEFINE_EXPLICIT_TYPE_ID(RemPass)
+
+mlir::PassPluginLibraryInfo getFunctionCallCounterPassPluginInfo() {
+  return {MLIR_PLUGIN_API_VERSION, "rem_pass", "1.0",
+          []() { mlir::PassRegistration<RemPass>(); }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo
+mlirGetPassPluginInfo() {
+  return getFunctionCallCounterPassPluginInfo();
+}

--- a/mlir/test/compiler-course/mironov_a_lab4/test.mlir
+++ b/mlir/test/compiler-course/mironov_a_lab4/test.mlir
@@ -1,0 +1,40 @@
+// RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/rem_pass_Mironov_Arseniy_FIIT1_MLIR%shlibext \
+// RUN: --pass-pipeline="builtin.module(rem_pass_Mironov_Arseniy_FIIT1_MLIR)" %s | FileCheck %s -dump-input=always
+
+// test.cpp
+// unsigned test1(unsigned a, unsigned b) {
+//   unsigned res = a % b;
+//   return res;
+// }
+
+// signed test2(signed a, signed b) {
+//   signed res = a % b;
+//   return res;
+// }
+
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f128, dense<128> : vector<2xi64>>, #dlti.dl_entry<f80, dense<128> : vector<2xi64>>, #dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<i1, dense<8> : vector<2xi64>>, #dlti.dl_entry<i32, dense<32> : vector<2xi64>>, #dlti.dl_entry<i16, dense<16> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr<271>, dense<32> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<272>, dense<64> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<270>, dense<32> : vector<4xi64>>, #dlti.dl_entry<f64, dense<64> : vector<2xi64>>, #dlti.dl_entry<f16, dense<16> : vector<2xi64>>, #dlti.dl_entry<"dlti.stack_alignment", 128 : i64>, #dlti.dl_entry<"dlti.endianness", "little">>} {
+  
+  // CHECK-LABEL: func.func @test1
+  // CHECK: %0 = arith.divui %arg0, %arg1 : i32
+  // CHECK-NEXT: %1 = arith.muli %0, %arg1 : i32
+  // CHECK-NEXT: %2 = arith.subi %arg0, %1 : i32
+  // CHECK-NEXT: return %2 : i32
+
+
+  func.func @test1(%arg0: i32, %arg1: i32) -> i32 attributes {llvm.noundef} {
+    %0 = arith.remui %arg0, %arg1 : i32
+    return %0 : i32
+  }
+
+  // CHECK-LABEL: func.func @test2
+  // CHECK: %0 = arith.divsi %arg0, %arg1 : i32
+  // CHECK-NEXT: %1 = arith.muli %0, %arg1 : i32
+  // CHECK-NEXT: %2 = arith.subi %arg0, %1 : i32
+  // CHECK-NEXT: return %2 : i32
+  
+  func.func @test2(%arg0: i32, %arg1: i32) -> i32 attributes {llvm.noundef} {
+    %0 = arith.remsi %arg0, %arg1 : i32
+    return %0 : i32
+  }
+}

--- a/mlir/test/compiler-course/mironov_a_lab4/test.mlir
+++ b/mlir/test/compiler-course/mironov_a_lab4/test.mlir
@@ -6,15 +6,23 @@
 //   unsigned res = a % b;
 //   return res;
 // }
-
+//
 // signed test2(signed a, signed b) {
 //   signed res = a % b;
 //   return res;
 // }
+//
+// long long test3(long long a, long long b){
+//   long long res = a % b;
+//   return res;
+// }
 
+// unsigned long long test4(unsigned long long a, unsigned long long b){
+//   unsigned long long res = a % b;
+//   return res;
+// }
 
-module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f128, dense<128> : vector<2xi64>>, #dlti.dl_entry<f80, dense<128> : vector<2xi64>>, #dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<i1, dense<8> : vector<2xi64>>, #dlti.dl_entry<i32, dense<32> : vector<2xi64>>, #dlti.dl_entry<i16, dense<16> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr<271>, dense<32> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<272>, dense<64> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<270>, dense<32> : vector<4xi64>>, #dlti.dl_entry<f64, dense<64> : vector<2xi64>>, #dlti.dl_entry<f16, dense<16> : vector<2xi64>>, #dlti.dl_entry<"dlti.stack_alignment", 128 : i64>, #dlti.dl_entry<"dlti.endianness", "little">>} {
-  
+module {
   // CHECK-LABEL: func.func @test1
   // CHECK: %0 = arith.divui %arg0, %arg1 : i32
   // CHECK-NEXT: %1 = arith.muli %0, %arg1 : i32
@@ -36,5 +44,28 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f128, dense<128> 
   func.func @test2(%arg0: i32, %arg1: i32) -> i32 attributes {llvm.noundef} {
     %0 = arith.remsi %arg0, %arg1 : i32
     return %0 : i32
+  }
+
+
+  // CHECK-LABEL: func.func @test3
+  // CHECK: %0 = arith.divsi %arg0, %arg1 : i64
+  // CHECK-NEXT: %1 = arith.muli %0, %arg1 : i64
+  // CHECK-NEXT: %2 = arith.subi %arg0, %1 : i64
+  // CHECK-NEXT: return %2 : i64
+
+  func.func @test3(%arg0: i64, %arg1: i64) -> i64 attributes {llvm.noundef} {
+      %0 = arith.remsi %arg0, %arg1 : i64
+      return %0 : i64
+  }
+
+  // CHECK-LABEL: func.func @test4
+  // CHECK: %0 = arith.divui %arg0, %arg1 : i64
+  // CHECK-NEXT: %1 = arith.muli %0, %arg1 : i64
+  // CHECK-NEXT: %2 = arith.subi %arg0, %1 : i64
+  // CHECK-NEXT: return %2 : i64
+
+  func.func @test4(%arg0: i64, %arg1: i64) -> i64 attributes {llvm.noundef} {
+      %0 = arith.remui %arg0, %arg1 : i64
+      return %0 : i64
   }
 }


### PR DESCRIPTION
Пасс `rem_pass` в MLIR преобразует операции остаточного деления в эквивалентные выражения, используя деление, умножение и вычитание. Он заменяет операции `arith.remui`  и `arith. remsi`на следующее выражение:

 <pre><code>                                          a % b = a - (a / b) * b</code></pre>

### Основные этапы работы пасса:
1. Поиск операций `remui` и `remsi` в исходном MLIR.
2. Замена найденных операций на эквивалентные выражения, состоящие из деления (`divui` или `divsi`), умножения (`muli`) и вычитания (`subi`).
3. Обновление модуля MLIR с результатами преобразования.
