### PR TITLE
Иванов Михаил. Лабортаорная работа 4: MLIR. Вариант 2.

### DIFF
--- a/mlir/compiler-course/ivanov_m_mlir/CMakeLists.txt
+++ b/mlir/compiler-course/ivanov_m_mlir/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(Title "IterCounterPass")
+set(Student "Ivanov_Mikhail")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_MLIR")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    MLIRBuiltinLocationAttributesIncGen
+    BUILDTREE_ONLY
+)
+
+set(MLIR_TEST_DEPENDS ${TARGET_NAME} ${MLIR_TEST_DEPENDS} PARENT_SCOPE)

--- a/mlir/compiler-course/ivanov_m_mlir/ivanov_trip_count.cpp
+++ b/mlir/compiler-course/ivanov_m_mlir/ivanov_trip_count.cpp
@@ -10,13 +10,15 @@
 using namespace mlir;
 
 namespace {
-class IterCounterPass : public PassWrapper<IterCounterPass, OperationPass<ModuleOp>> {
+class IterCounterPass :
+    public PassWrapper<IterCounterPass, OperationPass<ModuleOp>> {
 public:
   StringRef getArgument() const final {
     return "IterCounterPass_Ivanov_Mikhail_FIIT1_MLIR";
   }
   StringRef getDescription() const final {
-    return "Annotate scf.for loops with a 'trip_count' attribute if the number of "
+    return "Annotate scf.for loops with a 'trip_count' attribute if the number "
+           "of "
            "iterations is statically known.";
   }
 
@@ -40,7 +42,7 @@ public:
       auto lbCstIdx = lowerBound.getDefiningOp<arith::ConstantIndexOp>();
       auto ubCstIdx = upperBound.getDefiningOp<arith::ConstantIndexOp>();
       auto stCstIdx = step.getDefiningOp<arith::ConstantIndexOp>();
-      
+
       if (!lbCstIdx || !ubCstIdx || !stCstIdx || stCstIdx.value() == 0) {
         return;
       }
@@ -58,7 +60,7 @@ public:
       }
 
       forOp->setAttr("trip_count",
-        IntegerAttr::get(IndexType::get(ctx), tripCount));
+                     IntegerAttr::get(IndexType::get(ctx), tripCount));
     });
   }
 };

--- a/mlir/compiler-course/ivanov_m_mlir/ivanov_trip_count.cpp
+++ b/mlir/compiler-course/ivanov_m_mlir/ivanov_trip_count.cpp
@@ -10,8 +10,8 @@
 using namespace mlir;
 
 namespace {
-class IterCounterPass :
-    public PassWrapper<IterCounterPass, OperationPass<ModuleOp>> {
+class IterCounterPass
+    : public PassWrapper<IterCounterPass, OperationPass<ModuleOp>> {
 public:
   StringRef getArgument() const final {
     return "IterCounterPass_Ivanov_Mikhail_FIIT1_MLIR";

--- a/mlir/compiler-course/ivanov_m_mlir/ivanov_trip_count.cpp
+++ b/mlir/compiler-course/ivanov_m_mlir/ivanov_trip_count.cpp
@@ -1,0 +1,78 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Tools/Plugins/PassPlugin.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir;
+
+namespace {
+class IterCounterPass : public PassWrapper<IterCounterPass, OperationPass<ModuleOp>> {
+public:
+  StringRef getArgument() const final {
+    return "IterCounterPass_Ivanov_Mikhail_FIIT1_MLIR";
+  }
+  StringRef getDescription() const final {
+    return "Annotate scf.for loops with a 'trip_count' attribute if the number of "
+           "iterations is statically known.";
+  }
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<scf::SCFDialect, arith::ArithDialect>();
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    auto *ctx = module.getContext();
+
+    module.walk([&](scf::ForOp forOp) {
+      if (forOp->hasAttr("trip_count")) {
+        return;
+      }
+
+      auto lowerBound = forOp.getLowerBound();
+      auto upperBound = forOp.getUpperBound();
+      auto step = forOp.getStep();
+
+      auto lbCstIdx = lowerBound.getDefiningOp<arith::ConstantIndexOp>();
+      auto ubCstIdx = upperBound.getDefiningOp<arith::ConstantIndexOp>();
+      auto stCstIdx = step.getDefiningOp<arith::ConstantIndexOp>();
+      
+      if (!lbCstIdx || !ubCstIdx || !stCstIdx || stCstIdx.value() == 0) {
+        return;
+      }
+
+      int64_t lb = lbCstIdx.value();
+      int64_t ub = ubCstIdx.value();
+      int64_t st = stCstIdx.value();
+
+      int64_t tripCount = 0;
+      if (st > 0 && lb < ub) {
+        tripCount = (ub - lb + st - 1) / st;
+      } else if (st < 0 && lb > ub) {
+        int64_t stAbs = -st;
+        tripCount = (lb - ub + stAbs - 1) / stAbs;
+      }
+
+      forOp->setAttr("trip_count",
+        IntegerAttr::get(IndexType::get(ctx), tripCount));
+    });
+  }
+};
+} // namespace
+
+MLIR_DECLARE_EXPLICIT_TYPE_ID(IterCounterPass)
+MLIR_DEFINE_EXPLICIT_TYPE_ID(IterCounterPass)
+
+mlir::PassPluginLibraryInfo getFunctionCallCounterPassPluginInfo() {
+  return {MLIR_PLUGIN_API_VERSION, "IterCounterPass", "1.0",
+          []() { mlir::PassRegistration<IterCounterPass>(); }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo
+mlirGetPassPluginInfo() {
+  return getFunctionCallCounterPassPluginInfo();
+}

--- a/mlir/compiler-course/ivanov_m_mlir/ivanov_trip_count.cpp
+++ b/mlir/compiler-course/ivanov_m_mlir/ivanov_trip_count.cpp
@@ -1,7 +1,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Tools/Plugins/PassPlugin.h"

--- a/mlir/test/compiler-course/ivanov_m_mlir_test/ivanov_trip_count_test.mlir
+++ b/mlir/test/compiler-course/ivanov_m_mlir_test/ivanov_trip_count_test.mlir
@@ -1,0 +1,86 @@
+// RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/IterCounterPass_Ivanov_Mikhail_FIIT1_MLIR%shlibext \
+// RUN: --pass-pipeline="builtin.module(IterCounterPass_Ivanov_Mikhail_FIIT1_MLIR)" %s | FileCheck %s
+
+// case1
+// void loop_inc() {
+//   for (int i = 0; i < 10; ++i)
+// }
+
+// case2
+// void loop_dec() {
+//   for (int i = 9; i > -1; --i)
+// }
+
+// case3
+// void invalid_inc() {
+//   for (int i = 10; i < 0; ++i)
+// }
+
+// case4
+// void zero_step() {
+//   for (int i = 0; i < 10; i += 0)
+// }
+
+module {
+  func.func @loop_inc() {
+    // CHECK-LABEL: func.func @loop_inc()
+    // CHECK:   %c0   = arith.constant 0  : index
+    // CHECK-NEXT:   %c10  = arith.constant 10 : index
+    // CHECK-NEXT:   %c1   = arith.constant 1  : index
+    // CHECK-NEXT:   scf.for %arg0 = %c0 to %c10 step %c1 {
+    // CHECK-NEXT:   } {trip_count = 10 : index}
+    %c0 = arith.constant 0 : index
+    %c10 = arith.constant 10 : index
+    %c1 = arith.constant 1 : index
+    scf.for %arg0 = %c0 to %c10 step %c1 {
+      scf.yield
+    }
+    return
+  }
+
+  func.func @loop_dec() {
+    // CHECK-LABEL: func.func @loop_dec()
+    // CHECK:        %c9    = arith.constant 9  : index
+    // CHECK-NEXT:   %c-1 = arith.constant -1 : index
+    // CHECK-NEXT:   scf.for %arg0 = %c9 to %c-1 step %c-1 {
+    // CHECK-NEXT:   } {trip_count = 10 : index}
+    %c9  = arith.constant 9  : index
+    %cneg1 = arith.constant -1 : index
+    scf.for %arg0 = %c9 to %cneg1 step %cneg1 {
+      scf.yield
+    }
+    return
+  }
+
+  func.func @invalid_inc() {
+    // CHECK-LABEL: func.func @invalid_inc()
+    // CHECK:        %c10 = arith.constant 10 : index
+    // CHECK-NEXT:   %c0  = arith.constant 0  : index
+    // CHECK-NEXT:   %c1  = arith.constant 1  : index
+    // CHECK-NEXT:   scf.for %arg0 = %c10 to %c0 step %c1 {
+    // CHECK-NEXT:   } {trip_count = 0 : index}
+    %c10 = arith.constant 10 : index
+    %c0  = arith.constant 0  : index
+    %c1  = arith.constant 1  : index
+    scf.for %arg0 = %c10 to %c0 step %c1 {
+      scf.yield
+    }
+    return
+  }
+
+  func.func @zero_step() {
+    // CHECK-LABEL: func.func @zero_step()
+    // CHECK:        %c0   = arith.constant 0  : index
+    // CHECK-NEXT:   %c10  = arith.constant 10 : index
+    // CHECK-NEXT:   %c0_0  = arith.constant 0  : index
+    // CHECK-NEXT:   scf.for %arg0 = %c0 to %c10 step %c0_0 {
+    // CHECK-NEXT:   }
+    %c0  = arith.constant 0  : index
+    %c10 = arith.constant 10 : index
+    %c0_0 = arith.constant 0  : index
+    scf.for %arg0 = %c0 to %c10 step %c0_0 {
+      scf.yield
+    }
+    return
+  }
+}

--- a/mlir/test/compiler-course/ivanov_m_mlir_test/ivanov_trip_count_test.mlir
+++ b/mlir/test/compiler-course/ivanov_m_mlir_test/ivanov_trip_count_test.mlir
@@ -1,5 +1,5 @@
 // RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/IterCounterPass_Ivanov_Mikhail_FIIT1_MLIR%shlibext \
-// RUN: --pass-pipeline="builtin.module(IterCounterPass_Ivanov_Mikhail_FIIT1_MLIR)" %s | FileCheck %s
+// RUN: --pass-pipeline="builtin.module(IterCounterPass_Ivanov_Mikhail_FIIT1_MLIR)" %s | FileCheck --match-full-lines %s
 
 // case1
 // void loop_inc() {
@@ -23,10 +23,10 @@
 
 module {
   func.func @loop_inc() {
-    // CHECK-LABEL: func.func @loop_inc()
-    // CHECK:   %c0   = arith.constant 0  : index
-    // CHECK-NEXT:   %c10  = arith.constant 10 : index
-    // CHECK-NEXT:   %c1   = arith.constant 1  : index
+    // CHECK-LABEL:  func.func @loop_inc() {
+    // CHECK:   %c0 = arith.constant 0  : index
+    // CHECK-NEXT:   %c10 = arith.constant 10 : index
+    // CHECK-NEXT:   %c1 = arith.constant 1  : index
     // CHECK-NEXT:   scf.for %arg0 = %c0 to %c10 step %c1 {
     // CHECK-NEXT:   } {trip_count = 10 : index}
     %c0 = arith.constant 0 : index
@@ -39,8 +39,8 @@ module {
   }
 
   func.func @loop_dec() {
-    // CHECK-LABEL: func.func @loop_dec()
-    // CHECK:        %c9    = arith.constant 9  : index
+    // CHECK-LABEL:  func.func @loop_dec() {
+    // CHECK:        %c9  = arith.constant 9  : index
     // CHECK-NEXT:   %c-1 = arith.constant -1 : index
     // CHECK-NEXT:   scf.for %arg0 = %c9 to %c-1 step %c-1 {
     // CHECK-NEXT:   } {trip_count = 10 : index}
@@ -53,7 +53,7 @@ module {
   }
 
   func.func @invalid_inc() {
-    // CHECK-LABEL: func.func @invalid_inc()
+    // CHECK-LABEL: func.func @invalid_inc() {
     // CHECK:        %c10 = arith.constant 10 : index
     // CHECK-NEXT:   %c0  = arith.constant 0  : index
     // CHECK-NEXT:   %c1  = arith.constant 1  : index
@@ -69,10 +69,10 @@ module {
   }
 
   func.func @zero_step() {
-    // CHECK-LABEL: func.func @zero_step()
-    // CHECK:        %c0   = arith.constant 0  : index
-    // CHECK-NEXT:   %c10  = arith.constant 10 : index
-    // CHECK-NEXT:   %c0_0  = arith.constant 0  : index
+    // CHECK-LABEL: func.func @zero_step() {
+    // CHECK:        %c0  = arith.constant 0  : index
+    // CHECK-NEXT:   %c10 = arith.constant 10 : index
+    // CHECK-NEXT:   %c0_0 = arith.constant 0  : index
     // CHECK-NEXT:   scf.for %arg0 = %c0 to %c10 step %c0_0 {
     // CHECK-NEXT:   }
     %c0  = arith.constant 0  : index


### PR DESCRIPTION
Пасс `IterCounterPass` аннотирует циклы `scf.for` и добавляет к нему атрибут `trip_count` типа `IntegerAttr`, который содержит вычисленное алгоритмом число итераций. Атрибут добавляется только в том случае, если верхняя граница, нижняя граница и шаг являются константами `arith.constant`, в том числе обрабатываются ситуации, когда верхняя граница меньше нижней и когда шаг отрицательный. В случаях с шагом `0` атрибут не добавляют. Циклы, условия которых изначально не выполняются добавляют атрибут со значением `trip_count = 0`