### PR TITLE
Седова Ольга. 3822Б1ФИ1. Лабораторная 4. вариант 1

### DIFF
--- a/mlir/compiler-course/sedova_o_lab4/CMakeLists.txt
+++ b/mlir/compiler-course/sedova_o_lab4/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(Title "Lab4")
+set(Title "ExamplePass")
 set(Student "Sedova_Olga")
 set(Group "FIIT1")
 set(TARGET_NAME "${Title}_${Student}_${Group}_MLIR")
@@ -12,5 +12,6 @@ add_llvm_pass_plugin(${TARGET_NAME}
     MLIRBuiltinLocationAttributesIncGen
     BUILDTREE_ONLY
 )
+
 
 set(MLIR_TEST_DEPENDS ${TARGET_NAME} ${MLIR_TEST_DEPENDS} PARENT_SCOPE)

--- a/mlir/compiler-course/sedova_o_lab4/CMakeLists.txt
+++ b/mlir/compiler-course/sedova_o_lab4/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(Title "Lab4")
+set(Student "Sedova_Olga")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_MLIR")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    MLIRBuiltinLocationAttributesIncGen
+    BUILDTREE_ONLY
+)
+
+set(MLIR_TEST_DEPENDS ${TARGET_NAME} ${MLIR_TEST_DEPENDS} PARENT_SCOPE)

--- a/mlir/compiler-course/sedova_o_lab4/ExamplePass.cpp
+++ b/mlir/compiler-course/sedova_o_lab4/ExamplePass.cpp
@@ -51,8 +51,6 @@ struct ExamplePass : public PassWrapper<ExamplePass, OperationPass<ModuleOp>> {
         insertTraceCalls(affineFor, traceBeginFunc, traceEndFunc);
       } else if (auto scfFor = dyn_cast<scf::ForOp>(op)) {
         insertTraceCalls(scfFor, traceBeginFunc, traceEndFunc);
-      } else if (auto scfWhile = dyn_cast<scf::WhileOp>(op)) {
-        insertTraceCalls(scfWhile, traceBeginFunc, traceEndFunc);
       }
     });
   }

--- a/mlir/compiler-course/sedova_o_lab4/ExamplePass.cpp
+++ b/mlir/compiler-course/sedova_o_lab4/ExamplePass.cpp
@@ -6,6 +6,7 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
 #include "mlir/Tools/Plugins/PassPlugin.h"
 #include "llvm/Support/raw_ostream.h"
 

--- a/mlir/compiler-course/sedova_o_lab4/ExamplePass.cpp
+++ b/mlir/compiler-course/sedova_o_lab4/ExamplePass.cpp
@@ -27,7 +27,6 @@ struct ExamplePass : public PassWrapper<ExamplePass, OperationPass<ModuleOp>> {
   void runOnOperation() override {
     ModuleOp module = getOperation();
     OpBuilder builder(module.getContext());
-
     auto traceBeginFunc = module.lookupSymbol<FuncOp>("trace_loop_iter_begin");
     auto traceEndFunc = module.lookupSymbol<FuncOp>("trace_loop_iter_end");
 
@@ -46,12 +45,13 @@ struct ExamplePass : public PassWrapper<ExamplePass, OperationPass<ModuleOp>> {
       module.push_back(traceEndFunc);
       traceEndFunc.setPrivate();
     }
-
     module.walk([&](Operation *op) {
       if (auto affineFor = dyn_cast<affine::AffineForOp>(op)) {
         insertTraceCalls(affineFor, traceBeginFunc, traceEndFunc);
       } else if (auto scfFor = dyn_cast<scf::ForOp>(op)) {
         insertTraceCalls(scfFor, traceBeginFunc, traceEndFunc);
+      } else if (auto scfWhile = dyn_cast<scf::WhileOp>(op)) {
+        insertTraceCalls(scfWhile, traceBeginFunc, traceEndFunc);
       }
     });
   }
@@ -60,29 +60,52 @@ private:
   template <typename LoopOp>
   void insertTraceCalls(LoopOp loopOp, FuncOp traceBeginFunc,
                         FuncOp traceEndFunc) {
-    Block *bodyBlock = loopOp.getBody();
     OpBuilder builder(loopOp.getContext());
 
-    builder.setInsertionPointToStart(bodyBlock);
-    builder.create<func::CallOp>(loopOp.getLoc(), traceBeginFunc,
-                                 ArrayRef<Value>{});
+    if constexpr (std::is_same_v<LoopOp, affine::AffineForOp> ||
+                  std::is_same_v<LoopOp, scf::ForOp>) {
+      Block *bodyBlock = loopOp.getBody();
 
-    builder.setInsertionPoint(bodyBlock->getTerminator());
-    builder.create<func::CallOp>(loopOp.getLoc(), traceEndFunc,
-                                 ArrayRef<Value>{});
+      builder.setInsertionPointToStart(bodyBlock);
+      builder.create<func::CallOp>(loopOp.getLoc(), traceBeginFunc,
+                                   ArrayRef<Value>{});
+
+      builder.setInsertionPoint(bodyBlock->getTerminator());
+      builder.create<func::CallOp>(loopOp.getLoc(), traceEndFunc,
+                                   ArrayRef<Value>{});
+
+    } else if constexpr (std::is_same_v<LoopOp, scf::WhileOp>) {
+      Region &afterRegion = loopOp.getAfter();
+      assert(!afterRegion.empty() && "After region should not be empty");
+      Block &bodyBlockRef = afterRegion.front();
+      Block *bodyBlock = &bodyBlockRef;
+
+      OpBuilder builder(loopOp.getContext());
+
+      builder.setInsertionPointToStart(bodyBlock);
+      builder.create<func::CallOp>(loopOp.getLoc(), traceBeginFunc,
+                                   ArrayRef<Value>{});
+
+      builder.setInsertionPoint(bodyBlock->getTerminator());
+      builder.create<func::CallOp>(loopOp.getLoc(), traceEndFunc,
+                                   ArrayRef<Value>{});
+    }
   }
 };
 
 } // namespace
 
+
 MLIR_DECLARE_EXPLICIT_TYPE_ID(ExamplePass)
 MLIR_DEFINE_EXPLICIT_TYPE_ID(ExamplePass)
+
 
 static mlir::PassPipelineRegistration<>
     pipeline("ExamplePass_Sedova_Olga_FIIT1_MLIR",
              "Pipeline that runs ExamplePass", [](mlir::OpPassManager &pm) {
                pm.addPass(std::make_unique<ExamplePass>());
              });
+
 
 mlir::PassPluginLibraryInfo getTraceLoopIterPassPluginInfo() {
   return {MLIR_PLUGIN_API_VERSION, "ExamplePass_Sedova_Olga_FIIT1_MLIR", "1.0",

--- a/mlir/compiler-course/sedova_o_lab4/ExamplePass.cpp
+++ b/mlir/compiler-course/sedova_o_lab4/ExamplePass.cpp
@@ -77,6 +77,12 @@ private:
 MLIR_DECLARE_EXPLICIT_TYPE_ID(ExamplePass)
 MLIR_DEFINE_EXPLICIT_TYPE_ID(ExamplePass)
 
+static mlir::PassPipelineRegistration<>
+    pipeline("ExamplePass_Sedova_Olga_FIIT1_MLIR",
+             "Pipeline that runs ExamplePass", [](mlir::OpPassManager &pm) {
+               pm.addPass(std::make_unique<ExamplePass>());
+             });
+
 mlir::PassPluginLibraryInfo getTraceLoopIterPassPluginInfo() {
   return {MLIR_PLUGIN_API_VERSION, "ExamplePass_Sedova_Olga_FIIT1_MLIR", "1.0",
           []() { mlir::PassRegistration<ExamplePass>(); }};

--- a/mlir/compiler-course/sedova_o_lab4/ExamplePass.cpp
+++ b/mlir/compiler-course/sedova_o_lab4/ExamplePass.cpp
@@ -95,17 +95,14 @@ private:
 
 } // namespace
 
-
 MLIR_DECLARE_EXPLICIT_TYPE_ID(ExamplePass)
 MLIR_DEFINE_EXPLICIT_TYPE_ID(ExamplePass)
-
 
 static mlir::PassPipelineRegistration<>
     pipeline("ExamplePass_Sedova_Olga_FIIT1_MLIR",
              "Pipeline that runs ExamplePass", [](mlir::OpPassManager &pm) {
                pm.addPass(std::make_unique<ExamplePass>());
              });
-
 
 mlir::PassPluginLibraryInfo getTraceLoopIterPassPluginInfo() {
   return {MLIR_PLUGIN_API_VERSION, "ExamplePass_Sedova_Olga_FIIT1_MLIR", "1.0",

--- a/mlir/compiler-course/sedova_o_lab4/ExamplePass.cpp
+++ b/mlir/compiler-course/sedova_o_lab4/ExamplePass.cpp
@@ -1,0 +1,90 @@
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Tools/Plugins/PassPlugin.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir;
+using namespace mlir::func;
+
+namespace {
+
+struct ExamplePass : public PassWrapper<ExamplePass, OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ExamplePass)
+
+  StringRef getArgument() const final { return "trace-loop-iter"; }
+  StringRef getDescription() const final {
+    return "Insert calls to @trace_loop_iter_begin and @trace_loop_iter_end on "
+           "loop iterations";
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    OpBuilder builder(module.getContext());
+
+    auto traceBeginFunc = module.lookupSymbol<FuncOp>("trace_loop_iter_begin");
+    auto traceEndFunc = module.lookupSymbol<FuncOp>("trace_loop_iter_end");
+
+    if (!traceBeginFunc) {
+      auto loc = builder.getUnknownLoc();
+      auto funcType = builder.getFunctionType({}, {});
+      traceBeginFunc = FuncOp::create(loc, "trace_loop_iter_begin", funcType);
+      module.push_back(traceBeginFunc);
+      traceBeginFunc.setPrivate();
+    }
+
+    if (!traceEndFunc) {
+      auto loc = builder.getUnknownLoc();
+      auto funcType = builder.getFunctionType({}, {});
+      traceEndFunc = FuncOp::create(loc, "trace_loop_iter_end", funcType);
+      module.push_back(traceEndFunc);
+      traceEndFunc.setPrivate();
+    }
+
+    module.walk([&](Operation *op) {
+      if (auto affineFor = dyn_cast<affine::AffineForOp>(op)) {
+        insertTraceCalls(affineFor, traceBeginFunc, traceEndFunc);
+      } else if (auto scfFor = dyn_cast<scf::ForOp>(op)) {
+        insertTraceCalls(scfFor, traceBeginFunc, traceEndFunc);
+      } else if (auto scfWhile = dyn_cast<scf::WhileOp>(op)) {
+        insertTraceCalls(scfWhile, traceBeginFunc, traceEndFunc);
+      }
+    });
+  }
+
+private:
+  template <typename LoopOp>
+  void insertTraceCalls(LoopOp loopOp, FuncOp traceBeginFunc,
+                        FuncOp traceEndFunc) {
+    Block *bodyBlock = loopOp.getBody();
+    OpBuilder builder(loopOp.getContext());
+
+    builder.setInsertionPointToStart(bodyBlock);
+    builder.create<func::CallOp>(loopOp.getLoc(), traceBeginFunc,
+                                 ArrayRef<Value>{});
+
+    builder.setInsertionPoint(bodyBlock->getTerminator());
+    builder.create<func::CallOp>(loopOp.getLoc(), traceEndFunc,
+                                 ArrayRef<Value>{});
+  }
+};
+
+} // namespace
+
+MLIR_DECLARE_EXPLICIT_TYPE_ID(ExamplePass)
+MLIR_DEFINE_EXPLICIT_TYPE_ID(ExamplePass)
+
+mlir::PassPluginLibraryInfo getTraceLoopIterPassPluginInfo() {
+  return {MLIR_PLUGIN_API_VERSION, "ExamplePass_Sedova_Olga_FIIT1_MLIR", "1.0",
+          []() { mlir::PassRegistration<ExamplePass>(); }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo
+mlirGetPassPluginInfo() {
+  return getTraceLoopIterPassPluginInfo();
+}

--- a/mlir/test/compiler-course/sedova_o_lab4/test.mlir
+++ b/mlir/test/compiler-course/sedova_o_lab4/test.mlir
@@ -1,0 +1,67 @@
+// RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/ExamplePass_Sedova_Olga_FIIT1_MLIR%shlibext \
+// RUN: --pass-pipeline="builtin.module(ExamplePass_Sedova_Olga_FIIT1_MLIR)" %s | FileCheck %s
+
+
+// CHECK-LABEL: func @test_affine
+// CHECK: func.call @trace_loop_iter_begin()
+// CHECK: affine.for
+// CHECK: func.call @trace_loop_iter_end()
+
+// CHECK-LABEL: func @test_scf_for
+// CHECK: func.call @trace_loop_iter_begin()
+// CHECK: scf.for
+// CHECK: func.call @trace_loop_iter_end()
+
+// CHECK-LABEL: func @test_scf_while
+// CHECK: func.call @trace_loop_iter_begin()
+// CHECK: scf.while
+// CHECK: func.call @trace_loop_iter_end()
+
+func.func @trace_loop_iter_begin() {
+  return
+}
+
+func.func @trace_loop_iter_end() {
+  return
+}
+
+func.func @test_affine(%arg0: memref<10xf32>) {
+  affine.for %i = 0 to 10 {
+    // trace_loop_iter_begin should be inserted here by the pass
+    %val = affine.load %arg0[%i] : memref<10xf32>
+    // trace_loop_iter_end should be inserted here by the pass
+  }
+  return
+}
+
+func.func @test_scf_for(%arg0: memref<10xf32>) {
+%c0 = arith.constant 0 : index
+%c10 = arith.constant 10 : index
+%c1 = arith.constant 1 : index
+  scf.for %i = %c0 to %c10 step %c1  {
+    // trace_loop_iter_begin should be inserted here by the pass
+    %val = memref.load %arg0[%i] : memref<10xf32>
+    // trace_loop_iter_end should be inserted here by the pass
+  }
+  return
+}
+
+func.func @test_nested_loops(%arg0: memref<10xf32>) {
+  %c0 = arith.constant 0 : index
+  %c5 = arith.constant 5 : index
+  %c10 = arith.constant 10 : index
+  %c1 = arith.constant 1 : index
+
+  affine.for %i = 0 to 5 {
+    // CHECK: func.call @trace_loop_iter_begin()
+    affine.for %j = 0 to 10 {
+      // CHECK: func.call @trace_loop_iter_begin()
+      %val = memref.load %arg0[%j] : memref<10xf32>
+      // CHECK: func.call @trace_loop_iter_end()
+    }
+    // CHECK: func.call @trace_loop_iter_end()
+  }
+  return
+}
+
+

--- a/mlir/test/compiler-course/sedova_o_lab4/test.mlir
+++ b/mlir/test/compiler-course/sedova_o_lab4/test.mlir
@@ -56,3 +56,31 @@ func.func @test_nested_loops(%arg0: memref<10xf32>) {
   }
   return
 }
+
+func.func @test_while_loop(%arg0: memref<10xf32>) {
+  %c0 = arith.constant 0 : index
+  %c0_0 = arith.constant 0 : index
+  %c10 = arith.constant 10 : index
+
+  // CHECK: %{{.*}} = scf.while {{.*}} : (index, index) -> (index, index) {
+  // CHECK-NEXT: %{{.*}} = arith.cmpi slt, %{{.*}}, %{{.*}} : index
+  // CHECK-NEXT: scf.condition(%{{.*}}) %{{.*}}, %{{.*}} : index, index
+  // CHECK-NEXT: } do {
+  // CHECK-NEXT: ^bb0(%{{.*}}: index, %{{.*}}: index):
+  // CHECK-NEXT: func.call @trace_loop_iter_begin()
+  // CHECK-NEXT: %{{.*}} = arith.addi %{{.*}}, %{{.*}} : index
+  // CHECK-NEXT: %{{.*}} = arith.constant 1 : index
+  // CHECK-NEXT: %{{.*}} = arith.addi %{{.*}}, %{{.*}} : index
+  // CHECK-NEXT: func.call @trace_loop_iter_end()
+  scf.while (%iter1 = %c0, %iter2 = %c0_0) : (index, index) -> (index, index) {
+    %cond = arith.cmpi slt, %iter2, %c10 : index
+    scf.condition(%cond) %iter1, %iter2 : index, index
+  } do {
+  ^bb0(%arg1: index, %arg2: index):
+      %arg = arith.addi %arg1, %arg2 : index
+      %c1 = arith.constant 1 : index
+      %new_val = arith.addi %arg2, %c1 : index
+    scf.yield %arg, %new_val : index, index
+  }
+  return
+}

--- a/mlir/test/compiler-course/sedova_o_lab4/test.mlir
+++ b/mlir/test/compiler-course/sedova_o_lab4/test.mlir
@@ -2,14 +2,6 @@
 // RUN: --pass-pipeline="builtin.module(ExamplePass_Sedova_Olga_FIIT1_MLIR)" %s | FileCheck %s
 
 
-// CHECK-LABEL: func @test_affine
-// CHECK: func.call @trace_loop_iter_begin()
-// CHECK: func.call @trace_loop_iter_end()
-
-// CHECK-LABEL: func @test_scf_for
-// CHECK: func.call @trace_loop_iter_begin()
-// CHECK: func.call @trace_loop_iter_end()
-
 func.func @trace_loop_iter_begin() {
   return
 }
@@ -20,9 +12,9 @@ func.func @trace_loop_iter_end() {
 
 func.func @test_affine(%arg0: memref<10xf32>) {
   affine.for %i = 0 to 10 {
-    // trace_loop_iter_begin should be inserted here by the pass
+    // CHECK: func.call @trace_loop_iter_begin()
     %val = affine.load %arg0[%i] : memref<10xf32>
-    // trace_loop_iter_end should be inserted here by the pass
+    // CHECK: func.call @trace_loop_iter_end()
   }
   return
 }
@@ -32,9 +24,9 @@ func.func @test_scf_for(%arg0: memref<10xf32>) {
 %c10 = arith.constant 10 : index
 %c1 = arith.constant 1 : index
   scf.for %i = %c0 to %c10 step %c1  {
-    // trace_loop_iter_begin should be inserted here by the pass
+    // CHECK: func.call @trace_loop_iter_begin()
     %val = memref.load %arg0[%i] : memref<10xf32>
-    // trace_loop_iter_end should be inserted here by the pass
+    // CHECK: func.call @trace_loop_iter_end()
   }
   return
 }

--- a/mlir/test/compiler-course/sedova_o_lab4/test.mlir
+++ b/mlir/test/compiler-course/sedova_o_lab4/test.mlir
@@ -11,22 +11,26 @@ func.func @trace_loop_iter_end() {
 }
 
 func.func @test_affine(%arg0: memref<10xf32>) {
-  affine.for %i = 0 to 10 {
-    // CHECK: func.call @trace_loop_iter_begin()
-    %val = affine.load %arg0[%i] : memref<10xf32>
+  // CHECK: affine.for {{%[a-zA-Z0-9]+}} = 0 to 10
+  // CHECK-NEXT: func.call @trace_loop_iter_begin()
+  affine.for %arg1 = 0 to 10 {
+    %0 = affine.load %arg0[%arg1] : memref<10xf32>
     // CHECK: func.call @trace_loop_iter_end()
+    // CHECK-NEXT: }
   }
   return
 }
 
 func.func @test_scf_for(%arg0: memref<10xf32>) {
-%c0 = arith.constant 0 : index
-%c10 = arith.constant 10 : index
-%c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %c10 = arith.constant 10 : index
+  %c1 = arith.constant 1 : index
+  // CHECK: scf.for {{%[a-zA-Z0-9]+}} = %c0 to %c10 step %c1
+  // CHECK-NEXT: func.call @trace_loop_iter_begin()
   scf.for %i = %c0 to %c10 step %c1  {
-    // CHECK: func.call @trace_loop_iter_begin()
-    %val = memref.load %arg0[%i] : memref<10xf32>
+    %0 = memref.load %arg0[%i] : memref<10xf32>
     // CHECK: func.call @trace_loop_iter_end()
+    // CHECK-NEXT: }
   }
   return
 }
@@ -37,16 +41,18 @@ func.func @test_nested_loops(%arg0: memref<10xf32>) {
   %c10 = arith.constant 10 : index
   %c1 = arith.constant 1 : index
 
+  // CHECK: affine.for {{%[a-zA-Z0-9]+}} = 0 to 5
+  // CHECK-NEXT: func.call @trace_loop_iter_begin()
   affine.for %i = 0 to 5 {
-    // CHECK: func.call @trace_loop_iter_begin()
+    // CHECK: affine.for {{%[a-zA-Z0-9]+}} = 0 to 10
+    // CHECK-NEXT: func.call @trace_loop_iter_begin()
     affine.for %j = 0 to 10 {
-      // CHECK: func.call @trace_loop_iter_begin()
-      %val = memref.load %arg0[%j] : memref<10xf32>
+      %0 = memref.load %arg0[%j] : memref<10xf32>
       // CHECK: func.call @trace_loop_iter_end()
+      // CHECK-NEXT: }
     }
     // CHECK: func.call @trace_loop_iter_end()
+    // CHECK-NEXT: }
   }
   return
 }
-
-

--- a/mlir/test/compiler-course/sedova_o_lab4/test.mlir
+++ b/mlir/test/compiler-course/sedova_o_lab4/test.mlir
@@ -4,17 +4,10 @@
 
 // CHECK-LABEL: func @test_affine
 // CHECK: func.call @trace_loop_iter_begin()
-// CHECK: affine.for
 // CHECK: func.call @trace_loop_iter_end()
 
 // CHECK-LABEL: func @test_scf_for
 // CHECK: func.call @trace_loop_iter_begin()
-// CHECK: scf.for
-// CHECK: func.call @trace_loop_iter_end()
-
-// CHECK-LABEL: func @test_scf_while
-// CHECK: func.call @trace_loop_iter_begin()
-// CHECK: scf.while
 // CHECK: func.call @trace_loop_iter_end()
 
 func.func @trace_loop_iter_begin() {


### PR DESCRIPTION
Добавлен новый MLIR пасс ExamplePass_Sedova_Olga_FIIT1_MLIR, который автоматически вставляет вызовы функций @trace_loop_iter_begin и @trace_loop_iter_end в тела всех циклов в модуле. Пасc поддерживает следующие типы циклов:
-affine.for
-scf.for
Вызовы вставляются в начало тела цикла (перед первой операцией) и непосредственно перед терминатором тела цикла. Это позволяет эффективно трассировать начало и конец каждой итерации цикла, что полезно для профилирования, отладки и инструментирования программ на уровне MLIR.