### PR TITLE
Дрождинов Дмитрий. Лабораторная работа 4: MLIR. Вариант 1.

### DIFF
--- a/mlir/compiler-course/drozhdinov_d/CMakeLists.txt
+++ b/mlir/compiler-course/drozhdinov_d/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(Title "LoopTracePass")
+set(Student "DrozhdinovD")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_MLIR")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    MLIRBuiltinLocationAttributesIncGen
+    BUILDTREE_ONLY
+)
+
+set(MLIR_TEST_DEPENDS ${TARGET_NAME} ${MLIR_TEST_DEPENDS} PARENT_SCOPE)

--- a/mlir/compiler-course/drozhdinov_d/LoopTracePass.cpp
+++ b/mlir/compiler-course/drozhdinov_d/LoopTracePass.cpp
@@ -1,0 +1,80 @@
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Tools/Plugins/PassPlugin.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+class LoopTracePass
+    : public mlir::PassWrapper<LoopTracePass, mlir::OperationPass<mlir::ModuleOp>> {
+public:
+  mlir::StringRef getArgument() const final { return "LoopTracePass"; }
+
+  mlir::StringRef getDescription() const final {
+    return "Insert function calls in begin and end of the cycles";
+  }
+
+  void runOnOperation() override {
+    mlir::ModuleOp module = getOperation();
+    mlir::OpBuilder builder(module.getContext());
+
+    auto declareTraceFunc = [&](mlir::StringRef name) {
+      if (!module.lookupSymbol<mlir::func::FuncOp>(name)) {
+        builder.setInsertionPointToStart(module.getBody());
+        auto func = builder.create<mlir::func::FuncOp>(
+            module.getLoc(), name, builder.getFunctionType({}, {}));
+        func.setSymVisibility("private");
+      }
+    };
+
+    declareTraceFunc("trace_loop_iter_begin");
+    declareTraceFunc("trace_loop_iter_end");
+
+    module.walk([&](mlir::Operation *op) {
+      if (llvm::isa<mlir::scf::ForOp, mlir::scf::WhileOp,
+                    mlir::scf::ParallelOp, mlir::affine::AffineForOp>(op)) {
+        mlir::Location loc = op->getLoc();
+        handleLoopOp(op, loc, builder);
+      }
+    });
+  }
+ private:
+  static void createcalls(mlir::Block &block, mlir::Location loc,
+                                        mlir::OpBuilder &builder) {
+    builder.setInsertionPointToStart(&block);
+    builder.create<mlir::func::CallOp>(loc, "trace_loop_iter_begin", mlir::TypeRange{}, mlir::ValueRange{});
+
+    mlir::Operation *term = block.getTerminator();
+    builder.setInsertionPoint(term);
+    builder.create<mlir::func::CallOp>(loc, "trace_loop_iter_end", mlir::TypeRange{}, mlir::ValueRange{});
+  }
+
+  static void handleLoopOp(mlir::Operation *op, mlir::Location loc, mlir::OpBuilder &builder) {
+    if (auto affineFor = mlir::dyn_cast<mlir::affine::AffineForOp>(op)) {
+      createcalls(*affineFor.getBody(), loc, builder);
+    } else if (auto scfFor = mlir::dyn_cast<mlir::scf::ForOp>(op)) {
+      createcalls(*scfFor.getBody(), loc, builder);
+    } else if (auto scfWhile = mlir::dyn_cast<mlir::scf::WhileOp>(op)) {
+      createcalls(scfWhile.getAfter().front(), loc, builder);
+    }
+  }
+};
+} // namespace
+
+MLIR_DECLARE_EXPLICIT_TYPE_ID(LoopTracePass)
+MLIR_DEFINE_EXPLICIT_TYPE_ID(LoopTracePass)
+
+mlir::PassPluginLibraryInfo getTraceLoopPassPluginInfo() {
+  return {MLIR_PLUGIN_API_VERSION, "LoopTracePass", "1.0",
+          []() { mlir::PassRegistration<LoopTracePass>(); }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo
+mlirGetPassPluginInfo() {
+  return getTraceLoopPassPluginInfo();
+}

--- a/mlir/compiler-course/drozhdinov_d/LoopTracePass.cpp
+++ b/mlir/compiler-course/drozhdinov_d/LoopTracePass.cpp
@@ -10,7 +10,7 @@
 namespace {
 class LoopTracePass : public mlir::PassWrapper<LoopTracePass, mlir::OperationPass<mlir::ModuleOp>> {
 public:
-  mlir::StringRef getArgument() const final override { return "LoopTracePass"; }
+  mlir::StringRef getArgument() const final override { return "LoopTracePass_DrozhdinovD_FIIT1_MLIR"; }
 
   mlir::StringRef getDescription() const final override {
     return "Insert @trace_loop_iter_begin and @trace_loop_iter_end function calls in the start and the end of loops";

--- a/mlir/compiler-course/drozhdinov_d/LoopTracePass.cpp
+++ b/mlir/compiler-course/drozhdinov_d/LoopTracePass.cpp
@@ -1,19 +1,24 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Tools/Plugins/PassPlugin.h"
 
 namespace {
-class LoopTracePass : public mlir::PassWrapper<LoopTracePass, mlir::OperationPass<mlir::ModuleOp>> {
+class LoopTracePass
+    : public mlir::PassWrapper<LoopTracePass,
+                               mlir::OperationPass<mlir::ModuleOp>> {
 public:
-  mlir::StringRef getArgument() const final override { return "LoopTracePass_DrozhdinovD_FIIT1_MLIR"; }
+  mlir::StringRef getArgument() const final override {
+    return "LoopTracePass_DrozhdinovD_FIIT1_MLIR";
+  }
 
   mlir::StringRef getDescription() const final override {
-    return "Insert @trace_loop_iter_begin and @trace_loop_iter_end function calls in the start and the end of loops";
+    return "Insert @trace_loop_iter_begin and @trace_loop_iter_end function "
+           "calls in the start and the end of loops";
   }
 
   void runOnOperation() override {
@@ -35,26 +40,25 @@ public:
 
         builder.setInsertionPointToStart(&block);
         builder.create<mlir::func::CallOp>(
-            op->getLoc(), "trace_loop_iter_begin",
-            mlir::TypeRange{}, mlir::ValueRange{});
+            op->getLoc(), "trace_loop_iter_begin", mlir::TypeRange{},
+            mlir::ValueRange{});
 
         builder.setInsertionPoint(block.getTerminator());
-        builder.create<mlir::func::CallOp>(
-            op->getLoc(), "trace_loop_iter_end",
-            mlir::TypeRange{}, mlir::ValueRange{});
+        builder.create<mlir::func::CallOp>(op->getLoc(), "trace_loop_iter_end",
+                                           mlir::TypeRange{},
+                                           mlir::ValueRange{});
       }
     });
   }
 
 private:
   bool isRecognizedLoop(mlir::Operation *op) {
-    return llvm::isa<mlir::scf::ForOp,
-                     mlir::scf::WhileOp,
-                     mlir::scf::ParallelOp,
-                     mlir::affine::AffineForOp>(op);
+    return llvm::isa<mlir::scf::ForOp, mlir::scf::WhileOp,
+                     mlir::scf::ParallelOp, mlir::affine::AffineForOp>(op);
   }
 
-  void Declarator(mlir::StringRef name, mlir::ModuleOp module, mlir::OpBuilder &builder) {
+  void Declarator(mlir::StringRef name, mlir::ModuleOp module,
+                  mlir::OpBuilder &builder) {
     if (module.lookupSymbol<mlir::func::FuncOp>(name)) {
       return;
     }
@@ -70,12 +74,8 @@ MLIR_DECLARE_EXPLICIT_TYPE_ID(LoopTracePass)
 MLIR_DEFINE_EXPLICIT_TYPE_ID(LoopTracePass)
 
 mlir::PassPluginLibraryInfo getTraceLoopPassPluginInfo() {
-  return {
-    MLIR_PLUGIN_API_VERSION,
-    "LoopTracePass",
-    "1.0",
-    []() { mlir::PassRegistration<LoopTracePass>(); }
-  };
+  return {MLIR_PLUGIN_API_VERSION, "LoopTracePass", "1.0",
+          []() { mlir::PassRegistration<LoopTracePass>(); }};
 }
 
 extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo

--- a/mlir/compiler-course/drozhdinov_d/LoopTracePass.cpp
+++ b/mlir/compiler-course/drozhdinov_d/LoopTracePass.cpp
@@ -1,67 +1,67 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/Operation.h"
-#include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Tools/Plugins/PassPlugin.h"
-#include "llvm/Support/raw_ostream.h"
 
 namespace {
-class LoopTracePass
-    : public mlir::PassWrapper<LoopTracePass, mlir::OperationPass<mlir::ModuleOp>> {
+class LoopTracePass : public mlir::PassWrapper<LoopTracePass, mlir::OperationPass<mlir::ModuleOp>> {
 public:
-  mlir::StringRef getArgument() const final { return "LoopTracePass"; }
+  mlir::StringRef getArgument() const final override { return "LoopTracePass"; }
 
-  mlir::StringRef getDescription() const final {
-    return "Insert function calls in begin and end of the cycles";
+  mlir::StringRef getDescription() const final override {
+    return "Insert @trace_loop_iter_begin and @trace_loop_iter_end function calls in the start and the end of loops";
   }
 
   void runOnOperation() override {
     mlir::ModuleOp module = getOperation();
     mlir::OpBuilder builder(module.getContext());
 
-    auto declareTraceFunc = [&](mlir::StringRef name) {
-      if (!module.lookupSymbol<mlir::func::FuncOp>(name)) {
-        builder.setInsertionPointToStart(module.getBody());
-        auto func = builder.create<mlir::func::FuncOp>(
-            module.getLoc(), name, builder.getFunctionType({}, {}));
-        func.setSymVisibility("private");
-      }
-    };
-
-    declareTraceFunc("trace_loop_iter_begin");
-    declareTraceFunc("trace_loop_iter_end");
+    Declarator("trace_loop_iter_begin", module, builder);
+    Declarator("trace_loop_iter_end", module, builder);
 
     module.walk([&](mlir::Operation *op) {
-      if (llvm::isa<mlir::scf::ForOp, mlir::scf::WhileOp,
-                    mlir::scf::ParallelOp, mlir::affine::AffineForOp>(op)) {
-        mlir::Location loc = op->getLoc();
-        handleLoopOp(op, loc, builder);
+      if (!isRecognizedLoop(op))
+        return;
+
+      for (mlir::Region &region : op->getRegions()) {
+        if (region.empty())
+          continue;
+
+        mlir::Block &block = region.front();
+
+        builder.setInsertionPointToStart(&block);
+        builder.create<mlir::func::CallOp>(
+            op->getLoc(), "trace_loop_iter_begin",
+            mlir::TypeRange{}, mlir::ValueRange{});
+
+        builder.setInsertionPoint(block.getTerminator());
+        builder.create<mlir::func::CallOp>(
+            op->getLoc(), "trace_loop_iter_end",
+            mlir::TypeRange{}, mlir::ValueRange{});
       }
     });
   }
- private:
-  static void createcalls(mlir::Block &block, mlir::Location loc,
-                                        mlir::OpBuilder &builder) {
-    builder.setInsertionPointToStart(&block);
-    builder.create<mlir::func::CallOp>(loc, "trace_loop_iter_begin", mlir::TypeRange{}, mlir::ValueRange{});
 
-    mlir::Operation *term = block.getTerminator();
-    builder.setInsertionPoint(term);
-    builder.create<mlir::func::CallOp>(loc, "trace_loop_iter_end", mlir::TypeRange{}, mlir::ValueRange{});
+private:
+  bool isRecognizedLoop(mlir::Operation *op) {
+    return llvm::isa<mlir::scf::ForOp,
+                     mlir::scf::WhileOp,
+                     mlir::scf::ParallelOp,
+                     mlir::affine::AffineForOp>(op);
   }
 
-  static void handleLoopOp(mlir::Operation *op, mlir::Location loc, mlir::OpBuilder &builder) {
-    if (auto affineFor = mlir::dyn_cast<mlir::affine::AffineForOp>(op)) {
-      createcalls(*affineFor.getBody(), loc, builder);
-    } else if (auto scfFor = mlir::dyn_cast<mlir::scf::ForOp>(op)) {
-      createcalls(*scfFor.getBody(), loc, builder);
-    } else if (auto scfWhile = mlir::dyn_cast<mlir::scf::WhileOp>(op)) {
-      createcalls(scfWhile.getAfter().front(), loc, builder);
+  void Declarator(mlir::StringRef name, mlir::ModuleOp module, mlir::OpBuilder &builder) {
+    if (module.lookupSymbol<mlir::func::FuncOp>(name)) {
+      return;
     }
+    builder.setInsertionPointToStart(module.getBody());
+    auto func = builder.create<mlir::func::FuncOp>(
+        module.getLoc(), name, builder.getFunctionType({}, {}));
+    func.setSymVisibility("private");
   }
 };
 } // namespace
@@ -70,8 +70,12 @@ MLIR_DECLARE_EXPLICIT_TYPE_ID(LoopTracePass)
 MLIR_DEFINE_EXPLICIT_TYPE_ID(LoopTracePass)
 
 mlir::PassPluginLibraryInfo getTraceLoopPassPluginInfo() {
-  return {MLIR_PLUGIN_API_VERSION, "LoopTracePass", "1.0",
-          []() { mlir::PassRegistration<LoopTracePass>(); }};
+  return {
+    MLIR_PLUGIN_API_VERSION,
+    "LoopTracePass",
+    "1.0",
+    []() { mlir::PassRegistration<LoopTracePass>(); }
+  };
 }
 
 extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo

--- a/mlir/test/compiler-course/drozhdinov_d/test.mlir
+++ b/mlir/test/compiler-course/drozhdinov_d/test.mlir
@@ -1,0 +1,41 @@
+// RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/LoopTracePass_DrozhdinovD_FIIT1_MLIR%shlibext \
+// RUN: --pass-pipeline="builtin.module(LoopTracePass)" %s | FileCheck %s
+
+module {
+  // CHECK: func.func private @trace_loop_iter_end()
+  // CHECK-NEXT: func.func private @trace_loop_iter_begin()
+
+  // CHECK-LABEL: func.func @affine_for()
+  // CHECK: func.call @trace_loop_iter_begin() : () -> ()
+  // CHECK-NEXT: %1 = arith.index_cast %arg0 : index to i32
+  // CHECK-NEXT: %2 = arith.addi %arg1, %1 : i32
+  // CHECK-NEXT: func.call @trace_loop_iter_end() : () -> ()
+  func.func @affine_for() -> i32 {
+    %sum_init = arith.constant 0 : i32
+    %result = affine.for %i = 0 to 10 iter_args(%sum_iter = %sum_init) -> i32 {
+      %i_i32 = arith.index_cast %i : index to i32
+      %new_sum = arith.addi %sum_iter, %i_i32 : i32
+      affine.yield %new_sum : i32
+    }
+    return %result : i32
+  }
+  
+  /// CHECK-LABEL: func.func @scf_while(%arg0: index)
+  func.func @scf_while(%arg0: index) {
+    // CHECK:   func.call @trace_loop_iter_begin() : () -> ()
+    // CHECK:   func.call @trace_loop_iter_end() : () -> ()
+    %one   = arith.constant 1 : index
+    %res = scf.while (%i = %arg0) : (index) -> (index) {
+      %limit = arith.constant 10 : index
+      %cond  = arith.cmpi slt, %i, %limit : index
+      scf.condition(%cond) %i : index
+    } do {
+      ^bb0(%i_curr: index):
+        %v   = arith.constant 5 : i32 
+        %inc = arith.addi %i_curr, %one : index
+        scf.yield %inc : index 
+    }
+    return
+  }
+  
+}

--- a/mlir/test/compiler-course/drozhdinov_d/test.mlir
+++ b/mlir/test/compiler-course/drozhdinov_d/test.mlir
@@ -1,5 +1,5 @@
 // RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/LoopTracePass_DrozhdinovD_FIIT1_MLIR%shlibext \
-// RUN: --pass-pipeline="builtin.module(LoopTracePass)" %s | FileCheck %s
+// RUN: --pass-pipeline="builtin.module(LoopTracePass_DrozhdinovD_FIIT1_MLIR)" %s | FileCheck %s
 
 module {
   // CHECK: func.func private @trace_loop_iter_end()

--- a/mlir/test/compiler-course/drozhdinov_d/test.mlir
+++ b/mlir/test/compiler-course/drozhdinov_d/test.mlir
@@ -6,9 +6,10 @@ module {
   // CHECK-NEXT: func.func private @trace_loop_iter_begin()
 
   // CHECK-LABEL: func.func @affine_for()
-  // CHECK: func.call @trace_loop_iter_begin() : () -> ()
-  // CHECK-NEXT: %1 = arith.index_cast %arg0 : index to i32
-  // CHECK-NEXT: %2 = arith.addi %arg1, %1 : i32
+  // CHECK: affine.for
+  // CHECK-NEXT: func.call @trace_loop_iter_begin() : () -> ()
+  // CHECK-NEXT: %1 = arith.index_cast
+  // CHECK-NEXT: %2 = arith.addi
   // CHECK-NEXT: func.call @trace_loop_iter_end() : () -> ()
   func.func @affine_for() -> i32 {
     %sum_init = arith.constant 0 : i32
@@ -19,23 +20,59 @@ module {
     }
     return %result : i32
   }
-  
-  /// CHECK-LABEL: func.func @scf_while(%arg0: index)
+
+  // CHECK-LABEL: func.func @scf_while(
+  // CHECK: func.call @trace_loop_iter_begin() : () -> ()
+  // CHECK-NEXT: %c10 = arith.constant 10 : index
+  // CHECK-NEXT: %1 = arith.cmpi slt, %arg1, %c10 : index
+  // CHECK-NEXT: func.call @trace_loop_iter_end() : () -> ()
+  // CHECK-NEXT: scf.condition(%1) %arg1 : index
+  // CHECK-NEXT: } do {
+  // CHECK-NEXT: ^bb0(%arg1: index):
+  // CHECK-NEXT: func.call @trace_loop_iter_begin() : () -> ()
+  // CHECK-NEXT: %1 = arith.addi %arg1, %c1 : index
+  // CHECK-NEXT: func.call @trace_loop_iter_end() : () -> ()
   func.func @scf_while(%arg0: index) {
-    // CHECK:   func.call @trace_loop_iter_begin() : () -> ()
-    // CHECK:   func.call @trace_loop_iter_end() : () -> ()
-    %one   = arith.constant 1 : index
+    %one = arith.constant 1 : index
     %res = scf.while (%i = %arg0) : (index) -> (index) {
       %limit = arith.constant 10 : index
-      %cond  = arith.cmpi slt, %i, %limit : index
+      %cond = arith.cmpi slt, %i, %limit : index
       scf.condition(%cond) %i : index
     } do {
-      ^bb0(%i_curr: index):
-        %v   = arith.constant 5 : i32 
-        %inc = arith.addi %i_curr, %one : index
-        scf.yield %inc : index 
+    ^bb0(%i_curr: index):
+      %inc = arith.addi %i_curr, %one : index
+      scf.yield %inc : index
     }
     return
   }
-  
+
+  // CHECK-LABEL: func.func @scf_for()
+  // CHECK: scf.for
+  // CHECK-NEXT: func.call @trace_loop_iter_begin() : () -> ()
+  // CHECK-NEXT: %0 = arith.addi
+  // CHECK-NEXT: func.call @trace_loop_iter_end() : () -> ()
+  func.func @scf_for() {
+    %c0 = arith.constant 0 : index
+    %c10 = arith.constant 10 : index
+    %c1 = arith.constant 1 : index
+    scf.for %i = %c0 to %c10 step %c1 {
+      %x = arith.addi %i, %c1 : index
+    }
+    return
+  }
+
+  // CHECK-LABEL: func.func @scf_parallel()
+  // CHECK: scf.parallel
+  // CHECK-NEXT: func.call @trace_loop_iter_begin() : () -> ()
+  // CHECK-NEXT: %0 = arith.addi
+  // CHECK-NEXT: func.call @trace_loop_iter_end() : () -> ()
+  func.func @scf_parallel() {
+    %c0 = arith.constant 0 : index
+    %c10 = arith.constant 10 : index
+    %c1 = arith.constant 1 : index
+    scf.parallel (%i) = (%c0) to (%c10) step (%c1) {
+      %x = arith.addi %i, %c1 : index
+    }
+    return
+  }
 }


### PR DESCRIPTION
`LoopTracePass` встраивает вызовы функций `trace_loop_iter_begin` и `trace_loop_iter_end` в начало и конец циклов соответственно. Если функций нет в модуле на момент запуска пасса, срабатывает `Declarator`, объявляющий их в начале модуля. Поддерживаются циклы видов: `affine.for`, `scf.for`, `scf.while`, `scf.parallel` — проверяются в функции `isRecognizedLoop`.