### PR TITLE
Созонов Илья. Лабораторная работа 4. MLIR. Вариант 1.

### DIFF
--- a/mlir/compiler-course/sozonov_i_trace_loop_iterations/CMakeLists.txt
+++ b/mlir/compiler-course/sozonov_i_trace_loop_iterations/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(Title "TraceLoopIterationsPass")
+set(Student "Sozonov_Ilya")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_MLIR")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    MLIRBuiltinLocationAttributesIncGen
+    BUILDTREE_ONLY
+)
+
+set(MLIR_TEST_DEPENDS ${TARGET_NAME} ${MLIR_TEST_DEPENDS} PARENT_SCOPE)

--- a/mlir/compiler-course/sozonov_i_trace_loop_iterations/TraceLoopIterationsPass.cpp
+++ b/mlir/compiler-course/sozonov_i_trace_loop_iterations/TraceLoopIterationsPass.cpp
@@ -1,0 +1,78 @@
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Tools/Plugins/PassPlugin.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir;
+
+namespace {
+class TraceLoopIterationsPass
+    : public PassWrapper<TraceLoopIterationsPass, OperationPass<ModuleOp>> {
+public:
+  StringRef getArgument() const final {
+    return "TraceLoopIterationsPass_Sozonov_Ilya_FIIT3_MLIR";
+  }
+  StringRef getDescription() const final {
+    return "Insert trace calls at beginning and end of each loop iteration";
+  }
+
+  void runOnOperation() override {
+    ModuleOp moduleOp = getOperation();
+    OpBuilder builder(moduleOp);
+
+    auto ensureFuncDecl = [&](StringRef name) {
+      if (!moduleOp.lookupSymbol<func::FuncOp>(name)) {
+        auto funcType = FunctionType::get(moduleOp.getContext(), {}, {});
+        OpBuilder::InsertionGuard guard(builder);
+        builder.setInsertionPointToStart(moduleOp.getBody());
+        builder.create<func::FuncOp>(moduleOp.getLoc(), name, funcType)
+            .setPrivate();
+      }
+    };
+
+    ensureFuncDecl("trace_loop_iter_begin");
+    ensureFuncDecl("trace_loop_iter_end");
+
+    moduleOp.walk([&](Operation *op) {
+      if (isa<scf::ForOp, scf::WhileOp, affine::AffineForOp>(op)) {
+        auto loc = op->getLoc();
+        OpBuilder builder(op->getContext());
+
+        Region &bodyRegion = op->getRegion(0);
+        if (bodyRegion.empty())
+          return;
+
+        Block &entryBlock = bodyRegion.front();
+        builder.setInsertionPointToStart(&entryBlock);
+        builder.create<func::CallOp>(loc, "trace_loop_iter_begin",
+                                     TypeRange(), ValueRange());
+
+        for (Block &block : bodyRegion) {
+          Operation *terminator = block.getTerminator();
+          builder.setInsertionPoint(terminator);
+          builder.create<func::CallOp>(loc, "trace_loop_iter_end",
+                                       TypeRange(), ValueRange());
+        }
+      }
+    });
+  }
+};
+} // namespace
+
+MLIR_DECLARE_EXPLICIT_TYPE_ID(TraceLoopIterationsPass)
+MLIR_DEFINE_EXPLICIT_TYPE_ID(TraceLoopIterationsPass)
+
+mlir::PassPluginLibraryInfo getFunctionCallCounterPassPluginInfo() {
+  return {MLIR_PLUGIN_API_VERSION, "TraceLoopIterationsPass", "1.0",
+          []() { mlir::PassRegistration<TraceLoopIterationsPass>(); }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo
+mlirGetPassPluginInfo() {
+  return getFunctionCallCounterPassPluginInfo();
+}

--- a/mlir/compiler-course/sozonov_i_trace_loop_iterations/TraceLoopIterationsPass.cpp
+++ b/mlir/compiler-course/sozonov_i_trace_loop_iterations/TraceLoopIterationsPass.cpp
@@ -49,14 +49,14 @@ public:
 
         Block &entryBlock = bodyRegion.front();
         builder.setInsertionPointToStart(&entryBlock);
-        builder.create<func::CallOp>(loc, "trace_loop_iter_begin",
-                                     TypeRange(), ValueRange());
+        builder.create<func::CallOp>(loc, "trace_loop_iter_begin", TypeRange(),
+                                     ValueRange());
 
         for (Block &block : bodyRegion) {
           Operation *terminator = block.getTerminator();
           builder.setInsertionPoint(terminator);
-          builder.create<func::CallOp>(loc, "trace_loop_iter_end",
-                                       TypeRange(), ValueRange());
+          builder.create<func::CallOp>(loc, "trace_loop_iter_end", TypeRange(),
+                                       ValueRange());
         }
       }
     });

--- a/mlir/compiler-course/sozonov_i_trace_loop_iterations/TraceLoopIterationsPass.cpp
+++ b/mlir/compiler-course/sozonov_i_trace_loop_iterations/TraceLoopIterationsPass.cpp
@@ -38,36 +38,30 @@ public:
     ensureFuncDecl("trace_loop_iter_begin");
     ensureFuncDecl("trace_loop_iter_end");
 
+    auto insertTraceCalls = [&](Block &block, Location loc, MLIRContext *ctx) {
+      OpBuilder builder(ctx);
+      builder.setInsertionPointToStart(&block);
+      builder.create<func::CallOp>(loc, "trace_loop_iter_begin", TypeRange(),
+                                   ValueRange());
+
+      builder.setInsertionPoint(block.getTerminator());
+      builder.create<func::CallOp>(loc, "trace_loop_iter_end", TypeRange(),
+                                   ValueRange());
+    };
+
     moduleOp.walk([&](Operation *op) {
       if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
         Region &afterRegion = whileOp.getAfter();
         if (afterRegion.empty())
           return;
-
-        Block &afterBlock = afterRegion.front();
-        OpBuilder builder(op->getContext());
-        builder.setInsertionPointToStart(&afterBlock);
-        builder.create<func::CallOp>(whileOp.getLoc(), "trace_loop_iter_begin",
-                                     TypeRange(), ValueRange());
-
-        builder.setInsertionPoint(afterBlock.getTerminator());
-        builder.create<func::CallOp>(whileOp.getLoc(), "trace_loop_iter_end",
-                                     TypeRange(), ValueRange());
+        insertTraceCalls(afterRegion.front(), whileOp.getLoc(),
+                         op->getContext());
 
       } else if (isa<scf::ForOp, affine::AffineForOp>(op)) {
         Region &bodyRegion = op->getRegion(0);
         if (bodyRegion.empty())
           return;
-
-        Block &entryBlock = bodyRegion.front();
-        OpBuilder builder(op->getContext());
-        builder.setInsertionPointToStart(&entryBlock);
-        builder.create<func::CallOp>(op->getLoc(), "trace_loop_iter_begin",
-                                     TypeRange(), ValueRange());
-
-        builder.setInsertionPoint(entryBlock.getTerminator());
-        builder.create<func::CallOp>(op->getLoc(), "trace_loop_iter_end",
-                                     TypeRange(), ValueRange());
+        insertTraceCalls(bodyRegion.front(), op->getLoc(), op->getContext());
       }
     });
   }

--- a/mlir/compiler-course/sozonov_i_trace_loop_iterations/TraceLoopIterationsPass.cpp
+++ b/mlir/compiler-course/sozonov_i_trace_loop_iterations/TraceLoopIterationsPass.cpp
@@ -39,25 +39,35 @@ public:
     ensureFuncDecl("trace_loop_iter_end");
 
     moduleOp.walk([&](Operation *op) {
-      if (isa<scf::ForOp, scf::WhileOp, affine::AffineForOp>(op)) {
-        auto loc = op->getLoc();
-        OpBuilder builder(op->getContext());
+      if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+        Region &afterRegion = whileOp.getAfter();
+        if (afterRegion.empty())
+          return;
 
+        Block &afterBlock = afterRegion.front();
+        OpBuilder builder(op->getContext());
+        builder.setInsertionPointToStart(&afterBlock);
+        builder.create<func::CallOp>(whileOp.getLoc(), "trace_loop_iter_begin",
+                                     TypeRange(), ValueRange());
+
+        builder.setInsertionPoint(afterBlock.getTerminator());
+        builder.create<func::CallOp>(whileOp.getLoc(), "trace_loop_iter_end",
+                                     TypeRange(), ValueRange());
+
+      } else if (isa<scf::ForOp, affine::AffineForOp>(op)) {
         Region &bodyRegion = op->getRegion(0);
         if (bodyRegion.empty())
           return;
 
         Block &entryBlock = bodyRegion.front();
+        OpBuilder builder(op->getContext());
         builder.setInsertionPointToStart(&entryBlock);
-        builder.create<func::CallOp>(loc, "trace_loop_iter_begin", TypeRange(),
-                                     ValueRange());
+        builder.create<func::CallOp>(op->getLoc(), "trace_loop_iter_begin",
+                                     TypeRange(), ValueRange());
 
-        for (Block &block : bodyRegion) {
-          Operation *terminator = block.getTerminator();
-          builder.setInsertionPoint(terminator);
-          builder.create<func::CallOp>(loc, "trace_loop_iter_end", TypeRange(),
-                                       ValueRange());
-        }
+        builder.setInsertionPoint(entryBlock.getTerminator());
+        builder.create<func::CallOp>(op->getLoc(), "trace_loop_iter_end",
+                                     TypeRange(), ValueRange());
       }
     });
   }

--- a/mlir/test/compiler-course/sozonov_i_trace_loop_iterations/test.mlir
+++ b/mlir/test/compiler-course/sozonov_i_trace_loop_iterations/test.mlir
@@ -26,13 +26,13 @@ func.func @test_scf_while() {
   %init = arith.constant 0 : i32
 
   // CHECK: scf.while
-  // CHECK-NEXT: func.call @trace_loop_iter_begin()
   // CHECK-NEXT: %[[COND:.*]] = arith.cmpi
-  // CHECK-NEXT: func.call @trace_loop_iter_end()
   // CHECK-NEXT: scf.condition(%[[COND]]) %{{.*}} : i32
   // CHECK-NEXT: } do {
   // CHECK-NEXT: ^bb0
+  // CHECK-NEXT: func.call @trace_loop_iter_begin()
   // CHECK-NEXT: %[[INC:.*]] = arith.addi
+  // CHECK-NEXT: func.call @trace_loop_iter_end()
   // CHECK-NEXT: scf.yield %[[INC]] : i32
 
   scf.while (%x = %init) : (i32) -> (i32) {

--- a/mlir/test/compiler-course/sozonov_i_trace_loop_iterations/test.mlir
+++ b/mlir/test/compiler-course/sozonov_i_trace_loop_iterations/test.mlir
@@ -7,8 +7,12 @@ func.func @test_scf_for() {
   %c10 = arith.constant 10 : index
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
-  // CHECK: func.call @trace_loop_iter_begin
-  // CHECK: func.call @trace_loop_iter_end
+
+  // CHECK: scf.for
+  // CHECK-NEXT: func.call @trace_loop_iter_begin
+  // CHECK-NEXT: %[[VAL:.*]] = arith.addi
+  // CHECK-NEXT: func.call @trace_loop_iter_end
+
   scf.for %i = %c0 to %c10 step %c1 {
     %0 = arith.addi %c1, %c2 : index
   }
@@ -21,8 +25,16 @@ func.func @test_scf_while() {
   %c1 = arith.constant 1 : i32
   %init = arith.constant 0 : i32
 
-  // CHECK: func.call @trace_loop_iter_begin
-  // CHECK: func.call @trace_loop_iter_end
+  // CHECK: scf.while
+  // CHECK-NEXT: func.call @trace_loop_iter_begin()
+  // CHECK-NEXT: %[[COND:.*]] = arith.cmpi
+  // CHECK-NEXT: func.call @trace_loop_iter_end()
+  // CHECK-NEXT: scf.condition(%[[COND]]) %{{.*}} : i32
+  // CHECK-NEXT: } do {
+  // CHECK-NEXT: ^bb0
+  // CHECK-NEXT: %[[INC:.*]] = arith.addi
+  // CHECK-NEXT: scf.yield %[[INC]] : i32
+
   scf.while (%x = %init) : (i32) -> (i32) {
     %cond = arith.cmpi slt, %x, %c10 : i32
     scf.condition(%cond) %x : i32
@@ -38,18 +50,50 @@ func.func @test_scf_while() {
 func.func @test_affine_for() {
   %c1 = arith.constant 1 : i32
   %c2 = arith.constant 2 : i32
-  // CHECK: func.call @trace_loop_iter_begin
-  // CHECK: func.call @trace_loop_iter_end
+
+  // CHECK: affine.for
+  // CHECK-NEXT: func.call @trace_loop_iter_begin
+  // CHECK-NEXT: %[[V:.*]] = arith.addi
+  // CHECK-NEXT: func.call @trace_loop_iter_end
+
   affine.for %i = 0 to 10 {
     %v = arith.addi %c1, %c2 : i32
   }
   return
 }
 
+// CHECK-LABEL: func @test_nested_loops
+func.func @test_nested_loops() {
+  %c0 = arith.constant 0 : index
+  %c10 = arith.constant 10 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %ci1 = arith.constant 1 : i32
+  %ci2 = arith.constant 2 : i32
+
+  // CHECK: scf.for
+  // CHECK-NEXT: func.call @trace_loop_iter_begin
+  // CHECK-NEXT: affine.for
+  // CHECK-NEXT: func.call @trace_loop_iter_begin
+  // CHECK-NEXT: %[[V:.*]] = arith.addi
+  // CHECK-NEXT: func.call @trace_loop_iter_end
+  // CHECK-NEXT: }
+  // CHECK-NEXT: func.call @trace_loop_iter_end
+
+  scf.for %i = %c0 to %c10 step %c1 {
+    affine.for %j = 0 to 5 {
+      %v = arith.addi %ci1, %ci2 : i32
+    }
+  }
+  return
+}
+
 // CHECK-LABEL: func @test_no_loops
 func.func @test_no_loops() {
+
   // CHECK-NOT: func.call @trace_loop_iter_begin
   // CHECK-NOT: func.call @trace_loop_iter_end
+
   %c1 = arith.constant 1 : i32
   %c2 = arith.constant 2 : i32
   %v = arith.addi %c1, %c2 : i32

--- a/mlir/test/compiler-course/sozonov_i_trace_loop_iterations/test.mlir
+++ b/mlir/test/compiler-course/sozonov_i_trace_loop_iterations/test.mlir
@@ -1,0 +1,77 @@
+// RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/TraceLoopIterationsPass_Sozonov_Ilya_FIIT3_MLIR%shlibext \
+// RUN: --pass-pipeline="builtin.module(TraceLoopIterationsPass_Sozonov_Ilya_FIIT3_MLIR)" %s | FileCheck %s
+
+// CHECK-LABEL: func @test_scf_for
+func.func @test_scf_for() {
+  %c0 = arith.constant 0 : index
+  %c10 = arith.constant 10 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  // CHECK: func.call @trace_loop_iter_begin
+  // CHECK: func.call @trace_loop_iter_end
+  scf.for %i = %c0 to %c10 step %c1 {
+    %0 = arith.addi %c1, %c2 : index
+  }
+  return
+}
+
+// CHECK-LABEL: func @test_scf_while
+func.func @test_scf_while() {
+  %c10 = arith.constant 10 : i32
+  %c1 = arith.constant 1 : i32
+  %init = arith.constant 0 : i32
+
+  // CHECK: func.call @trace_loop_iter_begin
+  // CHECK: func.call @trace_loop_iter_end
+  scf.while (%x = %init) : (i32) -> (i32) {
+    %cond = arith.cmpi slt, %x, %c10 : i32
+    scf.condition(%cond) %x : i32
+  } do {
+  ^bb0(%x: i32):
+    %inc = arith.addi %x, %c1 : i32
+    scf.yield %inc : i32
+  }
+  return
+}
+
+// CHECK-LABEL: func @test_affine_for
+func.func @test_affine_for() {
+  %c1 = arith.constant 1 : i32
+  %c2 = arith.constant 2 : i32
+  // CHECK: func.call @trace_loop_iter_begin
+  // CHECK: func.call @trace_loop_iter_end
+  affine.for %i = 0 to 10 {
+    %v = arith.addi %c1, %c2 : i32
+  }
+  return
+}
+
+// CHECK-LABEL: func @test_nested_loops
+func.func @test_nested_loops() {
+  %c0 = arith.constant 0 : index
+  %c10 = arith.constant 10 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %ci1 = arith.constant 1 : i32
+  %ci2 = arith.constant 2 : i32
+  // CHECK: func.call @trace_loop_iter_begin
+  // CHECK: func.call @trace_loop_iter_end
+  scf.for %i = %c0 to %c10 step %c1 {
+    // CHECK: func.call @trace_loop_iter_begin
+    // CHECK: func.call @trace_loop_iter_end
+    affine.for %j = 0 to 5 {
+      %v = arith.addi %ci1, %ci2 : i32
+    }
+  }
+  return
+}
+
+// CHECK-LABEL: func @test_no_loops
+func.func @test_no_loops() {
+  // CHECK-NOT: func.call @trace_loop_iter_begin
+  // CHECK-NOT: func.call @trace_loop_iter_end
+  %c1 = arith.constant 1 : i32
+  %c2 = arith.constant 2 : i32
+  %v = arith.addi %c1, %c2 : i32
+  return
+}

--- a/mlir/test/compiler-course/sozonov_i_trace_loop_iterations/test.mlir
+++ b/mlir/test/compiler-course/sozonov_i_trace_loop_iterations/test.mlir
@@ -46,26 +46,6 @@ func.func @test_affine_for() {
   return
 }
 
-// CHECK-LABEL: func @test_nested_loops
-func.func @test_nested_loops() {
-  %c0 = arith.constant 0 : index
-  %c10 = arith.constant 10 : index
-  %c1 = arith.constant 1 : index
-  %c2 = arith.constant 2 : index
-  %ci1 = arith.constant 1 : i32
-  %ci2 = arith.constant 2 : i32
-  // CHECK: func.call @trace_loop_iter_begin
-  // CHECK: func.call @trace_loop_iter_end
-  scf.for %i = %c0 to %c10 step %c1 {
-    // CHECK: func.call @trace_loop_iter_begin
-    // CHECK: func.call @trace_loop_iter_end
-    affine.for %j = 0 to 5 {
-      %v = arith.addi %ci1, %ci2 : i32
-    }
-  }
-  return
-}
-
 // CHECK-LABEL: func @test_no_loops
 func.func @test_no_loops() {
   // CHECK-NOT: func.call @trace_loop_iter_begin


### PR DESCRIPTION
This MLIR transformation pass instruments loops by inserting tracing calls at the beginning and end of each loop iteration. The goal is to support runtime profiling or debugging by capturing entry and exit events for every iteration of supported loop types.

**1. Declaration of Tracing Functions**
The pass ensures that two function declarations - `trace_loop_iter_begin` and `trace_loop_iter_end` - exist in the module. If either is missing, it adds a private, zero-argument, zero-result function definition to the module. These functions serve as hooks for external instrumentation logic.

**2. Traversal of Loop Operations**
The pass walks through all operations in the module, identifying loops of types `scf.for`, `scf.while`, and `affine.for`. These loop types are part of MLIR's structured control flow and affine dialects.

**3. Instrumentation of Loop Body Entry**
For each identified loop, the pass inserts a call to `trace_loop_iter_begin` at the very start of the first block in the loop body. This marks the entry point of every loop iteration.

**4. Instrumentation of Loop Body Exit**
The pass then inserts a call to `trace_loop_iter_end` immediately before the terminator of every block in the loop body. This ensures that the end of each iteration is recorded, regardless of how control exits the body.

**5. Preservation of Program Semantics**
The inserted calls do not interfere with data flow, as they take no arguments and produce no results. This makes them side-effect-only operations that can be safely used for logging or profiling.