### PR TITLE
Ясакова Татьяна. Лабораторная работа 4: MLIR. Вариант 3.

### DIFF
--- a/mlir/compiler-course/yasakova_t_lower_rem_ops/CMakeLists.txt
+++ b/mlir/compiler-course/yasakova_t_lower_rem_ops/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(Title "LowerModOpsPass")
+set(Student "Yasakova_Tanya")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_MLIR")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    MLIRBuiltinLocationAttributesIncGen
+    BUILDTREE_ONLY
+)
+
+set(MLIR_TEST_DEPENDS ${TARGET_NAME} ${MLIR_TEST_DEPENDS} PARENT_SCOPE)

--- a/mlir/compiler-course/yasakova_t_lower_rem_ops/yasakova_t.cpp
+++ b/mlir/compiler-course/yasakova_t_lower_rem_ops/yasakova_t.cpp
@@ -17,6 +17,22 @@ struct ModRewritePattern : public OpRewritePattern<ModOp> {
     Value leftOperand = operation.getLhs();
     Value rightOperand = operation.getRhs();
 
+    // Проверка, если rightOperand - константа 1 или -1
+    if (auto constOp = rightOperand.getDefiningOp<arith::ConstantIntOp>()) {
+      int64_t constValue = constOp.value();
+      if (constValue == 1 || constValue == -1) {
+        // Создаем константу 0 того же типа, что и leftOperand
+        auto intType = leftOperand.getType().dyn_cast<IntegerType>();
+        if (!intType) {
+          return failure();
+        }
+        unsigned bitWidth = intType.getWidth();
+        Value zero = builder.create<arith::ConstantIntOp>(location, 0, bitWidth);
+        builder.replaceOp(operation, zero);
+        return success();
+      }
+    }
+
     Value division = builder.create<DivOp>(location, leftOperand, rightOperand);
     Value multiplication =
         builder.create<arith::MulIOp>(location, division, rightOperand);

--- a/mlir/compiler-course/yasakova_t_lower_rem_ops/yasakova_t.cpp
+++ b/mlir/compiler-course/yasakova_t_lower_rem_ops/yasakova_t.cpp
@@ -17,22 +17,17 @@ struct ModRewritePattern : public OpRewritePattern<ModOp> {
     Value leftOperand = operation.getLhs();
     Value rightOperand = operation.getRhs();
 
-    // Проверка, если rightOperand - константа 1 или -1
-    if (auto constOp = rightOperand.getDefiningOp<arith::ConstantIntOp>()) {
-      int64_t constValue = constOp.value();
-      if (constValue == 1 || constValue == -1) {
-        // Создаем константу 0 того же типа, что и leftOperand
-        auto intType = leftOperand.getType().dyn_cast<IntegerType>();
-        if (!intType) {
-          return failure();
-        }
-        unsigned bitWidth = intType.getWidth();
-        Value zero = builder.create<arith::ConstantIntOp>(location, 0, bitWidth);
+    if (auto constDivisor = rightOperand.getDefiningOp<arith::ConstantIntOp>()) {
+      int64_t divisorValue = constDivisor.value();
+      if (divisorValue == 1 || divisorValue == -1) {
+        // x % 1 = 0 and x % -1 = 0
+        Value zero = builder.create<arith::ConstantIntOp>(location, 0, 
+                                                         rightOperand.getType());
         builder.replaceOp(operation, zero);
         return success();
       }
     }
-
+    
     Value division = builder.create<DivOp>(location, leftOperand, rightOperand);
     Value multiplication =
         builder.create<arith::MulIOp>(location, division, rightOperand);

--- a/mlir/compiler-course/yasakova_t_lower_rem_ops/yasakova_t.cpp
+++ b/mlir/compiler-course/yasakova_t_lower_rem_ops/yasakova_t.cpp
@@ -1,0 +1,66 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Tools/Plugins/PassPlugin.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+
+namespace {
+template <typename ModOp, typename DivOp>
+struct ModRewritePattern : public OpRewritePattern<ModOp> {
+  using OpRewritePattern<ModOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ModOp operation,
+                                PatternRewriter &builder) const override {
+    Location location = operation.getLoc();
+    Value leftOperand = operation.getLhs();
+    Value rightOperand = operation.getRhs();
+
+    Value division = builder.create<DivOp>(location, leftOperand, rightOperand);
+    Value multiplication = builder.create<arith::MulIOp>(location, division, rightOperand);
+    Value result = builder.create<arith::SubIOp>(location, leftOperand, multiplication);
+
+    builder.replaceOp(operation, result);
+    return success();
+  }
+};
+
+using ModSIRewritePattern = ModRewritePattern<arith::RemSIOp, arith::DivSIOp>;
+using ModUIRewritePattern = ModRewritePattern<arith::RemUIOp, arith::DivUIOp>;
+
+class LowerModOpsPass
+    : public PassWrapper<LowerModOpsPass, OperationPass<ModuleOp>> {
+public:
+  StringRef getArgument() const final {
+    return "LowerModOpsPass_Yasakova_Tanya_FIIT2_MLIR";
+  }
+
+  StringRef getDescription() const final {
+    return "Lower arith.rem{si,ui} to arithmetic expressions";
+  }
+
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+    MLIRContext *context = mod.getContext();
+    RewritePatternSet patternSet(context);
+
+    patternSet.add<ModSIRewritePattern, ModUIRewritePattern>(context);
+    (void)applyPatternsAndFoldGreedily(mod, std::move(patternSet));
+  }
+};
+
+} // namespace
+
+MLIR_DECLARE_EXPLICIT_TYPE_ID(LowerModOpsPass)
+MLIR_DEFINE_EXPLICIT_TYPE_ID(LowerModOpsPass)
+
+mlir::PassPluginLibraryInfo getLowerModOpsPassPluginInfo() {
+  return {MLIR_PLUGIN_API_VERSION, "LowerModOpsPass", "1.0",
+          []() { PassRegistration<LowerModOpsPass>(); }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo
+mlirGetPassPluginInfo() {
+  return getLowerModOpsPassPluginInfo();
+}

--- a/mlir/compiler-course/yasakova_t_lower_rem_ops/yasakova_t.cpp
+++ b/mlir/compiler-course/yasakova_t_lower_rem_ops/yasakova_t.cpp
@@ -28,7 +28,6 @@ struct ModRewritePattern : public OpRewritePattern<ModOp> {
         return success();
       }
     }
-    
     Value division = builder.create<DivOp>(location, leftOperand, rightOperand);
     Value multiplication =
         builder.create<arith::MulIOp>(location, division, rightOperand);

--- a/mlir/compiler-course/yasakova_t_lower_rem_ops/yasakova_t.cpp
+++ b/mlir/compiler-course/yasakova_t_lower_rem_ops/yasakova_t.cpp
@@ -17,12 +17,13 @@ struct ModRewritePattern : public OpRewritePattern<ModOp> {
     Value leftOperand = operation.getLhs();
     Value rightOperand = operation.getRhs();
 
-    if (auto constDivisor = rightOperand.getDefiningOp<arith::ConstantIntOp>()) {
+    if (auto constDivisor =
+            rightOperand.getDefiningOp<arith::ConstantIntOp>()) {
       int64_t divisorValue = constDivisor.value();
       if (divisorValue == 1 || divisorValue == -1) {
         // x % 1 = 0 and x % -1 = 0
-        Value zero = builder.create<arith::ConstantIntOp>(location, 0, 
-                                                         rightOperand.getType());
+        Value zero = builder.create<arith::ConstantIntOp>(
+            location, 0, rightOperand.getType());
         builder.replaceOp(operation, zero);
         return success();
       }

--- a/mlir/compiler-course/yasakova_t_lower_rem_ops/yasakova_t.cpp
+++ b/mlir/compiler-course/yasakova_t_lower_rem_ops/yasakova_t.cpp
@@ -18,8 +18,10 @@ struct ModRewritePattern : public OpRewritePattern<ModOp> {
     Value rightOperand = operation.getRhs();
 
     Value division = builder.create<DivOp>(location, leftOperand, rightOperand);
-    Value multiplication = builder.create<arith::MulIOp>(location, division, rightOperand);
-    Value result = builder.create<arith::SubIOp>(location, leftOperand, multiplication);
+    Value multiplication =
+        builder.create<arith::MulIOp>(location, division, rightOperand);
+    Value result =
+        builder.create<arith::SubIOp>(location, leftOperand, multiplication);
 
     builder.replaceOp(operation, result);
     return success();

--- a/mlir/test/compiler-course/yasakova_t_lower_rem_ops/yasakova_t.mlir
+++ b/mlir/test/compiler-course/yasakova_t_lower_rem_ops/yasakova_t.mlir
@@ -40,4 +40,46 @@ module {
     %4 = arith.addi %2, %3 : i32
     return %4 : i32
   }
+
+  // Test 4: Signed remainder with divisor 1
+  // CHECK-LABEL: func.func @test_signed_div1
+  // CHECK-NEXT:     %[[ZERO:.*]] = arith.constant 0 : i32
+  // CHECK-NEXT:     return %[[ZERO]] : i32
+  func.func @test_signed_div1(%a: i32) -> i32 {
+    %c1 = arith.constant 1 : i32
+    %0 = arith.remsi %a, %c1 : i32
+    return %0 : i32
+  }
+
+  // Test 5: Unsigned remainder with divisor -1 (should be treated as unsigned max)
+  // CHECK-LABEL: func.func @test_unsigned_div_max
+  // CHECK-NEXT:     %[[ZERO:.*]] = arith.constant 0 : i32
+  // CHECK-NEXT:     return %[[ZERO]] : i32
+  func.func @test_unsigned_div_max(%a: i32) -> i32 {
+    %cmax = arith.constant -1 : i32
+    %0 = arith.remui %a, %cmax : i32
+    return %0 : i32
+  }
+
+  // Test 6: Mixed cases with constant divisors
+  // CHECK-LABEL: func.func @test_mixed_constants
+  // CHECK-DAG:     %[[ZERO:.*]] = arith.constant 0 : i32
+  // CHECK-DAG:     %[[DIV:.*]] = arith.divsi %arg0, %arg1 : i32
+  // CHECK-DAG:     %[[MUL:.*]] = arith.muli %[[DIV]], %arg1 : i32
+  // CHECK-DAG:     %[[RES:.*]] = arith.subi %arg0, %[[MUL]] : i32
+  // CHECK:         %[[SUM:.*]] = arith.addi %[[ZERO]], %[[RES]] : i32
+  // CHECK:         %[[SUM2:.*]] = arith.addi %[[SUM]], %[[ZERO]] : i32
+  // CHECK:         return %[[SUM2]] : i32
+  func.func @test_mixed_constants(%a: i32, %b: i32) -> i32 {
+    %c1 = arith.constant 1 : i32
+    %cm1 = arith.constant -1 : i32
+    
+    %mod1 = arith.remsi %a, %c1 : i32        // Should be optimized to 0
+    %mod2 = arith.remsi %a, %b : i32          // General case
+    %mod3 = arith.remsi %a, %cm1 : i32        // Should be optimized to 0
+    
+    %sum1 = arith.addi %mod1, %mod2 : i32
+    %sum2 = arith.addi %sum1, %mod3 : i32
+    return %sum2 : i32
+  }
 }

--- a/mlir/test/compiler-course/yasakova_t_lower_rem_ops/yasakova_t.mlir
+++ b/mlir/test/compiler-course/yasakova_t_lower_rem_ops/yasakova_t.mlir
@@ -60,26 +60,4 @@ module {
     %0 = arith.remui %a, %cmax : i32
     return %0 : i32
   }
-
-  // Test 6: Mixed cases with constant divisors
-  // CHECK-LABEL: func.func @test_mixed_constants
-  // CHECK-DAG:     %[[ZERO:.*]] = arith.constant 0 : i32
-  // CHECK-DAG:     %[[DIV:.*]] = arith.divsi %arg0, %arg1 : i32
-  // CHECK-DAG:     %[[MUL:.*]] = arith.muli %[[DIV]], %arg1 : i32
-  // CHECK-DAG:     %[[RES:.*]] = arith.subi %arg0, %[[MUL]] : i32
-  // CHECK:         %[[SUM:.*]] = arith.addi %[[ZERO]], %[[RES]] : i32
-  // CHECK:         %[[SUM2:.*]] = arith.addi %[[SUM]], %[[ZERO]] : i32
-  // CHECK:         return %[[SUM2]] : i32
-  func.func @test_mixed_constants(%a: i32, %b: i32) -> i32 {
-    %c1 = arith.constant 1 : i32
-    %cm1 = arith.constant -1 : i32
-    
-    %mod1 = arith.remsi %a, %c1 : i32        // Should be optimized to 0
-    %mod2 = arith.remsi %a, %b : i32          // General case
-    %mod3 = arith.remsi %a, %cm1 : i32        // Should be optimized to 0
-    
-    %sum1 = arith.addi %mod1, %mod2 : i32
-    %sum2 = arith.addi %sum1, %mod3 : i32
-    return %sum2 : i32
-  }
 }

--- a/mlir/test/compiler-course/yasakova_t_lower_rem_ops/yasakova_t.mlir
+++ b/mlir/test/compiler-course/yasakova_t_lower_rem_ops/yasakova_t.mlir
@@ -1,0 +1,43 @@
+// RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/LowerModOpsPass_Yasakova_Tanya_FIIT2_MLIR%shlibext \
+// RUN: --pass-pipeline="builtin.module(LowerModOpsPass_Yasakova_Tanya_FIIT2_MLIR)" %s | FileCheck %s
+
+module {
+  // Test 1: Signed remainder
+  // CHECK-LABEL: func.func @test_signed
+  // CHECK-NEXT:     %[[DIV:.*]] = arith.divsi %arg0, %arg1 : i32
+  // CHECK-NEXT:     %[[MUL:.*]] = arith.muli %[[DIV]], %arg1 : i32
+  // CHECK-NEXT:     %[[RES:.*]] = arith.subi %arg0, %[[MUL]] : i32
+  // CHECK-NEXT:     return %[[RES]] : i32
+  func.func @test_signed(%a: i32, %b: i32) -> i32 {
+    %0 = arith.remsi %a, %b : i32
+    return %0 : i32
+  }
+
+  // Test 2: Unsigned remainder
+  // CHECK-LABEL: func.func @test_unsigned
+  // CHECK-NEXT:     %[[DIV:.*]] = arith.divui %arg0, %arg1 : i32
+  // CHECK-NEXT:     %[[MUL:.*]] = arith.muli %[[DIV]], %arg1 : i32
+  // CHECK-NEXT:     %[[RES:.*]] = arith.subi %arg0, %[[MUL]] : i32
+  // CHECK-NEXT:     return %[[RES]] : i32
+  func.func @test_unsigned(%x: i32, %y: i32) -> i32 {
+    %1 = arith.remui %x, %y : i32
+    return %1 : i32
+  }
+
+  // Test 3: Two remainders in one function
+  // CHECK-LABEL: func.func @test_both
+  // CHECK-NEXT:     %[[DIV1:.*]] = arith.divsi %arg0, %arg1 : i32
+  // CHECK-NEXT:     %[[MUL1:.*]] = arith.muli %[[DIV1]], %arg1 : i32
+  // CHECK-NEXT:     %[[RES1:.*]] = arith.subi %arg0, %[[MUL1]] : i32
+  // CHECK-NEXT:     %[[DIV2:.*]] = arith.divui %arg0, %arg1 : i32
+  // CHECK-NEXT:     %[[MUL2:.*]] = arith.muli %[[DIV2]], %arg1 : i32
+  // CHECK-NEXT:     %[[RES2:.*]] = arith.subi %arg0, %[[MUL2]] : i32
+  // CHECK-NEXT:     %[[SUM:.*]] = arith.addi %[[RES1]], %[[RES2]] : i32
+  // CHECK-NEXT:     return %[[SUM]] : i32
+  func.func @test_both(%m: i32, %n: i32) -> i32 {
+    %2 = arith.remsi %m, %n : i32
+    %3 = arith.remui %m, %n : i32
+    %4 = arith.addi %2, %3 : i32
+    return %4 : i32
+  }
+}


### PR DESCRIPTION
MLIR-пасс LowerModOpsPass_Yasakova_Tanya_FIIT2_MLIR понижает операции arith.remsi и arith.remui до выражения a - (a // b) * b. Реализован через шаблонный паттерн ModRewritePattern, заменяющий остаток от деления на последовательность деления, умножения и вычитания. Применяется с помощью applyPatternsAndFoldGreedily. Поддерживает знаковые и беззнаковые операции, обеспечивая надёжное преобразование.