### PR TITLE
Коробейников Арсений. Лабораторная работа № 2. LLVM IR. Вариант № 4

### DIFF
--- a/llvm/compiler-course/llvm-ir/korobeinikov_a_llvm_ir/CMakeLists.txt
+++ b/llvm/compiler-course/llvm-ir/korobeinikov_a_llvm_ir/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(Title "DivToShiftPass")
+set(Student "Korobeinikov_Arseny")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_LLVM_IR")
+
+if (NOT WIN32 AND NOT CYGWIN)
+    file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+    add_llvm_pass_plugin(${TARGET_NAME} ${SOURCES}
+        DEPENDS
+        intrinsics_gen
+        BUILDTREE_ONLY
+    )
+    set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)
+endif()

--- a/llvm/compiler-course/llvm-ir/korobeinikov_a_llvm_ir/korobeinikov_div_opt_pass.cpp
+++ b/llvm/compiler-course/llvm-ir/korobeinikov_a_llvm_ir/korobeinikov_div_opt_pass.cpp
@@ -13,9 +13,8 @@ bool replaceDivWithShift(Function &F) {
   bool modified = false;
 
   for (auto &BB : F) {
-    for (auto it = BB.begin(), end = BB.end(); it != end;) {
-      Instruction *inst = &*it++;
-      auto *divInst = dyn_cast<BinaryOperator>(inst);
+    for (auto &inst : llvm::make_early_inc_range(BB)) {
+      auto *divInst = dyn_cast<BinaryOperator>(&inst);
       if (!divInst)
         continue;
 
@@ -42,6 +41,7 @@ bool replaceDivWithShift(Function &F) {
       } else if (divisorValue.abs().isPowerOf2()) {
         if (opcode == Instruction::UDiv && divisorValue.isNegative())
           continue;
+
         uint64_t shiftAmount = divisorValue.abs().exactLogBase2();
         Value *shift = nullptr;
 

--- a/llvm/compiler-course/llvm-ir/korobeinikov_a_llvm_ir/korobeinikov_div_opt_pass.cpp
+++ b/llvm/compiler-course/llvm-ir/korobeinikov_a_llvm_ir/korobeinikov_div_opt_pass.cpp
@@ -1,0 +1,100 @@
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+
+namespace {
+
+bool replaceDivWithShift(Function &F) {
+  bool modified = false;
+
+  for (auto &BB : F) {
+    for (auto it = BB.begin(), end = BB.end(); it != end;) {
+      Instruction *inst = &*it++;
+      auto *divInst = dyn_cast<BinaryOperator>(inst);
+      if (!divInst)
+        continue;
+
+      unsigned opcode = divInst->getOpcode();
+      if (opcode != Instruction::SDiv && opcode != Instruction::UDiv)
+        continue;
+
+      auto *constDivisor = dyn_cast<ConstantInt>(divInst->getOperand(1));
+      if (!constDivisor)
+        continue;
+
+      const APInt &divisorValue = constDivisor->getValue();
+      if (divisorValue.isZero())
+        continue;
+
+      IRBuilder<> builder(divInst);
+      Value *dividend = divInst->getOperand(0);
+      Value *replacement = nullptr;
+
+      if (divisorValue.isOne()) {
+        replacement = dividend;
+      } else if (divisorValue.isAllOnes() && opcode == Instruction::SDiv) {
+        replacement = builder.CreateNeg(dividend);
+      } else if (divisorValue.abs().isPowerOf2()) {
+        if (opcode == Instruction::UDiv && divisorValue.isNegative())
+          continue;
+        uint64_t shiftAmount = divisorValue.abs().exactLogBase2();
+        Value *shift = nullptr;
+
+        if (opcode == Instruction::SDiv) {
+          shift = builder.CreateAShr(
+              dividend, ConstantInt::get(constDivisor->getType(), shiftAmount));
+        } else {
+          shift = builder.CreateLShr(
+              dividend, ConstantInt::get(constDivisor->getType(), shiftAmount));
+        }
+
+        if (divisorValue.isNegative()) {
+          replacement = builder.CreateNeg(shift);
+        } else {
+          replacement = shift;
+        }
+      }
+
+      if (replacement) {
+        divInst->replaceAllUsesWith(replacement);
+        divInst->eraseFromParent();
+        modified = true;
+      }
+    }
+  }
+
+  return modified;
+}
+
+struct DivToShiftPass : PassInfoMixin<DivToShiftPass> {
+  PreservedAnalyses run(Function &F, FunctionAnalysisManager &) {
+    bool changed = replaceDivWithShift(F);
+    return changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+  }
+
+  static bool isRequired() { return true; }
+};
+
+} // namespace
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION,
+          "DivToShiftPass_Korobeinikov_Arseny_FIIT1_LLVM_IR", "1.0",
+          [](PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](StringRef name, FunctionPassManager &FPM,
+                   ArrayRef<PassBuilder::PipelineElement>) {
+                  if (name == "div-to-shift") {
+                    FPM.addPass(DivToShiftPass());
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}

--- a/llvm/test/compiler-course/korobeinikov_a_llvm_ir_test/korobeinikov_a_llvm_ir_test.ll
+++ b/llvm/test/compiler-course/korobeinikov_a_llvm_ir_test/korobeinikov_a_llvm_ir_test.ll
@@ -1,6 +1,6 @@
 ; RUN: opt -load-pass-plugin %llvmshlibdir/DivToShiftPass_Korobeinikov_Arseny_FIIT1_LLVM_IR%pluginext -passes=div-to-shift -S %s | FileCheck %s
 
-; Проверка i32, 8 степень двойки, должны поменять на сдвиг
+; Проверка знаковый i32, 8 степень двойки, должны поменять на сдвиг
 ; CHECK-LABEL: @test_div_by_8
 ; CHECK-NEXT: ashr i32 %x, 3
 define i32 @test_div_by_8(i32 %x) {
@@ -8,6 +8,7 @@ define i32 @test_div_by_8(i32 %x) {
   ret i32 %div
 }
 
+; Проверка знаковый i32, -4 степень двойки, должны поменять на сдвиг и вычесть из нуля
 ; CHECK-LABEL: @test_div_by_neg4
 ; CHECK-NEXT: ashr i32 %x, 2
 ; CHECK-NEXT: sub i32 0, %{{.*}}
@@ -16,6 +17,7 @@ define i32 @test_div_by_neg4(i32 %x) {
   ret i32 %div
 }
 
+; Проверка беззнаковый i32, 16 степень двойки, должны поменять на сдвиг
 ; CHECK-LABEL: @test_udiv_by_16
 ; CHECK-NEXT: lshr i32 %x, 4
 define i32 @test_udiv_by_16(i32 %x) {
@@ -23,6 +25,7 @@ define i32 @test_udiv_by_16(i32 %x) {
   ret i32 %div
 }
 
+; Проверка знаковый i32, 3 не степень двойки, ничего не меняем
 ; CHECK-LABEL: @test_div_by_3
 ; CHECK-NEXT: sdiv i32 %x, 3
 define i32 @test_div_by_3(i32 %x) {
@@ -30,6 +33,7 @@ define i32 @test_div_by_3(i32 %x) {
   ret i32 %div
 }
 
+; Проверка знаковый i32, 1 возвращаем само число
 ; CHECK-LABEL: @test_div_by_1
 ; CHECK-NEXT: ret i32 %x
 define i32 @test_div_by_1(i32 %x) {
@@ -37,6 +41,7 @@ define i32 @test_div_by_1(i32 %x) {
   ret i32 %div
 }
 
+; Проверка знаковый i32, -1 возвращаем само число с другим знаком
 ; CHECK-LABEL: @test_div_by_minus1
 ; CHECK-NEXT: sub i32 0, %x
 define i32 @test_div_by_minus1(i32 %x) {
@@ -44,6 +49,7 @@ define i32 @test_div_by_minus1(i32 %x) {
   ret i32 %div
 }
 
+; Проверка знаковый i32, 0 ничего не меняем
 ; CHECK-LABEL: @test_div_by_0
 ; CHECK-NEXT: sdiv i32 %x, 0
 define i32 @test_div_by_0(i32 %x) {
@@ -51,6 +57,7 @@ define i32 @test_div_by_0(i32 %x) {
   ret i32 %div
 }
 
+; Проверка миксуем операции, смотрим что отрабатывает корректно на нескольких операциях
 ; CHECK-LABEL: @test_mixed_sequence
 ; CHECK: ashr i32 %x, 2
 ; CHECK: sdiv i32 %x, 6

--- a/llvm/test/compiler-course/korobeinikov_a_llvm_ir_test/korobeinikov_a_llvm_ir_test.ll
+++ b/llvm/test/compiler-course/korobeinikov_a_llvm_ir_test/korobeinikov_a_llvm_ir_test.ll
@@ -1,0 +1,82 @@
+; RUN: opt -load-pass-plugin %llvmshlibdir/DivToShiftPass_Korobeinikov_Arseny_FIIT1_LLVM_IR%pluginext -passes=div-to-shift -S %s | FileCheck %s
+
+; Проверка i32, 8 степень двойки, должны поменять на сдвиг
+; CHECK-LABEL: @test_div_by_8
+; CHECK-NEXT: ashr i32 %x, 3
+define i32 @test_div_by_8(i32 %x) {
+  %div = sdiv i32 %x, 8
+  ret i32 %div
+}
+
+; CHECK-LABEL: @test_div_by_neg4
+; CHECK-NEXT: ashr i32 %x, 2
+; CHECK-NEXT: sub i32 0, %{{.*}}
+define i32 @test_div_by_neg4(i32 %x) {
+  %div = sdiv i32 %x, -4
+  ret i32 %div
+}
+
+; CHECK-LABEL: @test_udiv_by_16
+; CHECK-NEXT: lshr i32 %x, 4
+define i32 @test_udiv_by_16(i32 %x) {
+  %div = udiv i32 %x, 16
+  ret i32 %div
+}
+
+; CHECK-LABEL: @test_div_by_3
+; CHECK-NEXT: sdiv i32 %x, 3
+define i32 @test_div_by_3(i32 %x) {
+  %div = sdiv i32 %x, 3
+  ret i32 %div
+}
+
+; CHECK-LABEL: @test_div_by_1
+; CHECK-NEXT: ret i32 %x
+define i32 @test_div_by_1(i32 %x) {
+  %div = sdiv i32 %x, 1
+  ret i32 %div
+}
+
+; CHECK-LABEL: @test_div_by_minus1
+; CHECK-NEXT: sub i32 0, %x
+define i32 @test_div_by_minus1(i32 %x) {
+  %div = sdiv i32 %x, -1
+  ret i32 %div
+}
+
+; CHECK-LABEL: @test_div_by_0
+; CHECK-NEXT: sdiv i32 %x, 0
+define i32 @test_div_by_0(i32 %x) {
+  %div = sdiv i32 %x, 0
+  ret i32 %div
+}
+
+; CHECK-LABEL: @test_mixed_sequence
+; CHECK: ashr i32 %x, 2
+; CHECK: sdiv i32 %x, 6
+; CHECK: lshr i32 %x, 3
+define i32 @test_mixed_sequence(i32 %x) {
+  %div1 = sdiv i32 %x, 4
+  %div2 = sdiv i32 %x, 6
+  %div3 = udiv i32 %x, 8
+  %sum1 = add i32 %div1, %div2
+  %sum2 = add i32 %sum1, %div3
+  ret i32 %sum2
+}
+
+; Проверка работы с i64
+; CHECK-LABEL: @test_i64_div_by_8
+; CHECK-NEXT: ashr i64 %x, 3
+define i64 @test_i64_div_by_8(i64 %x) {
+  %div = sdiv i64 %x, 8
+  ret i64 %div
+}
+
+; Проверка деления на -1 (i64)
+; CHECK-LABEL: @test_i64_div_by_neg1
+; CHECK-NEXT: sub i64 0, %x
+define i64 @test_i64_div_by_neg1(i64 %x) {
+  %div = sdiv i64 %x, -1
+  ret i64 %div
+}
+


### PR DESCRIPTION
Этот pass реализует следующую оптимизацию: заменяет инструкции sdiv и udiv на деление константного делителя (если он является степенью двойки) на эквивалентные побитовые сдвиги.
Оптимизируются случаи:
x / 2^n -> x >> n (для знаковых и беззнаковых делений)
x / -2^n -> - (x >> n) (только для знаковых делений)
x / 1 -> x
x / -1 -> -x (только sdiv)
Не затрагиваются:
Деление на переменные
Деление на ноль
udiv на отрицательные значения (например, -1, т.к. невалидный use-case)