### PR TITLE
Соловьев Данила. Лабораторная работа 4: MLIR. Вариант 2.

### DIFF
--- a/mlir/compiler-course/solovyev_d_trip_count/CMakeLists.txt
+++ b/mlir/compiler-course/solovyev_d_trip_count/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(Title "TripCountPass")
+set(Student "Solovyev_Danila")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_MLIR")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    MLIRBuiltinLocationAttributesIncGen
+    BUILDTREE_ONLY
+)
+
+set(MLIR_TEST_DEPENDS ${TARGET_NAME} ${MLIR_TEST_DEPENDS} PARENT_SCOPE)

--- a/mlir/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_pass.cpp
+++ b/mlir/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_pass.cpp
@@ -8,6 +8,9 @@
 using namespace mlir;
 
 namespace {
+bool sameSign(int64_t a, int64_t b) {
+  return (a > 0 && b > 0) || (a < 0 && b < 0);
+}
 class TripCountPass
     : public PassWrapper<TripCountPass, OperationPass<ModuleOp>> {
 public:
@@ -35,8 +38,8 @@ public:
       auto stepConst =
           dyn_cast_or_null<arith::ConstantIndexOp>(step.getDefiningOp());
       if (lowerConst && upperConst && stepConst && stepConst.value()) {
-        if ((upperConst.value() - lowerConst.value()) * stepConst.value() >=
-            0) {
+        if (sameSign((upperConst.value() - lowerConst.value()),
+                     stepConst.value())) {
           int64_t tripCount =
               (std::abs(upperConst.value() - lowerConst.value()) +
                std::abs(stepConst.value()) - 1) /

--- a/mlir/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_pass.cpp
+++ b/mlir/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_pass.cpp
@@ -17,7 +17,7 @@ public:
 
   StringRef getDescription() const final {
     return "Annotate scf.for loops with an attribute \"trip_count\" that "
-               "represents amount of iteration.";
+           "represents amount of iteration.";
   }
 
   void runOnOperation() override {

--- a/mlir/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_pass.cpp
+++ b/mlir/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_pass.cpp
@@ -8,35 +8,41 @@
 using namespace mlir;
 
 namespace {
-class TripCountPass : public PassWrapper<TripCountPass, OperationPass<ModuleOp>> {
+class TripCountPass
+    : public PassWrapper<TripCountPass, OperationPass<ModuleOp>> {
 public:
   StringRef getArgument() const final {
     return "TripCountPass_Solovyev_Danila_FIIT3_MLIR";
   }
 
   StringRef getDescription() const final {
-    return "Annotate scf.for loops with an attribute \"trip_count\" that represents amount of iteration.";
+    return "Annotate scf.for loops with an attribute \"trip_count\" that "
+               "represents amount of iteration.";
   }
 
-    void runOnOperation() override {
-      ModuleOp moduleOp = getOperation();
-      OpBuilder builder(moduleOp);
-      moduleOp.walk([&](scf::ForOp forOp) {
-        auto lower = forOp.getLowerBound();
-        auto upper = forOp.getUpperBound();
-        auto step = forOp.getStep();
+  void runOnOperation() override {
+    ModuleOp moduleOp = getOperation();
+    OpBuilder builder(moduleOp);
+    moduleOp.walk([&](scf::ForOp forOp) {
+      auto lower = forOp.getLowerBound();
+      auto upper = forOp.getUpperBound();
+      auto step = forOp.getStep();
 
-        auto lowerConst = dyn_cast_or_null<arith::ConstantIndexOp>(lower.getDefiningOp());
-        auto upperConst = dyn_cast_or_null<arith::ConstantIndexOp>(upper.getDefiningOp());
-        auto stepConst = dyn_cast_or_null<arith::ConstantIndexOp>(step.getDefiningOp());
+      auto lowerConst =
+          dyn_cast_or_null<arith::ConstantIndexOp>(lower.getDefiningOp());
+      auto upperConst =
+          dyn_cast_or_null<arith::ConstantIndexOp>(upper.getDefiningOp());
+      auto stepConst =
+          dyn_cast_or_null<arith::ConstantIndexOp>(step.getDefiningOp());
 
-        if (lowerConst && upperConst && stepConst){
-          int64_t tripCount = (upperConst.value() - lowerConst.value()) / stepConst.value();
-          builder.setInsertionPoint(forOp);
-          forOp->setAttr("trip_count", builder.getI64IntegerAttr(tripCount));
-        }
-      });
-    }
+      if (lowerConst && upperConst && stepConst) {
+        int64_t tripCount =
+            (upperConst.value() - lowerConst.value()) / stepConst.value();
+        builder.setInsertionPoint(forOp);
+        forOp->setAttr("trip_count", builder.getI64IntegerAttr(tripCount));
+      }
+    });
+  }
 };
 } // namespace
 

--- a/mlir/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_pass.cpp
+++ b/mlir/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_pass.cpp
@@ -38,7 +38,9 @@ public:
         if ((upperConst.value() - lowerConst.value()) * stepConst.value() >=
             0) {
           int64_t tripCount =
-              (upperConst.value() - lowerConst.value()) / stepConst.value();
+              (std::abs(upperConst.value() - lowerConst.value()) +
+               std::abs(stepConst.value()) - 1) /
+              std::abs(stepConst.value());
           builder.setInsertionPoint(forOp);
           forOp->setAttr("trip_count", builder.getI64IntegerAttr(tripCount));
         }

--- a/mlir/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_pass.cpp
+++ b/mlir/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_pass.cpp
@@ -34,10 +34,9 @@ public:
           dyn_cast_or_null<arith::ConstantIndexOp>(upper.getDefiningOp());
       auto stepConst =
           dyn_cast_or_null<arith::ConstantIndexOp>(step.getDefiningOp());
-
-      if (lowerConst && upperConst && stepConst) {
+      if (lowerConst && upperConst && stepConst && stepConst.value()) {
         int64_t tripCount =
-            (upperConst.value() - lowerConst.value()) / stepConst.value();
+            std::abs(upperConst.value() - lowerConst.value()) / stepConst.value();
         builder.setInsertionPoint(forOp);
         forOp->setAttr("trip_count", builder.getI64IntegerAttr(tripCount));
       }

--- a/mlir/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_pass.cpp
+++ b/mlir/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_pass.cpp
@@ -1,0 +1,54 @@
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Tools/Plugins/PassPlugin.h"
+
+using namespace mlir;
+
+namespace {
+class TripCountPass : public PassWrapper<TripCountPass, OperationPass<ModuleOp>> {
+public:
+  StringRef getArgument() const final {
+    return "TripCountPass_Solovyev_Danila_FIIT3_MLIR";
+  }
+
+  StringRef getDescription() const final {
+    return "Annotate scf.for loops with an attribute \"trip_count\" that represents amount of iteration.";
+  }
+
+    void runOnOperation() override {
+      ModuleOp moduleOp = getOperation();
+      OpBuilder builder(moduleOp);
+      moduleOp.walk([&](scf::ForOp forOp) {
+        auto lower = forOp.getLowerBound();
+        auto upper = forOp.getUpperBound();
+        auto step = forOp.getStep();
+
+        auto lowerConst = dyn_cast_or_null<arith::ConstantIndexOp>(lower.getDefiningOp());
+        auto upperConst = dyn_cast_or_null<arith::ConstantIndexOp>(upper.getDefiningOp());
+        auto stepConst = dyn_cast_or_null<arith::ConstantIndexOp>(step.getDefiningOp());
+
+        if (lowerConst && upperConst && stepConst){
+          int64_t tripCount = (upperConst.value() - lowerConst.value()) / stepConst.value();
+          builder.setInsertionPoint(forOp);
+          forOp->setAttr("trip_count", builder.getI64IntegerAttr(tripCount));
+        }
+      });
+    }
+};
+} // namespace
+
+MLIR_DECLARE_EXPLICIT_TYPE_ID(TripCountPass)
+MLIR_DEFINE_EXPLICIT_TYPE_ID(TripCountPass)
+
+mlir::PassPluginLibraryInfo getFunctionCallCounterPassPluginInfo() {
+  return {MLIR_PLUGIN_API_VERSION, "TripCountPass", "1.0",
+          []() { PassRegistration<TripCountPass>(); }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo
+mlirGetPassPluginInfo() {
+  return getFunctionCallCounterPassPluginInfo();
+}

--- a/mlir/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_pass.cpp
+++ b/mlir/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_pass.cpp
@@ -35,10 +35,13 @@ public:
       auto stepConst =
           dyn_cast_or_null<arith::ConstantIndexOp>(step.getDefiningOp());
       if (lowerConst && upperConst && stepConst && stepConst.value()) {
-        int64_t tripCount =
-            std::abs(upperConst.value() - lowerConst.value()) / stepConst.value();
-        builder.setInsertionPoint(forOp);
-        forOp->setAttr("trip_count", builder.getI64IntegerAttr(tripCount));
+        if ((upperConst.value() - lowerConst.value()) * stepConst.value() >=
+            0) {
+          int64_t tripCount =
+              (upperConst.value() - lowerConst.value()) / stepConst.value();
+          builder.setInsertionPoint(forOp);
+          forOp->setAttr("trip_count", builder.getI64IntegerAttr(tripCount));
+        }
       }
     });
   }

--- a/mlir/test/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_test.mlir
+++ b/mlir/test/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_test.mlir
@@ -81,9 +81,9 @@ func.func @baz() {
 func.func @foobaz() {
   %c0 = arith.constant 0 : index
   %c5 = arith.constant 4611686018427387904 : index
-  %c1 = arith.constant 128 : index
+  %c1 = arith.constant -128 : index
   // CHECK: scf.for
-  // CHECK-NEXT: {trip_count = 36028797018963968 : i64}
+  // CHECK-NOT: trip_count
   scf.for %i = %c0 to %c5 step %c1 {
   }
   return

--- a/mlir/test/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_test.mlir
+++ b/mlir/test/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_test.mlir
@@ -18,7 +18,7 @@ func.func @bar() {
   %c12 = arith.constant 17 : index
   %c2_step = arith.constant 2 : index
   // CHECK: scf.for
-  // CHECK-NEXT: {trip_count = 7 : i64}
+  // CHECK-NEXT: {trip_count = 8 : i64}
   scf.for %i = %c2 to %c12 step %c2_step {
   }
   return
@@ -26,7 +26,7 @@ func.func @bar() {
 
 func.func @foobar(%arg0: index) {
   %c10 = arith.constant 10 : index
-  %c1 = arith.constant 1 : index
+  %c1 = arith.constant 1 : index  
   // CHECK: scf.for
   // CHECK-NOT: trip_count
   scf.for %i = %arg0 to %c10 step %c1 {
@@ -73,6 +73,17 @@ func.func @baz() {
   %c1 = arith.constant -1 : index
   // CHECK: scf.for
   // CHECK-NEXT: {trip_count = 4 : i64}
+  scf.for %i = %c0 to %c5 step %c1 {
+  }
+  return
+}
+
+func.func @foobaz() {
+  %c0 = arith.constant 0 : index
+  %c5 = arith.constant 4611686018427387904 : index
+  %c1 = arith.constant 128 : index
+  // CHECK: scf.for
+  // CHECK-NEXT: {trip_count = 36028797018963968 : i64}
   scf.for %i = %c0 to %c5 step %c1 {
   }
   return

--- a/mlir/test/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_test.mlir
+++ b/mlir/test/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_test.mlir
@@ -56,10 +56,21 @@ func.func @qux() {
   return
 }
 
-func.func @baz() {
+func.func @quxbar() {
   %c0 = arith.constant 5 : index
   %c5 = arith.constant 1 : index
   %c1 = arith.constant 1 : index
+  // CHECK: scf.for
+  // CHECK-NOT: trip_count
+  scf.for %i = %c0 to %c5 step %c1 {
+  }
+  return
+}
+
+func.func @baz() {
+  %c0 = arith.constant 5 : index
+  %c5 = arith.constant 1 : index
+  %c1 = arith.constant -1 : index
   // CHECK: scf.for
   // CHECK-NEXT: {trip_count = 4 : i64}
   scf.for %i = %c0 to %c5 step %c1 {

--- a/mlir/test/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_test.mlir
+++ b/mlir/test/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_test.mlir
@@ -44,3 +44,25 @@ func.func @barfoo(%arg0: index) {
   }
   return
 }
+
+func.func @qux() {
+  %c0 = arith.constant 1 : index
+  %c5 = arith.constant 5 : index
+  %c1 = arith.constant 0 : index
+  // CHECK: scf.for
+  // CHECK-NOT: trip_count
+  scf.for %i = %c0 to %c5 step %c1 {
+  }
+  return
+}
+
+func.func @baz() {
+  %c0 = arith.constant 5 : index
+  %c5 = arith.constant 1 : index
+  %c1 = arith.constant 1 : index
+  // CHECK: scf.for
+  // CHECK-NEXT: {trip_count = 4 : i64}
+  scf.for %i = %c0 to %c5 step %c1 {
+  }
+  return
+}

--- a/mlir/test/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_test.mlir
+++ b/mlir/test/compiler-course/solovyev_d_trip_count/solovyev_d_trip_count_test.mlir
@@ -1,0 +1,46 @@
+// RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/TripCountPass_Solovyev_Danila_FIIT3_MLIR%shlibext --pass-pipeline="builtin.module(TripCountPass_Solovyev_Danila_FIIT3_MLIR)" %s | FileCheck %s
+
+func.func private @get_upper_bound() -> index
+
+func.func @foo() {
+  %c0 = arith.constant 0 : index
+  %c5 = arith.constant 5 : index
+  %c1 = arith.constant 1 : index
+  // CHECK: scf.for
+  // CHECK-NEXT: {trip_count = 5 : i64}
+  scf.for %i = %c0 to %c5 step %c1 {
+  }
+  return
+}
+
+func.func @bar() {
+  %c2 = arith.constant 2 : index
+  %c12 = arith.constant 17 : index
+  %c2_step = arith.constant 2 : index
+  // CHECK: scf.for
+  // CHECK-NEXT: {trip_count = 7 : i64}
+  scf.for %i = %c2 to %c12 step %c2_step {
+  }
+  return
+}
+
+func.func @foobar(%arg0: index) {
+  %c10 = arith.constant 10 : index
+  %c1 = arith.constant 1 : index
+  // CHECK: scf.for
+  // CHECK-NOT: trip_count
+  scf.for %i = %arg0 to %c10 step %c1 {
+  }
+  return
+}
+
+func.func @barfoo(%arg0: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %upper = call @get_upper_bound() : () -> index
+  // CHECK: scf.for
+  // CHECK-NOT: trip_count
+  scf.for %i = %c0 to %upper step %c1 {
+  }
+  return
+}


### PR DESCRIPTION
Пасс проходит по каждой `for` операции и проверяет верхнюю, нижнюю границы и шаг.
Если данные параметры возможно преобразовать в константы - следовательно, можно сосчитать и количество итераций.
В данном случае, устанавливаем аттрибут `trip_count` по формуле `(<верхняя граница>-<нижняя граница>)/<шаг>`.
Если количество итераций установить невозможно - аттрибут не ставится