### PR TITLE
Плеханов Даниил. Лабораторная работа 3, Вариант 2, BACKEND.

### DIFF
--- a/llvm/compiler-course/backend/plekhanov_simd_counter/CMakeLists.txt
+++ b/llvm/compiler-course/backend/plekhanov_simd_counter/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(Title "SimdPass")
+set(Student "Plekhanov_Daniil")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_BACKEND")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY
+)
+
+target_include_directories(${TARGET_NAME} PUBLIC ${PATH_TO_X86})
+set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/compiler-course/backend/plekhanov_simd_counter/simd_counter.cpp
+++ b/llvm/compiler-course/backend/plekhanov_simd_counter/simd_counter.cpp
@@ -1,0 +1,26 @@
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+
+using namespace llvm;
+
+namespace {
+class SimdPass : public MachineFunctionPass {
+public:
+  static char ID;
+  SimdPass() : MachineFunctionPass(ID) {}
+  bool runOnMachineFunction(MachineFunction &MF) override;
+};
+
+char SimdPass::ID = 0;
+
+bool SimdPass::runOnMachineFunction(MachineFunction &func) {
+  llvm::outs() << func.getName() << '\n';
+  return true;
+}
+} // namespace
+
+static RegisterPass<SimdPass> X("example-x86", "description pass", false,
+                                   false);

--- a/llvm/compiler-course/backend/plekhanov_simd_counter/simd_counter.cpp
+++ b/llvm/compiler-course/backend/plekhanov_simd_counter/simd_counter.cpp
@@ -1,26 +1,116 @@
 #include "X86.h"
 #include "X86InstrInfo.h"
 #include "X86Subtarget.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/MachineMemOperand.h"
+#include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/CodeGen/Register.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/GlobalVariable.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+
+#define DEBUG_TYPE "instrument-simd"
 
 using namespace llvm;
 
 namespace {
-class SimdPass : public MachineFunctionPass {
+
+class InstrumentSimdPass : public MachineFunctionPass {
 public:
   static char ID;
-  SimdPass() : MachineFunctionPass(ID) {}
-  bool runOnMachineFunction(MachineFunction &MF) override;
+  InstrumentSimdPass() : MachineFunctionPass(ID) {}
+
+  bool doInitialization(Module &M) override {
+    LLVMContext &Ctx = M.getContext();
+    Type *Int64Ty = Type::getInt64Ty(Ctx);
+
+    if (M.getGlobalVariable("simd_counter")) {
+      return false;
+    }
+
+    Constant *Zero = ConstantInt::get(Int64Ty, 0);
+    GlobalVariable *CounterGV = new GlobalVariable(
+        M, Int64Ty, false, GlobalValue::ExternalLinkage, Zero, "simd_counter");
+    CounterGV->setAlignment(MaybeAlign(8));
+    return true;
+  }
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    MachineModuleInfo &MMI = MF.getMMI();
+    const Module *Mod = MMI.getModule();
+    const GlobalVariable *CounterGV = Mod->getGlobalVariable("simd_counter");
+
+    if (!CounterGV) {
+      errs() << "InstrumentSimdPass: simd_counter global variable not found.\n";
+      return false;
+    }
+
+    const X86Subtarget &ST = MF.getSubtarget<X86Subtarget>();
+    const X86InstrInfo *TII = ST.getInstrInfo();
+    MachineRegisterInfo &MRI = MF.getRegInfo();
+
+    bool Changed = false;
+
+    for (auto &MBB : MF) {
+      for (auto MI_it = MBB.begin(), E = MBB.end(); MI_it != E; ++MI_it) {
+        MachineInstr &MI = *MI_it;
+        bool isSimd = false;
+
+        for (const MachineOperand &MO : MI.operands()) {
+          if (!MO.isReg() || !MO.getReg())
+            continue;
+
+          unsigned Reg = MO.getReg();
+          if (!Register::isVirtualRegister(Reg))
+            continue;
+
+          const TargetRegisterClass *RC = MRI.getRegClass(Reg);
+          if (RC) {
+            unsigned RCID = RC->getID();
+            if (RCID == X86::VR128RegClassID || RCID == X86::VR256RegClassID ||
+                RCID == X86::VR512RegClassID) {
+              isSimd = true;
+              break;
+            }
+          }
+        }
+
+        if (!isSimd)
+          continue;
+
+        Changed = true;
+        DebugLoc DL = MI.getDebugLoc();
+
+        MachineInstrBuilder MIB =
+            BuildMI(MBB, MI_it, DL, TII->get(X86::ADD64mi8));
+
+        MIB.addReg(X86::RIP, RegState::Implicit);
+        MIB.addImm(1);
+        MIB.addReg(0, RegState::Implicit);
+        MIB.addGlobalAddress(CounterGV, 0);
+        MIB.addReg(0, RegState::Implicit);
+
+        MIB.addImm(1);
+
+        MachineMemOperand *MMO = MMI.getMachineMemOperand(
+            MachinePointerInfo(CounterGV),
+            MachineMemOperand::MOLoad | MachineMemOperand::MOStore |
+                MachineMemOperand::MOVolatile,
+            8, Align(8));
+        MIB.addMemOperand(MMO);
+      }
+    }
+    return Changed;
+  }
 };
 
-char SimdPass::ID = 0;
+char InstrumentSimdPass::ID = 0;
 
-bool SimdPass::runOnMachineFunction(MachineFunction &func) {
-  llvm::outs() << func.getName() << '\n';
-  return true;
-}
 } // namespace
 
-static RegisterPass<SimdPass> X("example-x86", "description pass", false,
-                                   false);
+static llvm::RegisterPass<InstrumentSimdPass>
+    X("simd-pass", "Instrument SIMD instructions", false, false);

--- a/llvm/test/compiler-course/plekhanov_simd_counter/simd_counter.mir
+++ b/llvm/test/compiler-course/plekhanov_simd_counter/simd_counter.mir
@@ -1,0 +1,98 @@
+# RUN: llc -mtriple x86_64-unknown-linux-gnu --load=%llvmshlibdir/ExamplePass_Ivanov_Ivan_FIIT0_BACKEND%shlibext \
+# RUN: -run-pass=example-x86  %s -o - | FileCheck %s
+
+
+# Source files
+
+# test.cpp
+#
+# [[nodiscard]] bool isEven(int value) noexcept { return value % 2 == 0; }
+
+# test.ll (-O2)
+#
+# define dso_local noundef zeroext i1 @_Z6isEveni(i32 noundef %0) local_unnamed_addr {
+#  %2 = and i32 %0, 1
+#  %3 = icmp eq i32 %2, 0
+#  ret i1 %3
+# }
+
+
+--- |
+  ; ModuleID = 'test.ll'
+  source_filename = "test.ll"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  
+  define dso_local noundef zeroext i1 @_Z6isEveni(i32 noundef %0) local_unnamed_addr {
+    %2 = and i32 %0, 1
+    %3 = icmp eq i32 %2, 0
+    ret i1 %3
+  }
+
+...
+---
+# CHECK: _Z6isEveni
+# CHECK: name:            _Z6isEveni
+name:            _Z6isEveni
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: true
+registers:       []
+liveins:
+  - { reg: '$edi', virtual-reg: '' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 0
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: true
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0 (%ir-block.1):
+    liveins: $edi
+  
+    ; CHECK: TEST8ri renamable $dil, 1, implicit-def $eflags, implicit killed $edi
+    ; CHECK-NEXT: renamable $al = SETCCr 4, implicit killed $eflags
+    ; CHECK-NEXT: RET64 $al
+
+    TEST8ri renamable $dil, 1, implicit-def $eflags, implicit killed $edi
+    renamable $al = SETCCr 4, implicit killed $eflags
+    RET64 $al
+
+...

--- a/llvm/test/compiler-course/plekhanov_simd_counter/simd_counter.mir
+++ b/llvm/test/compiler-course/plekhanov_simd_counter/simd_counter.mir
@@ -1,38 +1,80 @@
-# RUN: llc -mtriple x86_64-unknown-linux-gnu --load=%llvmshlibdir/ExamplePass_Ivanov_Ivan_FIIT0_BACKEND%shlibext \
-# RUN: -run-pass=example-x86  %s -o - | FileCheck %s
-
-
-# Source files
-
-# test.cpp
+#  RUN: llc -mtriple=x86_64-unknown-linux-gnu -mattr=+avx \
+#  RUN:     --load=%llvmshlibdir/SimdPass_Plekhanov_Daniil_FIIT2_BACKEND%shlibext \
+#  RUN:     -run-pass=simd-pass %s -o - | FileCheck %s
+# test_simd.cpp
 #
-# [[nodiscard]] bool isEven(int value) noexcept { return value % 2 == 0; }
-
-# test.ll (-O2)
-#
-# define dso_local noundef zeroext i1 @_Z6isEveni(i32 noundef %0) local_unnamed_addr {
-#  %2 = and i32 %0, 1
-#  %3 = icmp eq i32 %2, 0
-#  ret i1 %3
+# #include <immintrin.h>
+# 
+# // simple float add using 128-bit SSE
+# extern "C"
+# void simd_add_ps(__m128 a, __m128 b, __m128 *out) {
+#     // this maps to vaddps xmm*, xmm*, xmm*
+#     __m128 c = _mm_add_ps(a, b);
+#     *out = c;
+# }
+# 
+# // simple double add using 128-bit SSE2
+# extern "C"
+# void simd_add_pd(__m128d a, __m128d b, __m128d *out) {
+#     // this maps to vaddpd xmm*, xmm*, xmm*
+#     __m128d c = _mm_add_pd(a, b);
+#     *out = c;
+# }
+# 
+# // float add using 256-bit AVX
+# extern "C"
+# void simd256_add_ps(__m256 a, __m256 b, __m256 *out) {
+#     // this maps to vaddps ymm*, ymm*, ymm*
+#     __m256 c = _mm256_add_ps(a, b);
+#     *out = c;
 # }
 
-
 --- |
-  ; ModuleID = 'test.ll'
-  source_filename = "test.ll"
+  ; ModuleID = 'test_simd.ll'
+  source_filename = "test_simd.cpp"
   target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-pc-linux-gnu"
   
-  define dso_local noundef zeroext i1 @_Z6isEveni(i32 noundef %0) local_unnamed_addr {
-    %2 = and i32 %0, 1
-    %3 = icmp eq i32 %2, 0
-    ret i1 %3
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: write) uwtable
+  define dso_local void @simd_add_ps(<4 x float> noundef %0, <4 x float> noundef %1, ptr nocapture noundef writeonly %2) local_unnamed_addr #0 {
+    %4 = fadd <4 x float> %0, %1
+    store <4 x float> %4, ptr %2, align 16, !tbaa !5
+    ret void
   }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: write) uwtable
+  define dso_local void @simd_add_pd(<2 x double> noundef %0, <2 x double> noundef %1, ptr nocapture noundef writeonly %2) local_unnamed_addr #0 {
+    %4 = fadd <2 x double> %0, %1
+    store <2 x double> %4, ptr %2, align 16, !tbaa !5
+    ret void
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: write) uwtable
+  define dso_local void @simd256_add_ps(<8 x float> noundef %0, <8 x float> noundef %1, ptr nocapture noundef writeonly %2) local_unnamed_addr #1 {
+    %4 = fadd <8 x float> %0, %1
+    store <8 x float> %4, ptr %2, align 32, !tbaa !5
+    ret void
+  }
+  
+  attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: write) uwtable "min-legal-vector-width"="128" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+avx,+cmov,+crc32,+cx8,+fxsr,+mmx,+popcnt,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3,+x87,+xsave,+avx" "tune-cpu"="generic" }
+  attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: write) uwtable "min-legal-vector-width"="256" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+avx,+cmov,+crc32,+cx8,+fxsr,+mmx,+popcnt,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3,+x87,+xsave,+avx" "tune-cpu"="generic" }
+  
+  !llvm.module.flags = !{!0, !1, !2, !3}
+  !llvm.ident = !{!4}
+  
+  !0 = !{i32 1, !"wchar_size", i32 4}
+  !1 = !{i32 8, !"PIC Level", i32 2}
+  !2 = !{i32 7, !"PIE Level", i32 2}
+  !3 = !{i32 7, !"uwtable", i32 2}
+  !4 = !{!"Ubuntu clang version 18.1.3 (1ubuntu1)"}
+  !5 = !{!6, !6, i64 0}
+  !6 = !{!"omnipotent char", !7, i64 0}
+  !7 = !{!"Simple C++ TBAA"}
 
 ...
 ---
-# CHECK: _Z6isEveni
-# CHECK: name:            _Z6isEveni
-name:            _Z6isEveni
+# CHECK-LABEL: name:            simd_add_ps
+name:            simd_add_ps
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -49,10 +91,16 @@ hasEHFunclets:   false
 isOutlined:      false
 debugInstrRef:   true
 failsVerification: false
-tracksDebugUserValues: true
-registers:       []
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128, preferred-register: '' }
+  - { id: 1, class: vr128, preferred-register: '' }
+  - { id: 2, class: gr64, preferred-register: '' }
+  - { id: 3, class: vr128, preferred-register: '' }
 liveins:
-  - { reg: '$edi', virtual-reg: '' }
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$rdi', virtual-reg: '%2' }
 frameInfo:
   isFrameAddressTaken: false
   isReturnAddressTaken: false
@@ -65,13 +113,13 @@ frameInfo:
   hasCalls:        false
   stackProtector:  ''
   functionContext: ''
-  maxCallFrameSize: 0
+  maxCallFrameSize: 4294967295
   cvBytesOfCalleeSavedRegisters: 0
   hasOpaqueSPAdjustment: false
   hasVAStart:      false
   hasMustTailInVarArgFunc: false
   hasTailCall:     false
-  isCalleeSavedInfoValid: true
+  isCalleeSavedInfoValid: false
   localFrameSize:  0
   savePoint:       ''
   restorePoint:    ''
@@ -84,15 +132,211 @@ constants:       []
 machineFunctionInfo:
   amxProgModel:    None
 body:             |
-  bb.0 (%ir-block.1):
-    liveins: $edi
-  
-    ; CHECK: TEST8ri renamable $dil, 1, implicit-def $eflags, implicit killed $edi
-    ; CHECK-NEXT: renamable $al = SETCCr 4, implicit killed $eflags
-    ; CHECK-NEXT: RET64 $al
+  bb.0 (%ir-block.3):
+    liveins: $xmm0, $xmm1, $rdi
 
-    TEST8ri renamable $dil, 1, implicit-def $eflags, implicit killed $edi
-    renamable $al = SETCCr 4, implicit killed $eflags
-    RET64 $al
+    ; CHECK: %2:gr64 = COPY $rdi
+    ; CHECK-NEXT: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %4:gr64 = MOV64rm 1, @simd_counter, implicit $rip, implicit $noreg, implicit $noreg
+    ; CHECK-NEXT: %4:gr64 = ADD64ri32 %4, 1, implicit-def $eflags
+    ; CHECK-NEXT: MOV64mr 1, @simd_counter, %4, implicit $rip, implicit $noreg
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %5:gr64 = MOV64rm 1, @simd_counter, implicit $rip, implicit $noreg, implicit $noreg
+    ; CHECK-NEXT: %5:gr64 = ADD64ri32 %5, 1, implicit-def $eflags
+    ; CHECK-NEXT: MOV64mr 1, @simd_counter, %5, implicit $rip, implicit $noreg
+    ; CHECK-NEXT: %3:vr128 = nofpexcept VADDPSrr %0, %1, implicit $mxcsr
+    ; CHECK-NEXT: %6:gr64 = MOV64rm 1, @simd_counter, implicit $rip, implicit $noreg, implicit $noreg
+    ; CHECK-NEXT: %6:gr64 = ADD64ri32 %6, 1, implicit-def $eflags
+    ; CHECK-NEXT: MOV64mr 1, @simd_counter, %6, implicit $rip, implicit $noreg
+    ; CHECK-NEXT: VMOVAPSmr %2, 1, $noreg, 0, $noreg, killed %3 :: (store (s128) into %ir.2, !tbaa !5)
+    ; CHECK-NEXT: %7:gr64 = MOV64rm 1, @simd_counter, implicit $rip, implicit $noreg, implicit $noreg
+    ; CHECK-NEXT: %7:gr64 = ADD64ri32 %7, 1, implicit-def $eflags
+    ; CHECK-NEXT: MOV64mr 1, @simd_counter, %7, implicit $rip, implicit $noreg
+    ; CHECK-NEXT: RET 0
+  
+    %2:gr64 = COPY $rdi
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept VADDPSrr %0, %1, implicit $mxcsr
+    VMOVAPSmr %2, 1, $noreg, 0, $noreg, killed %3 :: (store (s128) into %ir.2, !tbaa !5)
+    RET 0
 
 ...
+---
+# CHECK-LABEL: name:            simd_add_pd
+name:            simd_add_pd
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128, preferred-register: '' }
+  - { id: 1, class: vr128, preferred-register: '' }
+  - { id: 2, class: gr64, preferred-register: '' }
+  - { id: 3, class: vr128, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$rdi', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $xmm0, $xmm1, $rdi
+
+    ; CHECK: %2:gr64 = COPY $rdi
+    ; CHECK-NEXT: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %4:gr64 = MOV64rm 1, @simd_counter, implicit $rip, implicit $noreg, implicit $noreg
+    ; CHECK-NEXT: %4:gr64 = ADD64ri32 %4, 1, implicit-def $eflags
+    ; CHECK-NEXT: MOV64mr 1, @simd_counter, %4, implicit $rip, implicit $noreg
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %5:gr64 = MOV64rm 1, @simd_counter, implicit $rip, implicit $noreg, implicit $noreg
+    ; CHECK-NEXT: %5:gr64 = ADD64ri32 %5, 1, implicit-def $eflags
+    ; CHECK-NEXT: MOV64mr 1, @simd_counter, %5, implicit $rip, implicit $noreg
+    ; CHECK-NEXT: %3:vr128 = nofpexcept VADDPDrr %0, %1, implicit $mxcsr
+    ; CHECK-NEXT: %6:gr64 = MOV64rm 1, @simd_counter, implicit $rip, implicit $noreg, implicit $noreg
+    ; CHECK-NEXT: %6:gr64 = ADD64ri32 %6, 1, implicit-def $eflags
+    ; CHECK-NEXT: MOV64mr 1, @simd_counter, %6, implicit $rip, implicit $noreg
+    ; CHECK-NEXT: VMOVAPDmr %2, 1, $noreg, 0, $noreg, killed %3 :: (store (s128) into %ir.2, !tbaa !5)
+    ; CHECK-NEXT: %7:gr64 = MOV64rm 1, @simd_counter, implicit $rip, implicit $noreg, implicit $noreg
+    ; CHECK-NEXT: %7:gr64 = ADD64ri32 %7, 1, implicit-def $eflags
+    ; CHECK-NEXT: MOV64mr 1, @simd_counter, %7, implicit $rip, implicit $noreg
+    ; CHECK-NEXT: RET 0
+  
+    %2:gr64 = COPY $rdi
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept VADDPDrr %0, %1, implicit $mxcsr
+    VMOVAPDmr %2, 1, $noreg, 0, $noreg, killed %3 :: (store (s128) into %ir.2, !tbaa !5)
+    RET 0
+
+...
+---
+# CHECK-LABEL: name:            simd256_add_ps
+name:            simd256_add_ps
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr256, preferred-register: '' }
+  - { id: 1, class: vr256, preferred-register: '' }
+  - { id: 2, class: gr64, preferred-register: '' }
+  - { id: 3, class: vr256, preferred-register: '' }
+liveins:
+  - { reg: '$ymm0', virtual-reg: '%0' }
+  - { reg: '$ymm1', virtual-reg: '%1' }
+  - { reg: '$rdi', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $ymm0, $ymm1, $rdi
+
+    ; CHECK: %2:gr64 = COPY $rdi
+    ; CHECK-NEXT: %1:vr256 = COPY $ymm1
+    ; CHECK-NEXT: %4:gr64 = MOV64rm 1, @simd_counter, implicit $rip, implicit $noreg, implicit $noreg
+    ; CHECK-NEXT: %4:gr64 = ADD64ri32 %4, 1, implicit-def $eflags
+    ; CHECK-NEXT: MOV64mr 1, @simd_counter, %4, implicit $rip, implicit $noreg
+    ; CHECK-NEXT: %0:vr256 = COPY $ymm0
+    ; CHECK-NEXT: %5:gr64 = MOV64rm 1, @simd_counter, implicit $rip, implicit $noreg, implicit $noreg
+    ; CHECK-NEXT: %5:gr64 = ADD64ri32 %5, 1, implicit-def $eflags
+    ; CHECK-NEXT: MOV64mr 1, @simd_counter, %5, implicit $rip, implicit $noreg
+    ; CHECK-NEXT: %3:vr256 = nofpexcept VADDPSYrr %0, %1, implicit $mxcsr
+    ; CHECK-NEXT: %6:gr64 = MOV64rm 1, @simd_counter, implicit $rip, implicit $noreg, implicit $noreg
+    ; CHECK-NEXT: %6:gr64 = ADD64ri32 %6, 1, implicit-def $eflags
+    ; CHECK-NEXT: MOV64mr 1, @simd_counter, %6, implicit $rip, implicit $noreg
+    ; CHECK-NEXT: VMOVAPSYmr %2, 1, $noreg, 0, $noreg, killed %3 :: (store (s256) into %ir.2, !tbaa !5)
+    ; CHECK-NEXT: %7:gr64 = MOV64rm 1, @simd_counter, implicit $rip, implicit $noreg, implicit $noreg
+    ; CHECK-NEXT: %7:gr64 = ADD64ri32 %7, 1, implicit-def $eflags
+    ; CHECK-NEXT: MOV64mr 1, @simd_counter, %7, implicit $rip, implicit $noreg
+    ; CHECK-NEXT: RET 0
+  
+    %2:gr64 = COPY $rdi
+    %1:vr256 = COPY $ymm1
+    %0:vr256 = COPY $ymm0
+    %3:vr256 = nofpexcept VADDPSYrr %0, %1, implicit $mxcsr
+    VMOVAPSYmr %2, 1, $noreg, 0, $noreg, killed %3 :: (store (s256) into %ir.2, !tbaa !5)
+    RET 0


### PR DESCRIPTION
Пасс InstrumentSimdPass предназначен для анализа и модификации машинных функций в LLVM, добавляя счетчик для SIMD-инструкций. Он инициализирует глобальную переменную simd_counter, если она еще не существует, и затем проходит через каждую инструкцию в функции, чтобы определить, использует ли она SIMD-регистры. Если SIMD-инструкция обнаружена, пасс добавляет инструкцию для увеличения счетчика, что позволяет отслеживать количество выполненных SIMD-операций.