### PR TITLE
Коробейников Арсений. Лабораторная работа № 3. Backend. Вариант № 4.

### DIFF
--- a/llvm/compiler-course/backend/korobeinikov_a_llvm_backend/CMakeLists.txt
+++ b/llvm/compiler-course/backend/korobeinikov_a_llvm_backend/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(Title "FuseMulSubPass")
+set(Student "Korobeinikov_Arseny")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_BACKEND")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY
+)
+
+target_include_directories(${TARGET_NAME} PUBLIC ${PATH_TO_X86})
+set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/compiler-course/backend/korobeinikov_a_llvm_backend/korobeinikov_a_llvm_backend_pass.cpp
+++ b/llvm/compiler-course/backend/korobeinikov_a_llvm_backend/korobeinikov_a_llvm_backend_pass.cpp
@@ -14,126 +14,167 @@ class FMACombinePass : public MachineFunctionPass {
 public:
   static char ID;
   FMACombinePass() : MachineFunctionPass(ID) {}
-
   bool runOnMachineFunction(MachineFunction &MF) override;
 
 private:
   const X86InstrInfo *TII = nullptr;
 
   bool processBlock(MachineBasicBlock &MBB);
-  std::optional<unsigned> getFMAOpcode(unsigned MulOp, unsigned SubOp) const;
-  bool checkRegisterUsage(const MachineInstr &MulMI,
-                          const MachineInstr &SubMI) const;
+  std::optional<unsigned> getFMAOpcode(unsigned MulOp, unsigned SubOp,
+                                       bool IsSubLHSfirst) const;
+  bool checkRegisterUsage(const MachineInstr &MulMI, const MachineInstr &SubMI,
+                          bool &IsSubLHSfirst) const;
 };
 
 char FMACombinePass::ID = 0;
 
 bool FMACombinePass::runOnMachineFunction(MachineFunction &MF) {
-  const X86Subtarget &ST = MF.getSubtarget<X86Subtarget>();
+  auto &ST = MF.getSubtarget<X86Subtarget>();
   if (!ST.hasFMA())
     return false;
-
   TII = ST.getInstrInfo();
+
   bool Changed = false;
-
-  for (MachineBasicBlock &MBB : MF)
+  for (auto &MBB : MF)
     Changed |= processBlock(MBB);
-
   return Changed;
 }
 
 bool FMACombinePass::processBlock(MachineBasicBlock &MBB) {
-  bool Modified = false;
-  MachineRegisterInfo &MRI = MBB.getParent()->getRegInfo();
   SmallVector<MachineInstr *, 4> ToErase;
+  auto &MRI = MBB.getParent()->getRegInfo();
+  bool Modified = false;
 
-  for (auto I = MBB.begin(); I != MBB.end(); ++I) {
-    MachineInstr &MI = *I;
-    unsigned MulOp = MI.getOpcode();
-
+  for (auto I = MBB.begin(), E = MBB.end(); I != E; ++I) {
+    MachineInstr &MulMI = *I;
+    unsigned MulOp = MulMI.getOpcode();
+    // 1) Ищем fmul
     if (MulOp != X86::MULSSrr && MulOp != X86::MULSDrr &&
         MulOp != X86::VMULSSrr && MulOp != X86::VMULSDrr &&
         MulOp != X86::VMULPSrr && MulOp != X86::VMULPDrr)
       continue;
 
-    Register MulDst = MI.getOperand(0).getReg();
+    // ровно одно использование результата mul
+    Register MulDst = MulMI.getOperand(0).getReg();
     if (!MRI.hasOneUse(MulDst))
       continue;
 
-    auto SubIter = std::next(I);
-    for (; SubIter != MBB.end(); ++SubIter) {
-      MachineInstr &SubMI = *SubIter;
+    // 2) Ищем sub или add вперед
+    bool IsSubLHSfirst = false;
+    auto SubIt = std::next(I);
+    for (; SubIt != E; ++SubIt) {
+      MachineInstr &SubMI = *SubIt;
       unsigned Op = SubMI.getOpcode();
-      bool isSub = (Op == X86::SUBSSrr || Op == X86::SUBSDrr ||
-                    Op == X86::VSUBSSrr || Op == X86::VSUBSDrr);
-      bool isAdd = (Op == X86::VADDSSrr || Op == X86::VADDSDrr);
-      if ((isSub && SubMI.getOperand(2).getReg() == MulDst) ||
-          (isAdd && SubMI.getOperand(1).getReg() == MulDst))
-        break;
+      bool isSub = Op == X86::SUBSSrr || Op == X86::SUBSDrr ||
+                   Op == X86::VSUBSSrr || Op == X86::VSUBSDrr;
+      bool isAdd = Op == X86::VADDSSrr || Op == X86::VADDSDrr;
+
+      if (isSub) {
+        // tmp-c (tmp in operand1) or c-tmp (tmp in operand2)
+        if (SubMI.getOperand(1).getReg() == MulDst ||
+            SubMI.getOperand(2).getReg() == MulDst)
+          break;
+      } else if (isAdd) {
+        // -(tmp)+c → tmp in operand1
+        if (SubMI.getOperand(1).getReg() == MulDst)
+          break;
+      }
     }
-    if (SubIter == MBB.end())
+    if (SubIt == E)
+      continue;
+    MachineInstr &SubMI = *SubIt;
+
+    // 3) Определяем, какой у нас случай, и корректность использования
+    if (!checkRegisterUsage(MulMI, SubMI, IsSubLHSfirst))
       continue;
 
-    MachineInstr &SubMI = *SubIter;
-    if (!checkRegisterUsage(MI, SubMI))
-      continue;
-
-    auto FMAOp = getFMAOpcode(MulOp, SubMI.getOpcode());
+    // 4) Получаем нужный FMA opcode
+    auto FMAOp = getFMAOpcode(MulOp, SubMI.getOpcode(), IsSubLHSfirst);
     if (!FMAOp)
       continue;
 
-    bool isAdd = (SubMI.getOpcode() == X86::VADDSSrr ||
-                  SubMI.getOpcode() == X86::VADDSDrr);
-    unsigned CIdx = isAdd ? 2 : 1;
+    // 5) Выбираем индекс региста c
+    //   если tmp в lhs → c = operand2, иначе c = operand1
+    unsigned CIdx = IsSubLHSfirst ? 2 : 1;
     Register CReg = SubMI.getOperand(CIdx).getReg();
 
-    // Строим новую FMA инструкцию
+    // 6) Строим fused-инструкцию
     BuildMI(MBB, SubMI, SubMI.getDebugLoc(), TII->get(*FMAOp),
             SubMI.getOperand(0).getReg())
-        .addReg(MI.getOperand(1).getReg(), getRegState(MI.getOperand(1)))
-        .addReg(MI.getOperand(2).getReg(), getRegState(MI.getOperand(2)))
+        .addReg(MulMI.getOperand(1).getReg(), getRegState(MulMI.getOperand(1)))
+        .addReg(MulMI.getOperand(2).getReg(), getRegState(MulMI.getOperand(2)))
         .addReg(CReg, getRegState(SubMI.getOperand(CIdx)));
 
-    // Отложенное удаление
-    ToErase.push_back(&MI);
+    ToErase.push_back(&MulMI);
     ToErase.push_back(&SubMI);
     Modified = true;
   }
 
-  if (!ToErase.empty()) {
-    for (MachineInstr *MI : reverse(ToErase))
-      MI->eraseFromParent();
-  }
-
+  for (auto *MI : reverse(ToErase))
+    MI->eraseFromParent();
   return Modified;
 }
 
 std::optional<unsigned> FMACombinePass::getFMAOpcode(unsigned MulOp,
-                                                     unsigned SubOp) const {
-  const static DenseMap<std::pair<unsigned, unsigned>, unsigned> Map = {
-      {{X86::MULSSrr, X86::SUBSSrr}, X86::VFMSUB213SSr},
-      {{X86::VMULSSrr, X86::VSUBSSrr}, X86::VFMSUB213SSr},
-      {{X86::MULSDrr, X86::SUBSDrr}, X86::VFMSUB213SDr},
-      {{X86::VMULSDrr, X86::VSUBSDrr}, X86::VFMSUB213SDr},
-      {{X86::VMULSSrr, X86::VADDSSrr}, X86::VFMSUB213SSr},
-      {{X86::VMULSDrr, X86::VADDSDrr}, X86::VFMSUB213SDr},
-      {{X86::VMULPSrr, X86::VSUBPSrr}, X86::VFMSUB213PSr},
-      {{X86::VMULPDrr, X86::VSUBPDrr}, X86::VFMSUB213PDr},
-  };
-  auto It = Map.find({MulOp, SubOp});
-  return It == Map.end() ? std::nullopt : std::optional<unsigned>(It->second);
+                                                     unsigned SubOp,
+                                                     bool IsSubLHSfirst) const {
+  // Если это ADD-случай (-(a*b)+c), всегда VFNMADD213
+  if (SubOp == X86::VADDSSrr)
+    return X86::VFNMADD213SSr;
+  if (SubOp == X86::VADDSDrr)
+    return X86::VFNMADD213SDr;
+
+  // Иначе SUB-случай:
+  //   если tmp в lhs → (a*b)-c = VFMSUB213
+  //   иначе           c-(a*b) = VFNMADD213
+  bool tmpOnLHS = IsSubLHSfirst;
+  switch (MulOp) {
+  case X86::MULSSrr:
+    return tmpOnLHS ? X86::VFMSUB213SSr : X86::VFNMADD213SSr;
+  case X86::VMULSSrr:
+    return tmpOnLHS ? X86::VFMSUB213SSr : X86::VFNMADD213SSr;
+  case X86::MULSDrr:
+    return tmpOnLHS ? X86::VFMSUB213SDr : X86::VFNMADD213SDr;
+  case X86::VMULSDrr:
+    return tmpOnLHS ? X86::VFMSUB213SDr : X86::VFNMADD213SDr;
+  case X86::VMULPSrr:
+    return tmpOnLHS ? X86::VFMSUB213PSr : X86::VFNMADD213PSr;
+  case X86::VMULPDrr:
+    return tmpOnLHS ? X86::VFMSUB213PDr : X86::VFNMADD213PDr;
+  default:
+    return std::nullopt;
+  }
 }
 
 bool FMACombinePass::checkRegisterUsage(const MachineInstr &MulMI,
-                                        const MachineInstr &SubMI) const {
+                                        const MachineInstr &SubMI,
+                                        bool &IsSubLHSfirst) const {
   Register MulDst = MulMI.getOperand(0).getReg();
-  bool isAdd = (SubMI.getOpcode() == X86::VADDSSrr ||
-                SubMI.getOpcode() == X86::VADDSDrr);
-  Register SubSrc = SubMI.getOperand(isAdd ? 1 : 2).getReg();
-  return MulDst == SubSrc;
+  unsigned Op = SubMI.getOpcode();
+  Register LHS = SubMI.getOperand(1).getReg();
+  Register RHS = SubMI.getOperand(2).getReg();
+
+  if (Op == X86::VADDSSrr || Op == X86::VADDSDrr) {
+    // ADD-case: -(tmp)+c → tmp must be in LHS
+    IsSubLHSfirst = true;
+    return LHS == MulDst;
+  }
+  // SUB-case:
+  if (LHS == MulDst) {
+    // tmp - c
+    IsSubLHSfirst = true;
+    return true;
+  }
+  if (RHS == MulDst) {
+    // c - tmp
+    IsSubLHSfirst = false;
+    return true;
+  }
+  return false;
 }
 
 } // namespace
 
-static RegisterPass<FMACombinePass> X("korobeinikov-fuse-mul-sub",
-                                      "FMA Combine Pass", false, false);
+static RegisterPass<FMACombinePass>
+    X("korobeinikov-fuse-mul-sub", "Fuse mul+sub/add into VFMSUB213/VFNMADD213",
+      false, false);

--- a/llvm/compiler-course/backend/korobeinikov_a_llvm_backend/korobeinikov_a_llvm_backend_pass.cpp
+++ b/llvm/compiler-course/backend/korobeinikov_a_llvm_backend/korobeinikov_a_llvm_backend_pass.cpp
@@ -1,0 +1,139 @@
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/Pass.h"
+
+using namespace llvm;
+
+namespace {
+class FMACombinePass : public MachineFunctionPass {
+public:
+  static char ID;
+  FMACombinePass() : MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(MachineFunction &MF) override;
+
+private:
+  const X86InstrInfo *TII = nullptr;
+
+  bool processBlock(MachineBasicBlock &MBB);
+  std::optional<unsigned> getFMAOpcode(unsigned MulOp, unsigned SubOp) const;
+  bool checkRegisterUsage(const MachineInstr &MulMI,
+                          const MachineInstr &SubMI) const;
+};
+
+char FMACombinePass::ID = 0;
+
+bool FMACombinePass::runOnMachineFunction(MachineFunction &MF) {
+  const X86Subtarget &ST = MF.getSubtarget<X86Subtarget>();
+  if (!ST.hasFMA())
+    return false;
+
+  TII = ST.getInstrInfo();
+  bool Changed = false;
+
+  for (MachineBasicBlock &MBB : MF)
+    Changed |= processBlock(MBB);
+
+  return Changed;
+}
+
+bool FMACombinePass::processBlock(MachineBasicBlock &MBB) {
+  bool Modified = false;
+  MachineRegisterInfo &MRI = MBB.getParent()->getRegInfo();
+  SmallVector<MachineInstr *, 4> ToErase;
+
+  for (auto I = MBB.begin(); I != MBB.end(); ++I) {
+    MachineInstr &MI = *I;
+    unsigned MulOp = MI.getOpcode();
+
+    if (MulOp != X86::MULSSrr && MulOp != X86::MULSDrr &&
+        MulOp != X86::VMULSSrr && MulOp != X86::VMULSDrr &&
+        MulOp != X86::VMULPSrr && MulOp != X86::VMULPDrr)
+      continue;
+
+    Register MulDst = MI.getOperand(0).getReg();
+    if (!MRI.hasOneUse(MulDst))
+      continue;
+
+    auto SubIter = std::next(I);
+    for (; SubIter != MBB.end(); ++SubIter) {
+      MachineInstr &SubMI = *SubIter;
+      unsigned Op = SubMI.getOpcode();
+      bool isSub = (Op == X86::SUBSSrr || Op == X86::SUBSDrr ||
+                    Op == X86::VSUBSSrr || Op == X86::VSUBSDrr);
+      bool isAdd = (Op == X86::VADDSSrr || Op == X86::VADDSDrr);
+      if ((isSub && SubMI.getOperand(2).getReg() == MulDst) ||
+          (isAdd && SubMI.getOperand(1).getReg() == MulDst))
+        break;
+    }
+    if (SubIter == MBB.end())
+      continue;
+
+    MachineInstr &SubMI = *SubIter;
+    if (!checkRegisterUsage(MI, SubMI))
+      continue;
+
+    auto FMAOp = getFMAOpcode(MulOp, SubMI.getOpcode());
+    if (!FMAOp)
+      continue;
+
+    bool isAdd = (SubMI.getOpcode() == X86::VADDSSrr ||
+                  SubMI.getOpcode() == X86::VADDSDrr);
+    unsigned CIdx = isAdd ? 2 : 1;
+    Register CReg = SubMI.getOperand(CIdx).getReg();
+
+    // Строим новую FMA инструкцию
+    BuildMI(MBB, SubMI, SubMI.getDebugLoc(), TII->get(*FMAOp),
+            SubMI.getOperand(0).getReg())
+        .addReg(MI.getOperand(1).getReg(), getRegState(MI.getOperand(1)))
+        .addReg(MI.getOperand(2).getReg(), getRegState(MI.getOperand(2)))
+        .addReg(CReg, getRegState(SubMI.getOperand(CIdx)));
+
+    // Отложенное удаление
+    ToErase.push_back(&MI);
+    ToErase.push_back(&SubMI);
+    Modified = true;
+  }
+
+  if (!ToErase.empty()) {
+    for (MachineInstr *MI : reverse(ToErase))
+      MI->eraseFromParent();
+  }
+
+  return Modified;
+}
+
+std::optional<unsigned> FMACombinePass::getFMAOpcode(unsigned MulOp,
+                                                     unsigned SubOp) const {
+  const static DenseMap<std::pair<unsigned, unsigned>, unsigned> Map = {
+      {{X86::MULSSrr, X86::SUBSSrr}, X86::VFMSUB213SSr},
+      {{X86::VMULSSrr, X86::VSUBSSrr}, X86::VFMSUB213SSr},
+      {{X86::MULSDrr, X86::SUBSDrr}, X86::VFMSUB213SDr},
+      {{X86::VMULSDrr, X86::VSUBSDrr}, X86::VFMSUB213SDr},
+      {{X86::VMULSSrr, X86::VADDSSrr}, X86::VFMSUB213SSr},
+      {{X86::VMULSDrr, X86::VADDSDrr}, X86::VFMSUB213SDr},
+      {{X86::VMULPSrr, X86::VSUBPSrr}, X86::VFMSUB213PSr},
+      {{X86::VMULPDrr, X86::VSUBPDrr}, X86::VFMSUB213PDr},
+  };
+  auto It = Map.find({MulOp, SubOp});
+  return It == Map.end() ? std::nullopt : std::optional<unsigned>(It->second);
+}
+
+bool FMACombinePass::checkRegisterUsage(const MachineInstr &MulMI,
+                                        const MachineInstr &SubMI) const {
+  Register MulDst = MulMI.getOperand(0).getReg();
+  bool isAdd = (SubMI.getOpcode() == X86::VADDSSrr ||
+                SubMI.getOpcode() == X86::VADDSDrr);
+  Register SubSrc = SubMI.getOperand(isAdd ? 1 : 2).getReg();
+  return MulDst == SubSrc;
+}
+
+} // namespace
+
+static RegisterPass<FMACombinePass> X("korobeinikov-fuse-mul-sub",
+                                      "FMA Combine Pass", false, false);

--- a/llvm/compiler-course/backend/korobeinikov_a_llvm_backend/korobeinikov_a_llvm_backend_pass.cpp
+++ b/llvm/compiler-course/backend/korobeinikov_a_llvm_backend/korobeinikov_a_llvm_backend_pass.cpp
@@ -59,7 +59,7 @@ bool FMACombinePass::processBlock(MachineBasicBlock &MBB) {
     if (!MRI.hasOneUse(MulDst))
       continue;
 
-    // 2) Ищем sub или add вперед
+    // 2) Ищем sub или add вперед (теперь ловим и tmp во 2-м операнде для add)
     bool IsSubLHSfirst = false;
     auto SubIt = std::next(I);
     for (; SubIt != E; ++SubIt) {
@@ -70,16 +70,20 @@ bool FMACombinePass::processBlock(MachineBasicBlock &MBB) {
       bool isAdd = Op == X86::VADDSSrr || Op == X86::VADDSDrr;
 
       if (isSub) {
-        // tmp-c (tmp in operand1) or c-tmp (tmp in operand2)
+        // tmp-c (tmp в operand1) или c-tmp (tmp в operand2)
         if (SubMI.getOperand(1).getReg() == MulDst ||
             SubMI.getOperand(2).getReg() == MulDst)
           break;
       } else if (isAdd) {
-        // -(tmp)+c → tmp in operand1
-        if (SubMI.getOperand(1).getReg() == MulDst)
+        // два варианта:
+        //   -(tmp)+c  → tmp в operand1
+        //    c+tmp    → tmp в operand2
+        if (SubMI.getOperand(1).getReg() == MulDst ||
+            SubMI.getOperand(2).getReg() == MulDst)
           break;
       }
     }
+
     if (SubIt == E)
       continue;
     MachineInstr &SubMI = *SubIt;
@@ -120,9 +124,9 @@ std::optional<unsigned> FMACombinePass::getFMAOpcode(unsigned MulOp,
                                                      bool IsSubLHSfirst) const {
   // Если это ADD-случай (-(a*b)+c), всегда VFNMADD213
   if (SubOp == X86::VADDSSrr)
-    return X86::VFNMADD213SSr;
+    return IsSubLHSfirst ? X86::VFNMADD213SSr : X86::VFNMADD132SSr;
   if (SubOp == X86::VADDSDrr)
-    return X86::VFNMADD213SDr;
+    return IsSubLHSfirst ? X86::VFNMADD213SDr : X86::VFNMADD132SDr;
 
   // Иначе SUB-случай:
   //   если tmp в lhs → (a*b)-c = VFMSUB213
@@ -155,9 +159,18 @@ bool FMACombinePass::checkRegisterUsage(const MachineInstr &MulMI,
   Register RHS = SubMI.getOperand(2).getReg();
 
   if (Op == X86::VADDSSrr || Op == X86::VADDSDrr) {
-    // ADD-case: -(tmp)+c → tmp must be in LHS
-    IsSubLHSfirst = true;
-    return LHS == MulDst;
+    // ADD-case:
+    //   -(tmp)+c → tmp in LHS  → IsSubLHSfirst = true
+    //    c + (tmp) → tmp in RHS → IsSubLHSfirst = false
+    if (LHS == MulDst) {
+      IsSubLHSfirst = true;
+      return true;
+    }
+    if (RHS == MulDst) {
+      IsSubLHSfirst = false;
+      return true;
+    }
+    return false;
   }
   // SUB-case:
   if (LHS == MulDst) {

--- a/llvm/test/compiler-course/korobeinikov_a_llvm_backend_test/korobeinikov_a_llvm_backend_test.mir
+++ b/llvm/test/compiler-course/korobeinikov_a_llvm_backend_test/korobeinikov_a_llvm_backend_test.mir
@@ -1,0 +1,143 @@
+#  RUN: llc -mtriple=x86_64-unknown-linux-gnu -mattr=+fma \
+#  RUN:     --load=%llvmshlibdir/FuseMulSubPass_Korobeinikov_Arseny_FIIT1_BACKEND%shlibext \
+#  RUN:     -run-pass=korobeinikov-fuse-mul-sub %s -o - | FileCheck %s
+
+--- |
+  ; ModuleID = 'FuseMulSubTests_Korobeinikov.ll'
+  source_filename = "FuseTests_Korobeinikov.cpp"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-pc-linux-gnu"
+
+  module asm ".globl _ZSt21ios_base_library_initv"
+
+  %"class.std::basic_ostream" = type { ptr, %"class.std::basic_ios" }
+  %"class.std::basic_ios" = type { %"class.std::ios_base", ptr, i8, i8, ptr, ptr, ptr, ptr }
+  %"class.std::ios_base" = type { ptr, i64, i64, i32, i32, i32, ptr, %"struct.std::ios_base::_Words", [8 x %"struct.std::ios_base::_Words"], i32, ptr, %"class.std::locale" }
+  %"struct.std::ios_base::_Words" = type { ptr, i64 }
+  %"class.std::locale" = type { ptr }
+
+  @_ZSt4cout = external global %"class.std::basic_ostream", align 8
+
+  define dso_local noundef float @korobeinikov_ss_fma_test(float %a, float %b, float %c) #0 {
+  entry:
+    %mul = fmul float %a, %b
+    %res = fsub float %c, %mul
+    ret float %res
+  }
+
+  define dso_local noundef float @korobeinikov_ss_neg_test(float %a, float %b, float %c) #0 {
+  entry:
+    %mul = fmul float %a, %b
+    %neg = fneg float %mul
+    %res = fadd float %neg, %c
+    ret float %res
+  }
+
+  define dso_local noundef double @korobeinikov_sd_fma_test(double %a, double %b, double %c) #0 {
+  entry:
+    %mul = fmul double %a, %b
+    %res = fsub double %c, %mul
+    ret double %res
+  }
+
+  attributes #0 = { nounwind "target-features"="+fma" }
+
+  !llvm.module.flags = !{!0, !1}
+  !llvm.ident = !{!2}
+
+  !0 = !{i32 1, !"wchar_size", i32 4}
+  !1 = !{i32 7, !"frame-pointer", i32 2}
+  !2 = !{!"Korobeinikov Custom Compiler"}
+
+# CHECK-LABEL: name: korobeinikov_ss_fma_test
+# CHECK: bb.0.entry:
+# CHECK-NOT: VMULSSrr
+# CHECK-NOT: VSUBSSrr
+# CHECK: %[[RES:[a-z0-9]+]]:fr32 = VFMSUB213SSr %0, %1, %2, implicit $mxcsr
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
+...
+---
+name:            korobeinikov_ss_fma_test
+alignment:       16
+tracksRegLiveness: true
+registers:
+  - { id: 0, class: fr32 }
+  - { id: 1, class: fr32 }
+  - { id: 2, class: fr32 }
+  - { id: 3, class: fr32 }
+  - { id: 4, class: fr32 }
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+    
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr
+    %4:fr32 = nofpexcept VSUBSSrr %2, killed %3, implicit $mxcsr
+    $xmm0 = COPY %4
+    RET64 implicit $xmm0
+
+# CHECK-LABEL: name: korobeinikov_ss_neg_test
+# CHECK: bb.0.entry:
+# CHECK-NOT: VMULSSrr
+# CHECK-NOT: VADDSSrr
+# CHECK: %[[RES:[a-z0-9]+]]:fr32 = VFMSUB213SSr
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
+...
+---
+name:            korobeinikov_ss_neg_test
+alignment:       16
+tracksRegLiveness: true
+registers:
+  - { id: 0, class: fr32 }
+  - { id: 1, class: fr32 }
+  - { id: 2, class: fr32 }
+  - { id: 3, class: fr32 }
+  - { id: 4, class: fr32 }
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+    
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr
+    %4:fr32 = nofpexcept VADDSSrr killed %3, %2, implicit $mxcsr
+    $xmm0 = COPY %4
+    RET64 implicit $xmm0
+
+# CHECK-LABEL: name: korobeinikov_sd_fma_test
+# CHECK: bb.0.entry:
+# CHECK-NOT: VMULSDrr
+# CHECK-NOT: VSUBSDrr
+# CHECK: %[[RES:[a-z0-9]+]]:fr64 = VFMSUB213SDr
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
+...
+---
+name:            korobeinikov_sd_fma_test
+alignment:       16
+tracksRegLiveness: true
+registers:
+  - { id: 0, class: fr64 }
+  - { id: 1, class: fr64 }
+  - { id: 2, class: fr64 }
+  - { id: 3, class: fr64 }
+  - { id: 4, class: fr64 }
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+    
+    %2:fr64 = COPY $xmm2
+    %1:fr64 = COPY $xmm1
+    %0:fr64 = COPY $xmm0
+    %3:fr64 = nofpexcept VMULSDrr %0, %1, implicit $mxcsr
+    %4:fr64 = nofpexcept VSUBSDrr %2, killed %3, implicit $mxcsr
+    $xmm0 = COPY %4
+    RET64 implicit $xmm0

--- a/llvm/test/compiler-course/korobeinikov_a_llvm_backend_test/korobeinikov_a_llvm_backend_test.mir
+++ b/llvm/test/compiler-course/korobeinikov_a_llvm_backend_test/korobeinikov_a_llvm_backend_test.mir
@@ -1,63 +1,16 @@
-#  RUN: llc -mtriple=x86_64-unknown-linux-gnu -mattr=+fma \
-#  RUN:     --load=%llvmshlibdir/FuseMulSubPass_Korobeinikov_Arseny_FIIT1_BACKEND%shlibext \
-#  RUN:     -run-pass=korobeinikov-fuse-mul-sub %s -o - | FileCheck %s
+# RUN: llc -mtriple=x86_64-unknown-linux-gnu -mattr=+fma \
+# RUN:     --load=%llvmshlibdir/FuseMulSubPass_Korobeinikov_Arseny_FIIT1_BACKEND%shlibext \
+# RUN:     -run-pass=korobeinikov-fuse-mul-sub %s -o - | FileCheck %s
 
---- |
-  ; ModuleID = 'FuseMulSubTests_Korobeinikov.ll'
-  source_filename = "FuseTests_Korobeinikov.cpp"
-  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-  target triple = "x86_64-pc-linux-gnu"
-
-  module asm ".globl _ZSt21ios_base_library_initv"
-
-  %"class.std::basic_ostream" = type { ptr, %"class.std::basic_ios" }
-  %"class.std::basic_ios" = type { %"class.std::ios_base", ptr, i8, i8, ptr, ptr, ptr, ptr }
-  %"class.std::ios_base" = type { ptr, i64, i64, i32, i32, i32, ptr, %"struct.std::ios_base::_Words", [8 x %"struct.std::ios_base::_Words"], i32, ptr, %"class.std::locale" }
-  %"struct.std::ios_base::_Words" = type { ptr, i64 }
-  %"class.std::locale" = type { ptr }
-
-  @_ZSt4cout = external global %"class.std::basic_ostream", align 8
-
-  define dso_local noundef float @korobeinikov_ss_fma_test(float %a, float %b, float %c) #0 {
-  entry:
-    %mul = fmul float %a, %b
-    %res = fsub float %c, %mul
-    ret float %res
-  }
-
-  define dso_local noundef float @korobeinikov_ss_neg_test(float %a, float %b, float %c) #0 {
-  entry:
-    %mul = fmul float %a, %b
-    %neg = fneg float %mul
-    %res = fadd float %neg, %c
-    ret float %res
-  }
-
-  define dso_local noundef double @korobeinikov_sd_fma_test(double %a, double %b, double %c) #0 {
-  entry:
-    %mul = fmul double %a, %b
-    %res = fsub double %c, %mul
-    ret double %res
-  }
-
-  attributes #0 = { nounwind "target-features"="+fma" }
-
-  !llvm.module.flags = !{!0, !1}
-  !llvm.ident = !{!2}
-
-  !0 = !{i32 1, !"wchar_size", i32 4}
-  !1 = !{i32 7, !"frame-pointer", i32 2}
-  !2 = !{!"Korobeinikov Custom Compiler"}
-
+# Проверка базового случая: c - (a*b) → VFNMADD213SS
 # CHECK-LABEL: name: korobeinikov_ss_fma_test
 # CHECK: bb.0.entry:
 # CHECK-NOT: VMULSSrr
 # CHECK-NOT: VSUBSSrr
-# CHECK: %[[RES:[a-z0-9]+]]:fr32 = VFMSUB213SSr %0, %1, %2, implicit $mxcsr
+# CHECK: %[[RES:[a-z0-9]+]]:fr32 = VFNMADD213SSr %0, %1, %2, implicit $mxcsr
 # CHECK: $xmm0 = COPY %[[RES]]
 # CHECK: RET64 implicit $xmm0
 
-...
 ---
 name:            korobeinikov_ss_fma_test
 alignment:       16
@@ -71,7 +24,7 @@ registers:
 body:             |
   bb.0.entry:
     liveins: $xmm0, $xmm1, $xmm2
-    
+
     %2:fr32 = COPY $xmm2
     %1:fr32 = COPY $xmm1
     %0:fr32 = COPY $xmm0
@@ -80,15 +33,15 @@ body:             |
     $xmm0 = COPY %4
     RET64 implicit $xmm0
 
+# Проверка случая с fneg + fadd: (-(a*b)) + c → тоже VFNMADD213SS
 # CHECK-LABEL: name: korobeinikov_ss_neg_test
 # CHECK: bb.0.entry:
 # CHECK-NOT: VMULSSrr
 # CHECK-NOT: VADDSSrr
-# CHECK: %[[RES:[a-z0-9]+]]:fr32 = VFMSUB213SSr
+# CHECK: %[[RES:[a-z0-9]+]]:fr32 = VFNMADD213SSr %0, %1, %2, implicit $mxcsr
 # CHECK: $xmm0 = COPY %[[RES]]
 # CHECK: RET64 implicit $xmm0
 
-...
 ---
 name:            korobeinikov_ss_neg_test
 alignment:       16
@@ -102,7 +55,7 @@ registers:
 body:             |
   bb.0.entry:
     liveins: $xmm0, $xmm1, $xmm2
-    
+
     %2:fr32 = COPY $xmm2
     %1:fr32 = COPY $xmm1
     %0:fr32 = COPY $xmm0
@@ -111,15 +64,15 @@ body:             |
     $xmm0 = COPY %4
     RET64 implicit $xmm0
 
+# Проверка случая с double: c - (a*b) → VFNMADD213SD
 # CHECK-LABEL: name: korobeinikov_sd_fma_test
 # CHECK: bb.0.entry:
 # CHECK-NOT: VMULSDrr
 # CHECK-NOT: VSUBSDrr
-# CHECK: %[[RES:[a-z0-9]+]]:fr64 = VFMSUB213SDr
+# CHECK: %[[RES:[a-z0-9]+]]:fr64 = VFNMADD213SDr %0, %1, %2, implicit $mxcsr
 # CHECK: $xmm0 = COPY %[[RES]]
 # CHECK: RET64 implicit $xmm0
 
-...
 ---
 name:            korobeinikov_sd_fma_test
 alignment:       16
@@ -133,11 +86,42 @@ registers:
 body:             |
   bb.0.entry:
     liveins: $xmm0, $xmm1, $xmm2
-    
+
     %2:fr64 = COPY $xmm2
     %1:fr64 = COPY $xmm1
     %0:fr64 = COPY $xmm0
     %3:fr64 = nofpexcept VMULSDrr %0, %1, implicit $mxcsr
     %4:fr64 = nofpexcept VSUBSDrr %2, killed %3, implicit $mxcsr
+    $xmm0 = COPY %4
+    RET64 implicit $xmm0
+
+# Проверка случая (a*b) - c → VFMSUB213SS
+# CHECK-LABEL: name: korobeinikov_ss_fmsub_test
+# CHECK: bb.0.entry:
+# CHECK-NOT: VMULSSrr
+# CHECK-NOT: VSUBSSrr
+# CHECK: %[[RES:[a-z0-9]+]]:fr32 = VFMSUB213SSr %0, %1, %2, implicit $mxcsr
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
+---
+name:            korobeinikov_ss_fmsub_test
+alignment:       16
+tracksRegLiveness: true
+registers:
+  - { id: 0, class: fr32 }
+  - { id: 1, class: fr32 }
+  - { id: 2, class: fr32 }
+  - { id: 3, class: fr32 }
+  - { id: 4, class: fr32 }
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr
+    %4:fr32 = nofpexcept VSUBSSrr killed %3, %2, implicit $mxcsr
     $xmm0 = COPY %4
     RET64 implicit $xmm0

--- a/llvm/test/compiler-course/korobeinikov_a_llvm_backend_test/korobeinikov_a_llvm_backend_test.mir
+++ b/llvm/test/compiler-course/korobeinikov_a_llvm_backend_test/korobeinikov_a_llvm_backend_test.mir
@@ -125,3 +125,33 @@ body:             |
     %4:fr32 = nofpexcept VSUBSSrr killed %3, %2, implicit $mxcsr
     $xmm0 = COPY %4
     RET64 implicit $xmm0
+
+# Проверка случая с порядком 132: c  (a*b) → VFNMADD132SS
+# CHECK-LABEL: name: korobeinikov_ss_fma132_add_test
+# CHECK: bb.0.entry:
+# CHECK-NOT: VMULSSrr
+# CHECK-NOT: VADDSSrr
+# CHECK: %[[RES:[a-z0-9]]]:fr32 = VFNMADD132SSr %0, %1, %2, implicit $mxcsr
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+---
+name:            korobeinikov_ss_fma132_add_test
+alignment:       16
+tracksRegLiveness: true
+registers:
+  - { id: 0, class: fr32 }
+  - { id: 1, class: fr32 }
+  - { id: 2, class: fr32 }
+  - { id: 3, class: fr32 }
+  - { id: 4, class: fr32 }
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+
+    %2:fr32 = COPY $xmm2      ; c
+    %0:fr32 = COPY $xmm0      ; a
+    %1:fr32 = COPY $xmm1      ; b
+    %3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr  ; tmp = a * b
+    %4:fr32 = nofpexcept VADDSSrr %2, killed %3, implicit $mxcsr  ; c  tmp
+    $xmm0 = COPY %4
+    RET64 implicit $xmm0


### PR DESCRIPTION
Оптимизация FMA: объединение умножения и сложения/вычитания в FMA-инструкции

Этот патч добавляет новый MachineFunctionPass, который ищет в коде паттерны из инструкций умножения (MUL) и сложения/вычитания (ADD/SUB) с плавающей точкой и заменяет их на соответствующие FMA-инструкции (VFMSUB213/VFNMADD213), когда это возможно.

Основные особенности:
1. Обрабатывает скалярные и векторные операции (SS/SD/PS/PD)
2. Поддерживает два варианта замены:
   - (a * b) - c → VFMSUB213
   - c - (a * b) → VFNMADD213
   - -(a * b) + c → VFNMADD213 (через преобразование ADD)
3. Проверяет корректность использования регистров
4. Работает только когда результат умножения имеет ровно одно использование
5. Активируется только для целевых процессоров с поддержкой FMA