### PR TITLE
Кошкин Никита. Лабораторная работа 4: MLIR. Вариант 6.

### DIFF
--- a/mlir/compiler-course/koshkin_n_mlir/CMakeLists.txt
+++ b/mlir/compiler-course/koshkin_n_mlir/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(Title "GenericCallCounter")
+set(Student "Koshkin_Nikita")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_MLIR")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    MLIRBuiltinLocationAttributesIncGen
+    BUILDTREE_ONLY
+)
+
+set(MLIR_TEST_DEPENDS ${TARGET_NAME} ${MLIR_TEST_DEPENDS} PARENT_SCOPE)

--- a/mlir/compiler-course/koshkin_n_mlir/koshkin_n_mlir.cpp
+++ b/mlir/compiler-course/koshkin_n_mlir/koshkin_n_mlir.cpp
@@ -1,0 +1,65 @@
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/CallInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Tools/Plugins/PassPlugin.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir;
+
+namespace {
+class GenericCallCounter
+    : public PassWrapper<GenericCallCounter, OperationPass<ModuleOp>> {
+public:
+  StringRef getArgument() const final {
+    return "GenericCallCounter_Koshkin_Nikita_FIIT3_MLIR";
+  }
+  StringRef getDescription() const final { return "Description pass"; }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+
+    SmallVector<CallOpInterface, 8> gloabalCalls;
+    module.walk([&](Operation *OP) {
+      if (auto call = dyn_cast<CallOpInterface>(OP))
+        gloabalCalls.push_back(call);
+    });
+
+    llvm::StringMap<int64_t> globalCounts;
+    for (auto &call : gloabalCalls) {
+      if (auto symCallAttr =
+              call.getCallableForCallee().dyn_cast<SymbolRefAttr>()) {
+        StringRef nameCallee = symCallAttr.getRootReference().getValue();
+        globalCounts[nameCallee]++;
+      }
+    }
+
+    OpBuilder builder(module.getContext());
+    for (auto &call : gloabalCalls) {
+      if (auto symCallAttr =
+              call.getCallableForCallee().dyn_cast<SymbolRefAttr>()) {
+        StringRef nameCallee = symCallAttr.getRootReference().getValue();
+        int64_t n = globalCounts.lookup(nameCallee);
+        call->setAttr("func.call_count", builder.getIndexAttr(n));
+      }
+    }
+  }
+};
+} // namespace
+
+MLIR_DECLARE_EXPLICIT_TYPE_ID(GenericCallCounter)
+MLIR_DEFINE_EXPLICIT_TYPE_ID(GenericCallCounter)
+
+mlir::PassPluginLibraryInfo getFunctionCallCounterPassPluginInfo() {
+  return {MLIR_PLUGIN_API_VERSION, "GenericCallCounter", "1.2",
+          []() { mlir::PassRegistration<GenericCallCounter>(); }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo
+mlirGetPassPluginInfo() {
+  return getFunctionCallCounterPassPluginInfo();
+}

--- a/mlir/compiler-course/koshkin_n_mlir/koshkin_n_mlir.cpp
+++ b/mlir/compiler-course/koshkin_n_mlir/koshkin_n_mlir.cpp
@@ -23,14 +23,13 @@ public:
   void runOnOperation() override {
     ModuleOp module = getOperation();
 
-    SmallVector<CallOpInterface, 8> gloabalCalls;
-    module.walk([&](Operation *OP) {
-      if (auto call = dyn_cast<CallOpInterface>(OP))
-        gloabalCalls.push_back(call);
+    SmallVector<CallOpInterface, 8> globalCalls;
+    module.walk([&](CallOpInterface callOp) {
+        globalCalls.push_back(callOp);
     });
 
     llvm::StringMap<int64_t> globalCounts;
-    for (auto &call : gloabalCalls) {
+    for (auto &call : globalCalls) {
       if (auto symCallAttr =
               call.getCallableForCallee().dyn_cast<SymbolRefAttr>()) {
         StringRef nameCallee = symCallAttr.getRootReference().getValue();
@@ -39,7 +38,7 @@ public:
     }
 
     OpBuilder builder(module.getContext());
-    for (auto &call : gloabalCalls) {
+    for (auto &call : globalCalls) {
       if (auto symCallAttr =
               call.getCallableForCallee().dyn_cast<SymbolRefAttr>()) {
         StringRef nameCallee = symCallAttr.getRootReference().getValue();

--- a/mlir/compiler-course/koshkin_n_mlir/koshkin_n_mlir.cpp
+++ b/mlir/compiler-course/koshkin_n_mlir/koshkin_n_mlir.cpp
@@ -24,9 +24,7 @@ public:
     ModuleOp module = getOperation();
 
     SmallVector<CallOpInterface, 8> globalCalls;
-    module.walk([&](CallOpInterface callOp) {
-        globalCalls.push_back(callOp);
-    });
+    module.walk([&](CallOpInterface callOp) { globalCalls.push_back(callOp); });
 
     llvm::StringMap<int64_t> globalCounts;
     for (auto &call : globalCalls) {

--- a/mlir/test/compiler-course/koshkin_n_mlir_test/koshkin_n_mlir_test.mlir
+++ b/mlir/test/compiler-course/koshkin_n_mlir_test/koshkin_n_mlir_test.mlir
@@ -1,0 +1,57 @@
+// RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/GenericCallCounter_Koshkin_Nikita_FIIT3_MLIR%shlibext \
+// RUN: --pass-pipeline="builtin.module(GenericCallCounter_Koshkin_Nikita_FIIT3_MLIR)" %s | FileCheck --implicit-check-not="call @unused() {func.call_count =" %s
+
+module {
+  func.func @foo() -> () {
+    func.return
+  }
+
+  func.func @bar() -> () {
+    func.return
+  }
+
+  func.func @baz() -> () {
+    func.return
+  }
+
+  func.func @util() -> () {
+    func.return
+  }
+
+  // CHECK-LABEL: func.func @main()
+  // CHECK-NEXT: call @foo() {func.call_count = 3 : index} : () -> ()
+  // CHECK-NEXT: call @foo() {func.call_count = 3 : index} : () -> ()
+  // CHECK-NEXT: call @bar() {func.call_count = 2 : index} : () -> ()
+  // CHECK-NEXT: call @baz() {func.call_count = 1 : index} : () -> ()
+  func.func @main() -> () {
+    call @foo() : () -> ()
+    call @foo() : () -> ()
+    call @bar() : () -> ()
+    call @baz() : () -> ()
+    func.return
+  }
+
+  // CHECK-LABEL: func.func @withNested()
+  // CHECK-DAG: call @util() {func.call_count = 2 : index} : () -> ()
+  // CHECK-DAG: call @util() {func.call_count = 2 : index} : () -> ()
+  // CHECK-DAG: call @bar() {func.call_count = 2 : index} : () -> ()
+  func.func @withNested() -> () {
+    call @util() : () -> ()
+    call @bar() : () -> ()
+    call @util() : () -> ()
+    func.return
+  }
+
+  // CHECK-LABEL: func.func @noCalls()
+  // CHECK-NOT: call_count
+  func.func @noCalls() -> () {
+    func.return
+  }
+
+  // CHECK-LABEL: func.func @mixed()
+  // CHECK: call @foo() {func.call_count = 3 : index} : () -> ()
+  func.func @mixed() -> () {
+    call @foo() : () -> ()
+    func.return
+  }
+}


### PR DESCRIPTION
Данный GenericCallCounter pass собирает все вызовы функций в модуле, подсчитывает количество вызовов каждой функции и проставляет для каждого вызова атрибут func.call_count с этим количеством вызовов.