### PR TITLE
Дормидонтов Егор. Лабораторная работа 1. Clang AST. Вариант 4

### DIFF
--- a/clang/compiler-course/egor_dormidontov_lab1/CMakeLists.txt
+++ b/clang/compiler-course/egor_dormidontov_lab1/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "PrefixCallbackPlugin")
+set(Student "Dormidontov_Egor")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/egor_dormidontov_lab1/lab1_ast_egor.cpp
+++ b/clang/compiler-course/egor_dormidontov_lab1/lab1_ast_egor.cpp
@@ -1,0 +1,158 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/ASTTypeTraits.h"
+#include "clang/AST/ParentMapContext.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include <unordered_map>
+
+using namespace clang;
+
+namespace {
+
+class PrefixCallbackVisitor
+    : public RecursiveASTVisitor<PrefixCallbackVisitor> {
+public:
+  PrefixCallbackVisitor(ASTContext *context, Rewriter &rewriter)
+      : Context(context), TheRewriter(rewriter) {}
+
+  bool VisitFunctionDecl(FunctionDecl *func) {
+    if (!func->hasBody())
+      return true;
+    funcDecl2Map[func] = std::unordered_map<const ValueDecl *, std::string>();
+
+    for (auto *param : func->parameters()) {
+      std::string newName = "param_" + param->getNameAsString();
+      funcDecl2Map[func][param] = newName;
+      TheRewriter.ReplaceText(param->getLocation(),
+                              param->getNameAsString().length(), newName);
+    }
+    return true;
+  }
+
+  bool VisitVarDecl(VarDecl *decl) {
+    const FunctionDecl *func = findParentFunction(decl);
+    if (func && decl->isLocalVarDecl() && !decl->isStaticLocal()) {
+      std::string newName = "local_" + decl->getNameAsString();
+      funcDecl2Map[func][decl] = newName;
+      TheRewriter.ReplaceText(decl->getLocation(),
+                              decl->getNameAsString().length(), newName);
+      return true;
+    }
+    if (func && decl->isStaticLocal()) {
+      std::string newName = "static_" + decl->getNameAsString();
+      funcDecl2Map[func][decl] = newName;
+      TheRewriter.ReplaceText(decl->getLocation(),
+                              decl->getNameAsString().length(), newName);
+      return true;
+    }
+    if (decl->isFileVarDecl() && decl->hasGlobalStorage() &&
+        !decl->isStaticLocal()) {
+      std::string newName = "global_" + decl->getNameAsString();
+      TheRewriter.ReplaceText(decl->getLocation(),
+                              decl->getNameAsString().length(), newName);
+      return true;
+    }
+    return true;
+  }
+
+  bool VisitDeclRefExpr(DeclRefExpr *expr) {
+    const ValueDecl *vd = dyn_cast<ValueDecl>(expr->getDecl());
+    if (!vd)
+      return true;
+    if (!Context->getSourceManager().isWrittenInMainFile(expr->getLocation()))
+      return true;
+    const FunctionDecl *func = findParentFunction(expr);
+    if (func) {
+      auto fit = funcDecl2Map.find(func);
+      if (fit != funcDecl2Map.end()) {
+        auto it = fit->second.find(vd);
+        if (it != fit->second.end()) {
+          TheRewriter.ReplaceText(expr->getLocation(),
+                                  vd->getNameAsString().length(), it->second);
+        }
+      }
+    } else {
+      if (const VarDecl *gvd = dyn_cast<VarDecl>(vd)) {
+        if (gvd->hasGlobalStorage() && !gvd->isStaticLocal()) {
+          std::string newName = "global_" + vd->getNameAsString();
+          TheRewriter.ReplaceText(expr->getLocation(),
+                                  vd->getNameAsString().length(), newName);
+        }
+      }
+    }
+    return true;
+  }
+
+private:
+  ASTContext *Context;
+  Rewriter &TheRewriter;
+  std::unordered_map<const FunctionDecl *,
+                     std::unordered_map<const ValueDecl *, std::string>>
+      funcDecl2Map;
+
+  const FunctionDecl *findParentFunction(const Decl *decl) {
+    const auto &parents = Context->getParents(*decl);
+    if (!parents.empty()) {
+      if (const FunctionDecl *func = parents[0].get<FunctionDecl>())
+        return func;
+      if (const Decl *parentDecl = parents[0].get<Decl>())
+        return findParentFunction(parentDecl);
+    }
+    return nullptr;
+  }
+  const FunctionDecl *findParentFunction(const Stmt *stmt) {
+    const auto &parents = Context->getParents(*stmt);
+    if (!parents.empty()) {
+      if (const FunctionDecl *func = parents[0].get<FunctionDecl>())
+        return func;
+      if (const Stmt *parentStmt = parents[0].get<Stmt>())
+        return findParentFunction(parentStmt);
+    }
+    return nullptr;
+  }
+};
+
+class PrefixCallbackConsumer : public ASTConsumer {
+public:
+  PrefixCallbackConsumer(ASTContext *context, Rewriter &rewriter)
+      : Visitor(context, rewriter) {}
+
+  void HandleTranslationUnit(ASTContext &context) override {
+    Visitor.TraverseDecl(context.getTranslationUnitDecl());
+  }
+
+private:
+  PrefixCallbackVisitor Visitor;
+};
+
+class PrefixCallbackAction : public PluginASTAction {
+public:
+  std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &ci,
+                                                 llvm::StringRef) override {
+    TheRewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
+    return std::make_unique<PrefixCallbackConsumer>(&ci.getASTContext(),
+                                                    TheRewriter);
+  }
+
+  bool ParseArgs(const CompilerInstance &,
+                 const std::vector<std::string> &) override {
+    return true;
+  }
+
+  void EndSourceFileAction() override {
+    TheRewriter.getEditBuffer(TheRewriter.getSourceMgr().getMainFileID())
+        .write(llvm::outs());
+  }
+
+private:
+  Rewriter TheRewriter;
+};
+
+} // namespace
+
+static FrontendPluginRegistry::Add<PrefixCallbackAction>
+    X("prefix_var_callback_plugin",
+      "Add static_, local_, global_, param_ to variable names (unique logic)");

--- a/clang/compiler-course/egor_dormidontov_lab1/lab1_ast_egor.cpp
+++ b/clang/compiler-course/egor_dormidontov_lab1/lab1_ast_egor.cpp
@@ -18,17 +18,21 @@ public:
   PrefixCallbackVisitor(ASTContext *context, Rewriter &rewriter)
       : Context(context), TheRewriter(rewriter) {}
 
+  bool VisitParmVarDecl(ParmVarDecl *param) {
+    const FunctionDecl *func = findParentFunction(param);
+    if (!func)
+      return true;
+    std::string newName = "param_" + param->getNameAsString();
+    funcDecl2Map[func][param] = newName;
+    TheRewriter.ReplaceText(param->getLocation(),
+                            param->getNameAsString().length(), newName);
+    return true;
+  }
+
   bool VisitFunctionDecl(FunctionDecl *func) {
     if (!func->hasBody())
       return true;
     funcDecl2Map[func] = std::unordered_map<const ValueDecl *, std::string>();
-
-    for (auto *param : func->parameters()) {
-      std::string newName = "param_" + param->getNameAsString();
-      funcDecl2Map[func][param] = newName;
-      TheRewriter.ReplaceText(param->getLocation(),
-                              param->getNameAsString().length(), newName);
-    }
     return true;
   }
 
@@ -93,22 +97,14 @@ private:
                      std::unordered_map<const ValueDecl *, std::string>>
       funcDecl2Map;
 
-  const FunctionDecl *findParentFunction(const Decl *decl) {
-    const auto &parents = Context->getParents(*decl);
+  template <typename T> const FunctionDecl *findParentFunction(const T *node) {
+    const auto &parents = Context->getParents(*node);
     if (!parents.empty()) {
-      if (const FunctionDecl *func = parents[0].get<FunctionDecl>())
+      if (const FunctionDecl *func = parents[0].template get<FunctionDecl>())
         return func;
-      if (const Decl *parentDecl = parents[0].get<Decl>())
+      if (const Decl *parentDecl = parents[0].template get<Decl>())
         return findParentFunction(parentDecl);
-    }
-    return nullptr;
-  }
-  const FunctionDecl *findParentFunction(const Stmt *stmt) {
-    const auto &parents = Context->getParents(*stmt);
-    if (!parents.empty()) {
-      if (const FunctionDecl *func = parents[0].get<FunctionDecl>())
-        return func;
-      if (const Stmt *parentStmt = parents[0].get<Stmt>())
+      if (const Stmt *parentStmt = parents[0].template get<Stmt>())
         return findParentFunction(parentStmt);
     }
     return nullptr;

--- a/clang/test/compiler-course/dormidontov_egor_lab1/test_lab1.cpp
+++ b/clang/test/compiler-course/dormidontov_egor_lab1/test_lab1.cpp
@@ -1,0 +1,33 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/PrefixCallbackPlugin_Dormidontov_Egor_FIIT2_ClangAST%pluginext -plugin prefix_var_callback_plugin -fsyntax-only %s 2>&1 | FileCheck %s
+
+// CHECK: int global_var1 = 0;
+// CHECK: int foo(int param_a, int param_b) {
+// CHECK:   static int static_var2 = 0;
+// CHECK:   int local_var3 = 123;
+// CHECK:   ++static_var2;
+// CHECK:   return param_a + param_b + global_var1 + static_var2 + local_var3;
+// CHECK: }
+// CHECK: int bar(int param_x) {
+// CHECK:   int local_y = 0;
+// CHECK:   for (int local_i = 0; local_i < param_x; ++local_i) {
+// CHECK:     local_y += global_var1 + param_x + local_i;
+// CHECK:   }
+// CHECK:   return local_y;
+// CHECK: }
+
+int var1 = 0;
+
+int foo(int a, int b) {
+  static int var2 = 0;
+  int var3 = 123;
+  ++var2;
+  return a + b + var1 + var2 + var3;
+}
+
+int bar(int x) {
+  int y = 0;
+  for (int i = 0; i < x; ++i) {
+    y += var1 + x + i;
+  }
+  return y;
+}

--- a/clang/test/compiler-course/dormidontov_egor_lab1/test_lab1.cpp
+++ b/clang/test/compiler-course/dormidontov_egor_lab1/test_lab1.cpp
@@ -9,6 +9,7 @@
 // CHECK: }
 // CHECK: int bar(int param_x) {
 // CHECK:   int local_y = 0;
+// CHECK:   long long local_var1 = 9LL;
 // CHECK:   for (int local_i = 0; local_i < param_x; ++local_i) {
 // CHECK:     local_y += global_var1 + param_x + local_i;
 // CHECK:   }
@@ -26,6 +27,7 @@ int foo(int a, int b) {
 
 int bar(int x) {
   int y = 0;
+  long long var1 = 9LL;
   for (int i = 0; i < x; ++i) {
     y += var1 + x + i;
   }


### PR DESCRIPTION
Данный плагин для Clang автоматически добавляет к именам переменных и параметров в коде специальные префиксы:

global_ - ко всем глобальным переменным;

static_ - к статическим локальным переменным;

local_ - к обычным локальным переменным внутри функций,;
param_ - ко всем параметрам функций;

Префиксы добавляются в местах объявления и во всех местах использования переменных: внутри выражений, циклов и тд.