### PR TITLE
Дормидонтов Егор. Лабораторная работа 2. LLVM IR. Вариант 4

### DIFF
--- a/llvm/compiler-course/llvm-ir/dormidontov_egor_lab2/CMakeLists.txt
+++ b/llvm/compiler-course/llvm-ir/dormidontov_egor_lab2/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(Title "DivToBitwiseShiftPass")
+set(Student "Dormidontov_Egor")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_LLVM_IR")
+
+if (NOT WIN32 AND NOT CYGWIN)
+    file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+    add_llvm_pass_plugin(${TARGET_NAME} ${SOURCES}
+        DEPENDS
+        intrinsics_gen
+        BUILDTREE_ONLY
+    )
+    set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)
+endif()

--- a/llvm/compiler-course/llvm-ir/dormidontov_egor_lab2/lab2.cpp
+++ b/llvm/compiler-course/llvm-ir/dormidontov_egor_lab2/lab2.cpp
@@ -1,0 +1,79 @@
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/raw_ostream.h"
+#include <cmath>
+
+using namespace llvm;
+
+namespace {
+static bool isPowerOfTwo(uint64_t n) { return n && !(n & (n - 1)); }
+
+static unsigned getLog2(uint64_t n) {
+  // n - степень двойки, log2(n) - позиция единственного бита
+  unsigned res = 0;
+  while (n >>= 1)
+    ++res;
+  return res;
+}
+
+struct DivToBitwiseShiftPass : llvm::PassInfoMixin<DivToBitwiseShiftPass> {
+  llvm::PreservedAnalyses run(llvm::Function &func,
+                              llvm::FunctionAnalysisManager &) {
+    bool changed = false;
+
+    for (auto &BB : func) {
+      for (auto it = BB.begin(); it != BB.end();) {
+        Instruction *inst = &*it++;
+        if (auto *div = dyn_cast<BinaryOperator>(inst)) {
+          if (div->getOpcode() == Instruction::SDiv ||
+              div->getOpcode() == Instruction::UDiv) {
+
+            if (auto *C = dyn_cast<ConstantInt>(div->getOperand(1))) {
+              uint64_t divisor = C->getZExtValue();
+              if (isPowerOfTwo(divisor)) {
+                unsigned shift = getLog2(divisor);
+                IRBuilder<> builder(div);
+
+                Value *lhs = div->getOperand(0);
+                Value *shift_amt = ConstantInt::get(lhs->getType(), shift);
+
+                Value *newInstr = nullptr;
+                if (div->getOpcode() == Instruction::SDiv) {
+                  newInstr = builder.CreateAShr(lhs, shift_amt, "div2shift");
+                } else {
+                  newInstr = builder.CreateLShr(lhs, shift_amt, "div2shift");
+                }
+                div->replaceAllUsesWith(newInstr);
+                div->eraseFromParent();
+                changed = true;
+              }
+            }
+          }
+        }
+      }
+    }
+    return changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+  }
+
+  static bool isRequired() { return true; }
+};
+} // namespace
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "DivToBitwiseShiftPass", "0.1",
+          [](llvm::PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](llvm::StringRef name, llvm::FunctionPassManager &FPM,
+                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) -> bool {
+                  if (name == "div-to-shift") {
+                    FPM.addPass(DivToBitwiseShiftPass{});
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}

--- a/llvm/compiler-course/llvm-ir/dormidontov_egor_lab2/lab2.cpp
+++ b/llvm/compiler-course/llvm-ir/dormidontov_egor_lab2/lab2.cpp
@@ -3,21 +3,12 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
-#include <cmath>
 
 using namespace llvm;
 
 namespace {
-static bool isPowerOfTwo(uint64_t N) { return N && !(N & (N - 1)); }
-
-static unsigned getLog2(uint64_t N) {
-  // N Ч степень двойки, log2(N) Ч позици¤ единственного бита
-  unsigned Res = 0;
-  while (N >>= 1)
-    ++Res;
-  return Res;
-}
 
 struct DivToBitwiseShiftPass : PassInfoMixin<DivToBitwiseShiftPass> {
   PreservedAnalyses run(Function &Func, FunctionAnalysisManager &) {
@@ -32,8 +23,8 @@ struct DivToBitwiseShiftPass : PassInfoMixin<DivToBitwiseShiftPass> {
 
             if (auto *C = dyn_cast<ConstantInt>(Div->getOperand(1))) {
               uint64_t Divisor = C->getZExtValue();
-              if (isPowerOfTwo(Divisor)) {
-                unsigned ShiftAmt = getLog2(Divisor);
+              if (isPowerOf2_64(Divisor)) {
+                unsigned ShiftAmt = Log2_64(Divisor);
                 IRBuilder<> Builder(Div);
 
                 Value *LHS = Div->getOperand(0);

--- a/llvm/compiler-course/llvm-ir/dormidontov_egor_lab2/lab2.cpp
+++ b/llvm/compiler-course/llvm-ir/dormidontov_egor_lab2/lab2.cpp
@@ -9,55 +9,53 @@
 using namespace llvm;
 
 namespace {
-static bool isPowerOfTwo(uint64_t n) { return n && !(n & (n - 1)); }
+static bool isPowerOfTwo(uint64_t N) { return N && !(N & (N - 1)); }
 
-static unsigned getLog2(uint64_t n) {
-  // n - ñòåïåíü äâîéêè, log2(n) - ïîçèöèÿ åäèíñòâåííîãî áèòà
-  unsigned res = 0;
-  while (n >>= 1)
-    ++res;
-  return res;
+static unsigned getLog2(uint64_t N) {
+  // N Ð§ ÑÑ‚ÐµÐ¿ÐµÐ½ÑŒ Ð´Ð²Ð¾Ð¹ÐºÐ¸, log2(N) Ð§ Ð¿Ð¾Ð·Ð¸Ñ†Ð¸Â¤ ÐµÐ´Ð¸Ð½ÑÑ‚Ð²ÐµÐ½Ð½Ð¾Ð³Ð¾ Ð±Ð¸Ñ‚Ð°
+  unsigned Res = 0;
+  while (N >>= 1)
+    ++Res;
+  return Res;
 }
 
-struct DivToBitwiseShiftPass : llvm::PassInfoMixin<DivToBitwiseShiftPass> {
-  llvm::PreservedAnalyses run(llvm::Function &func,
-                              llvm::FunctionAnalysisManager &) {
-    bool changed = false;
+struct DivToBitwiseShiftPass : PassInfoMixin<DivToBitwiseShiftPass> {
+  PreservedAnalyses run(Function &Func, FunctionAnalysisManager &) {
+    bool Changed = false;
 
-    for (auto &BB : func) {
-      for (auto it = BB.begin(); it != BB.end();) {
-        Instruction *inst = &*it++;
-        if (auto *div = dyn_cast<BinaryOperator>(inst)) {
-          if (div->getOpcode() == Instruction::SDiv ||
-              div->getOpcode() == Instruction::UDiv) {
+    for (auto &BB : Func) {
+      for (auto It = BB.begin(); It != BB.end();) {
+        Instruction *Inst = &*It++;
+        if (auto *Div = dyn_cast<BinaryOperator>(Inst)) {
+          if (Div->getOpcode() == Instruction::SDiv ||
+              Div->getOpcode() == Instruction::UDiv) {
 
-            if (auto *C = dyn_cast<ConstantInt>(div->getOperand(1))) {
-              uint64_t divisor = C->getZExtValue();
-              if (isPowerOfTwo(divisor)) {
-                unsigned shift = getLog2(divisor);
-                IRBuilder<> builder(div);
+            if (auto *C = dyn_cast<ConstantInt>(Div->getOperand(1))) {
+              uint64_t Divisor = C->getZExtValue();
+              if (isPowerOfTwo(Divisor)) {
+                unsigned ShiftAmt = getLog2(Divisor);
+                IRBuilder<> Builder(Div);
 
-                Value *lhs = div->getOperand(0);
-                Value *shift_amt = ConstantInt::get(lhs->getType(), shift);
+                Value *LHS = Div->getOperand(0);
+                Value *ShiftValue = ConstantInt::get(LHS->getType(), ShiftAmt);
 
-                Value *newInstr = nullptr;
-                if (div->getOpcode() == Instruction::SDiv) {
-                  newInstr = builder.CreateAShr(lhs, shift_amt, "div2shift");
+                Value *NewInstr = nullptr;
+                if (Div->getOpcode() == Instruction::SDiv) {
+                  NewInstr = Builder.CreateAShr(LHS, ShiftValue, "div2shift");
                 } else {
-                  newInstr = builder.CreateLShr(lhs, shift_amt, "div2shift");
+                  NewInstr = Builder.CreateLShr(LHS, ShiftValue, "div2shift");
                 }
-                div->replaceAllUsesWith(newInstr);
-                div->eraseFromParent();
-                changed = true;
+                Div->replaceAllUsesWith(NewInstr);
+                Div->eraseFromParent();
+                Changed = true;
               }
             }
           }
         }
       }
     }
-    return changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+    return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
   }
-
   static bool isRequired() { return true; }
 };
 } // namespace

--- a/llvm/compiler-course/llvm-ir/dormidontov_egor_lab2/lab2.cpp
+++ b/llvm/compiler-course/llvm-ir/dormidontov_egor_lab2/lab2.cpp
@@ -22,23 +22,47 @@ struct DivToBitwiseShiftPass : PassInfoMixin<DivToBitwiseShiftPass> {
               Div->getOpcode() == Instruction::UDiv) {
 
             if (auto *C = dyn_cast<ConstantInt>(Div->getOperand(1))) {
-              uint64_t Divisor = C->getZExtValue();
-              if (isPowerOf2_64(Divisor)) {
-                unsigned ShiftAmt = Log2_64(Divisor);
-                IRBuilder<> Builder(Div);
+              int64_t Divisor = C->getSExtValue();
 
-                Value *LHS = Div->getOperand(0);
-                Value *ShiftValue = ConstantInt::get(LHS->getType(), ShiftAmt);
+              if (Div->getOpcode() == Instruction::SDiv) {
+                int64_t AbsDiv = std::abs(Divisor);
+                if (AbsDiv > 0 && isPowerOf2_64(AbsDiv)) {
+                  unsigned ShiftAmt = Log2_64(AbsDiv);
+                  IRBuilder<> Builder(Div);
 
-                Value *NewInstr = nullptr;
-                if (Div->getOpcode() == Instruction::SDiv) {
-                  NewInstr = Builder.CreateAShr(LHS, ShiftValue, "div2shift");
-                } else {
-                  NewInstr = Builder.CreateLShr(LHS, ShiftValue, "div2shift");
+                  Value *LHS = Div->getOperand(0);
+                  Value *ShiftValue =
+                      ConstantInt::get(LHS->getType(), ShiftAmt);
+                  Value *Shifted =
+                      Builder.CreateAShr(LHS, ShiftValue, "div2shift");
+
+                  Value *NewInstr = Shifted;
+                  if (Divisor < 0) {
+                    NewInstr = Builder.CreateSub(
+                        ConstantInt::get(LHS->getType(), 0), Shifted, "neg");
+                  }
+
+                  Div->replaceAllUsesWith(NewInstr);
+                  Div->eraseFromParent();
+                  Changed = true;
                 }
-                Div->replaceAllUsesWith(NewInstr);
-                Div->eraseFromParent();
-                Changed = true;
+              } else {
+                uint64_t UDivisor = C->getZExtValue();
+                if (UDivisor > 0 && isPowerOf2_64(UDivisor)) {
+                  unsigned ShiftAmt = Log2_64(UDivisor);
+                  IRBuilder<> Builder(Div);
+
+                  Value *LHS = Div->getOperand(0);
+                  Value *ShiftValue =
+                      ConstantInt::get(LHS->getType(), ShiftAmt);
+
+                  Value *NewInstr =
+                      Builder.CreateLShr(LHS, ShiftValue, "div2shift");
+
+                  Div->replaceAllUsesWith(NewInstr);
+                  Div->eraseFromParent();
+                  Changed = true;
+                }
               }
             }
           }

--- a/llvm/test/compiler-course/dormidontov_egor_lab2/lab2_test_llvm_ir.ll
+++ b/llvm/test/compiler-course/dormidontov_egor_lab2/lab2_test_llvm_ir.ll
@@ -49,3 +49,50 @@ entry:
   ret i32 %mul
 }
 
+; ###Проверка, что деление на не-степень двойки (17) НЕ заменяется
+; ###Вход:  return value / 17;
+; ###После пасса:  return value / 17;  // никаких сдвигов
+; CHECK-LABEL: @divide_by_seventeen
+; CHECK: sdiv i32 %{{[^,]+}}, 17
+
+define i32 @divide_by_seventeen(i32 %val) {
+entry:
+  %div = sdiv i32 %val, 17
+  ret i32 %div
+}
+
+; ###Проверка, что деление на не-степень двойки (3) НЕ заменяется
+; ###Вход:  return value / 3;
+; ###После пасса:  return value / 3;  // никаких сдвигов
+; CHECK-LABEL: @divide_by_three
+; CHECK: sdiv i32 %{{[^,]+}}, 3
+
+define i32 @divide_by_three(i32 %val) {
+entry:
+  %div = sdiv i32 %val, 3
+  ret i32 %div
+}
+
+; ###Проверка замены деления на степень двойки (16) на сдвиг вправо
+; ###Вход:  return value / 16;
+; ###После пасса:  return value >> 4;
+; CHECK-LABEL: @divide_by_sixteen
+; CHECK: ashr i32 %{{[^,]+}}, 4
+
+define i32 @divide_by_sixteen(i32 %val) {
+entry:
+  %div = sdiv i32 %val, 16
+  ret i32 %div
+}
+
+; ###Проверка замены деления на степень двойки (2) на сдвиг вправо
+; ###Вход:  return value / 2;
+; ###После пасса:  return value >> 1;
+; CHECK-LABEL: @divide_by_two
+; CHECK: ashr i32 %{{[^,]+}}, 1
+
+define i32 @divide_by_two(i32 %val) {
+entry:
+  %div = sdiv i32 %val, 2
+  ret i32 %div
+}

--- a/llvm/test/compiler-course/dormidontov_egor_lab2/lab2_test_llvm_ir.ll
+++ b/llvm/test/compiler-course/dormidontov_egor_lab2/lab2_test_llvm_ir.ll
@@ -1,0 +1,51 @@
+; RUN: opt -load-pass-plugin %llvmshlibdir/DivToBitwiseShiftPass_Dormidontov_Egor_FIIT2_LLVM_IR%pluginext \
+; RUN: -passes=div-to-shift -S %s | FileCheck %s
+
+; ###Проверка замены деления на степень двойки (8) на сдвиг вправо
+; ###Вход:  return value / 8;
+; ###После пасса:  return value >> 3;
+; CHECK-LABEL: @divide_by_eight
+; CHECK: ashr i32 %{{[^,]+}}, 3
+
+define i32 @divide_by_eight(i32 %val) {
+entry:
+  %div = sdiv i32 %val, 8
+  ret i32 %div
+}
+
+; ###Проверка, что деление на не-степень двойки (5) НЕ заменяется
+; ###Вход:  return value / 5;
+; ###После пасса:  return value / 5;  //никаких сдвигов
+; CHECK-LABEL: @divide_by_five
+; CHECK: sdiv i32 %{{[^,]+}}, 5
+
+define i32 @divide_by_five(i32 %val) {
+entry:
+  %div = sdiv i32 %val, 5
+  ret i32 %div
+}
+
+; ###Проверка замены беззнакового деления на степень двойки (16) на логический сдвиг вправо 
+; ###Вход:  return value / 16;   //где value - unsigned
+; ###После пасса:  return value >> 4;
+; CHECK-LABEL: @udivide_by_sixteen
+; CHECK: lshr i32 %{{[^,]+}}, 4
+
+define i32 @udivide_by_sixteen(i32 %val) {
+entry:
+  %div = udiv i32 %val, 16
+  ret i32 %div
+}
+
+; ###Проверка, что посторонние инструкции (умножение) не затрагиваются пассом
+; ###Вход:  return value * 2;
+; ###После пасса:  return value * 2; //никаких сдвигов, никаких изменений
+; CHECK-LABEL: @multiply_by_two
+; CHECK: mul i32 %{{[^,]+}}, 2
+
+define i32 @multiply_by_two(i32 %val) {
+entry:
+  %mul = mul i32 %val, 2
+  ret i32 %mul
+}
+

--- a/llvm/test/compiler-course/dormidontov_egor_lab2/lab2_test_llvm_ir.ll
+++ b/llvm/test/compiler-course/dormidontov_egor_lab2/lab2_test_llvm_ir.ll
@@ -70,7 +70,7 @@ entry:
 define i32 @divide_by_three(i32 %val) {
 entry:
   %div = sdiv i32 %val, 3
-  ret i32 %div
+    ret i32 %div
 }
 
 ; ###Проверка замены деления на степень двойки (16) на сдвиг вправо
@@ -94,5 +94,62 @@ entry:
 define i32 @divide_by_two(i32 %val) {
 entry:
   %div = sdiv i32 %val, 2
+  ret i32 %div
+}
+
+; ###Проверка: деление на 0 (деление на 0 запрещено, оптимизации не будет, оставляем как есть)
+; ###Вход:  return value / 0;
+; CHECK-LABEL: @divide_by_zero
+; CHECK: sdiv i32 %{{[^,]+}}, 0
+
+define i32 @divide_by_zero(i32 %val) {
+entry:
+  %div = sdiv i32 %val, 0
+  ret i32 %div
+}
+
+; ###Проверка: деление на 1 (обычно оптимизируется в сдвиг на 0 или просто %val)
+; CHECK-LABEL: @divide_by_one
+; CHECK: ashr i32 %val, 0
+
+define i32 @divide_by_one(i32 %val) {
+entry:
+  %div2shift = ashr i32 %val, 0
+  ret i32 %div2shift
+}
+
+; ###Проверка: деление на переменную (никакой оптимизации, т.к. делитель неизвестен на этапе компиляции)
+; ###Вход:  return value / divisor;
+; CHECK-LABEL: @divide_by_variable
+; CHECK: sdiv i32 %{{[^,]+}}, %{{[^,]+}}
+
+define i32 @divide_by_variable(i32 %val, i32 %divisor) {
+entry:
+  %div = sdiv i32 %val, %divisor
+  ret i32 %div
+}
+
+; ###Проверка: деление на -4 (отрицательная степень двойки, ожидается оптимизация)
+; ###Вход:  return value / -4;
+; ###После пасса:  return -(value >> 2);
+; CHECK-LABEL: @divide_by_minus_four
+; CHECK: %div2shift = ashr i32 %val, 2
+; CHECK: %neg = sub i32 0, %div2shift
+; CHECK: ret i32 %neg
+
+define i32 @divide_by_minus_four(i32 %val) {
+entry:
+  %div = sdiv i32 %val, -4
+  ret i32 %div
+}
+
+; ###Проверка: деление на -11 (не степень двойки, оптимизации не будет, оставляем как есть)
+; ###Вход:  return value / -11;
+; CHECK-LABEL: @divide_by_minus_eleven
+; CHECK: sdiv i32 %{{[^,]+}}, -11
+
+define i32 @divide_by_minus_eleven(i32 %val) {
+entry:
+  %div = sdiv i32 %val, -11
   ret i32 %div
 }


### PR DESCRIPTION
Данный пасс автоматически заменяет целочисленное деление (sdiv или udiv) на степень двойки соответствующим побитовым сдвигом вправо (ashr или lshr) там, где это возможно.

Пасс обходит все инструкции функции, находит деления на константу-степень двойки, вычисляет величину сдвига и подменяет деление на сдвиг, не затрагивая другие операции.

