### PR TITLE
Седова Ольга 3822б1фи1 лабораторная работа 3, вариант 3

### DIFF
--- a/llvm/compiler-course/backend/sedova_olga_lab3/CMakeLists.txt
+++ b/llvm/compiler-course/backend/sedova_olga_lab3/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(Title "FMADecomposePass")
+set(Student "Sedova_Olga")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_BACKEND")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY
+)
+
+target_include_directories(${TARGET_NAME} PUBLIC ${PATH_TO_X86})
+set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/compiler-course/backend/sedova_olga_lab3/ExamplePass.cpp
+++ b/llvm/compiler-course/backend/sedova_olga_lab3/ExamplePass.cpp
@@ -1,0 +1,86 @@
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/CodeGen/TargetOpcodes.h"
+#include "llvm/Passes/PassBuilder.h"
+using namespace llvm;
+
+namespace {
+class ExamplePass : public MachineFunctionPass {
+public:
+  static char ID;
+  ExamplePass() : MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(MachineFunction &MF) override;
+};
+} // namespace
+
+char ExamplePass::ID = 0;
+
+static bool isAddInstr(MachineInstr &MI) {
+  return MI.getOpcode() == X86::ADDPDrr || MI.getOpcode() == X86::ADDPDrm;
+}
+
+static bool isMulInstr(MachineInstr &MI) {
+  return MI.getOpcode() == X86::MULPDrr || MI.getOpcode() == X86::MULPDrm;
+}
+
+static bool existInvector(std::vector<MachineInstr *> *vector,
+                          MachineInstr *val) {
+  return std::find(vector->begin(), vector->end(), val) == vector->end();
+}
+
+bool ExamplePass::runOnMachineFunction(MachineFunction &MF) {
+  const X86Subtarget &STI = MF.getSubtarget<X86Subtarget>();
+  const X86InstrInfo *TII = STI.getInstrInfo();
+  const TargetRegisterInfo *TRI = &TII->getRegisterInfo();
+
+  std::vector<MachineInstr *> MIvector;
+
+  for (auto &MBB : MF) {
+    for (auto &MI : MBB) {
+      if (!(isMulInstr(MI)))
+        continue;
+
+      auto &op = MI.getOperand(0);
+      for (auto &secondMI : MBB) {
+        int ind = secondMI.findRegisterUseOperandIdx(op.getReg(), TRI, false);
+        if (ind != -1 && isAddInstr(secondMI)) {
+          if (ind == 0)
+            break;
+          int second_ind = 3 - ind;
+
+          MIMetadata MIMD(MI);
+          MachineInstr *Mul = &MI;
+          MachineInstr *Add = &secondMI;
+
+          BuildMI(MBB, Mul, MIMD, TII->get(X86::VFMADD213PDr),
+                  Add->getOperand(0).getReg())
+              .addReg(Mul->getOperand(1).getReg())
+              .addReg(Mul->getOperand(2).getReg())
+              .addReg(Add->getOperand(second_ind).getReg());
+
+          if (existInvector(&MIvector, Mul))
+            MIvector.push_back(Mul);
+          if (existInvector(&MIvector, Add))
+            MIvector.push_back(Add);
+        }
+      }
+    }
+  }
+
+  for (auto &MI : MIvector) {
+    MI->eraseFromParent();
+  }
+
+  return true;
+}
+
+static llvm::RegisterPass<ExamplePass>
+    X("fma-decompose-x86",
+      "Decomposes single FMA instructions into MUL and ADD ones", false, false);

--- a/llvm/test/compiler-course/sedova_olga_lab3/test_backend.mir
+++ b/llvm/test/compiler-course/sedova_olga_lab3/test_backend.mir
@@ -1,0 +1,273 @@
+﻿# RUN: llc -mtriple x86_64-unknown-linux-gnu -mattr=+avx,+fma --load=%llvmshlibdir/FMADecomposePass_Sedova_Olga_FIIT1_BACKEND%shlibext \
+# RUN: -run-pass=fma-decompose-x86  %s -o - | FileCheck %s
+--- |
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <2 x double> @test_base(<2 x double> noundef %a, <2 x double> noundef %b, <2 x double> noundef %c, <2 x double> noundef %d) local_unnamed_addr #0 {
+  entry:
+    %mul = fmul <2 x double> %a, %b
+    %add = fadd <2 x double> %mul, %c
+    ret <2 x double> %add
+  }
+
+  ; Function Attrs: mustprogress nofree nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <2 x double> @test_two_ops(<2 x double> noundef %a, <2 x double> noundef %b, <2 x double> noundef %c, <2 x double> noundef %d) local_unnamed_addr #1 {
+  entry:
+    %mul = fmul <2 x double> %a, %b
+    %add = fadd <2 x double> %a, %b
+    %0 = tail call <2 x double> @llvm.fmuladd.v2f64(<2 x double> %b, <2 x double> %b, <2 x double> %add)
+    %add2 = fadd <2 x double> %mul, %c
+    %mul3 = fmul <2 x double> %add2, %0
+    ret <2 x double> %mul3
+  }
+
+  ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+  declare <2 x double> @llvm.fmuladd.v2f64(<2 x double>, <2 x double>, <2 x double>) #2
+
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <2 x double> @test_three(<2 x double> noundef %a, <2 x double> noundef %b, <2 x double> noundef %c, <2 x double> noundef %d) local_unnamed_addr #0 {
+  entry:
+    %mul = fmul <2 x double> %a, %b
+    %add = fadd <2 x double> %mul, %c
+    %add1 = fadd <2 x double> %mul, %d
+    %div = fdiv <2 x double> %add, %add1
+    ret <2 x double> %div
+  }
+...
+---
+name:            test_base
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128, preferred-register: '' }
+  - { id: 1, class: vr128, preferred-register: '' }
+  - { id: 2, class: vr128, preferred-register: '' }
+  - { id: 3, class: vr128, preferred-register: '' }
+  - { id: 4, class: vr128, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    16
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:
+  - { id: 0, type: default, offset: 0, size: 16, alignment: 4, stack-id: default, 
+      isImmutable: true, isAliased: false, callee-saved-register: '', callee-saved-restored: true, 
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo: {}
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+  
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    ; CHECK: %4:vr128 = VFMADD213PDr %0, %1, %2, implicit $mxcsr
+    ; CHECK-NEXT: $xmm0 = COPY %4
+    %3:vr128 = nofpexcept MULPDrr %0, %1, implicit $mxcsr
+    %4:vr128 = nofpexcept ADDPDrr %3, %2, implicit $mxcsr
+    $xmm0 = COPY %4
+    RET 0, $xmm0
+...
+---
+name:            test_two_ops
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128, preferred-register: '' }
+  - { id: 1, class: vr128, preferred-register: '' }
+  - { id: 2, class: vr128, preferred-register: '' }
+  - { id: 3, class: vr128, preferred-register: '' }
+  - { id: 4, class: vr128, preferred-register: '' }
+  - { id: 5, class: vr128, preferred-register: '' }
+  - { id: 6, class: vr128, preferred-register: '' }
+  - { id: 7, class: vr128, preferred-register: '' }
+  - { id: 8, class: vr128, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    16
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:
+  - { id: 0, type: default, offset: 0, size: 16, alignment: 4, stack-id: default, 
+      isImmutable: true, isAliased: false, callee-saved-register: '', callee-saved-restored: true, 
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo: {}
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+  
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    ; CHECK: %7:vr128 = VFMADD213PDr %0, %1, %2, implicit $mxcsr
+    ; CHECK-NEXT: %4:vr128 = nofpexcept ADDPDrr %0, %1, implicit $mxcsr
+    %3:vr128 = nofpexcept MULPDrr %0, %1, implicit $mxcsr
+    %4:vr128 = nofpexcept ADDPDrr %0, %1, implicit $mxcsr
+    ; CHECK: %6:vr128 = VFMADD213PDr %1, %1, %4, implicit $mxcsr
+    ; CHECK-NEXT: %8:vr128 = nofpexcept MULPDrr %7, killed %6, implicit $mxcsr
+    %5:vr128 = nofpexcept MULPDrr %1, %1, implicit $mxcsr
+    %6:vr128 = nofpexcept ADDPDrr %5, killed %4, implicit $mxcsr
+    %7:vr128 = nofpexcept ADDPDrr %3, %2, implicit $mxcsr
+    %8:vr128 = nofpexcept MULPDrr %7, killed %6, implicit $mxcsr
+    $xmm0 = COPY %8
+    RET 0, $xmm0
+...
+---
+name:            test_three
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: gr64, preferred-register: '' }
+  - { id: 1, class: gr64, preferred-register: '' }
+  - { id: 2, class: gr64, preferred-register: '' }
+  - { id: 3, class: gr64, preferred-register: '' }
+  - { id: 4, class: vr128, preferred-register: '' }
+  - { id: 5, class: vr128, preferred-register: '' }
+  - { id: 6, class: vr128, preferred-register: '' }
+  - { id: 7, class: vr128, preferred-register: '' }
+  - { id: 8, class: vr128, preferred-register: '' }
+liveins:
+  - { reg: '$rcx', virtual-reg: '%0' }
+  - { reg: '$rdx', virtual-reg: '%1' }
+  - { reg: '$r8', virtual-reg: '%2' }
+  - { reg: '$r9', virtual-reg: '%3' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    8
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo: {}
+body:             |
+  bb.0.entry:
+    liveins: $rcx, $rdx, $r8, $r9
+  
+    %3:gr64 = COPY $r9
+    %2:gr64 = COPY $r8
+    %1:gr64 = COPY $rdx
+    %0:gr64 = COPY $rcx
+    %4:vr128 = MOVAPDrm %0, 1, $noreg, 0, $noreg :: (load (s128))
+    ; CHECK: %6:vr128 = VFMADD213PDr %4, %1, %2, implicit $mxcsr
+    ; CHECK-NEXT: %7:vr128 = VFMADD213PDr %4, %1, %3, implicit $mxcsr
+    ; CHECK-NEXT: %8:vr128 = nofpexcept DIVPDrr %6, killed %7, implicit $mxcsr
+    %5:vr128 = nofpexcept MULPDrm %4, %1, 1, $noreg, 0, $noreg, implicit $mxcsr :: (load (s128))
+    %6:vr128 = nofpexcept ADDPDrm %5, %2, 1, $noreg, 0, $noreg, implicit $mxcsr :: (load (s128))
+    %7:vr128 = nofpexcept ADDPDrm %5, %3, 1, $noreg, 0, $noreg, implicit $mxcsr :: (load (s128))
+    %8:vr128 = nofpexcept DIVPDrr %6, killed %7, implicit $mxcsr
+    $xmm0 = COPY %8
+    RET 0, $xmm0


### PR DESCRIPTION
Описание
Добавлен новый LLVM MachineFunctionPass ExamplePass, который выполняет оптимизацию для архитектуры x86, заменяя последовательности инструкций умножения и сложения (MULPD + ADDPD) на одну инструкцию FMA (VFMADD213PDr).

Что сделано
Поиск пар инструкций MULPD и ADDPD, где результат умножения используется в сложении.
Замена таких пар на одну инструкцию FMA, что улучшает производительность за счёт уменьшения количества инструкций и использования аппаратной поддержки FMA.
Удаление исходных инструкций MUL и ADD после вставки FMA.
Поддержка только инструкций с двойной точностью (packed double).

Зачем это нужно
Современные процессоры поддерживают FMA инструкции, которые выполняют умножение и сложение за одну инструкцию, повышая эффективность и снижая задержки.
Автоматическая замена последовательностей MUL + ADD на FMA улучшает качество генерируемого кода.
Улучшает производительность приложений, использующих интенсивные вычисления с плавающей точкой.

Тестирование
Добавлены MIR-тесты, проверяющие корректность замены MUL + ADD на FMA.
Тесты проходят успешно в среде сборки LLVM.