### PR TITLE
Межуев Максим. Задача 1. Вариант 4.

### DIFF
--- a/clang/compiler-course/mezhuev_m_lab1/CMakeLists.txt
+++ b/clang/compiler-course/mezhuev_m_lab1/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "clangAstPrefix_1")
+set(Student "MezhuevM")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/mezhuev_m_lab1/mezhuev_m_lab1.cpp
+++ b/clang/compiler-course/mezhuev_m_lab1/mezhuev_m_lab1.cpp
@@ -148,4 +148,4 @@ private:
 
 static clang::FrontendPluginRegistry::Add<PrefixPlugin>
     PluginRegistration("clangAstPrefix_1",
-                        "Adds scope-based prefixes to variable names");
+                      "Adds scope-based prefixes to variable names");

--- a/clang/compiler-course/mezhuev_m_lab1/mezhuev_m_lab1.cpp
+++ b/clang/compiler-course/mezhuev_m_lab1/mezhuev_m_lab1.cpp
@@ -1,0 +1,139 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "llvm/Support/raw_ostream.h"
+#include <map>
+
+namespace {
+
+class ScopePrefixAdder final : public clang::RecursiveASTVisitor<ScopePrefixAdder> {
+public:
+  explicit ScopePrefixAdder(clang::Rewriter &CodeRewriter)
+      : RewriterTool(CodeRewriter) {}
+
+  bool VisitVarDecl(clang::VarDecl *VariableDeclaration) {
+    if (VariableDeclaration->getName().empty()) {
+      return true;
+    }
+
+    std::string ScopePrefix;
+    
+    if (VariableDeclaration->isStaticLocal()) {
+      ScopePrefix = "static_";
+    } else if (VariableDeclaration->isLocalVarDecl()) {
+      ScopePrefix = "local_";
+    } else if (VariableDeclaration->hasGlobalStorage()) {
+      ScopePrefix = "global_";
+    }
+
+    if (!ScopePrefix.empty()) {
+      std::string OriginalName = VariableDeclaration->getName().str();
+      if (OriginalName.find(ScopePrefix) != 0) {
+        std::string NewVariableName = ScopePrefix + OriginalName;
+        RenamedVariablesMap[OriginalName] = NewVariableName;
+        clang::SourceLocation NamePosition = VariableDeclaration->getLocation();
+        RewriterTool.ReplaceText(NamePosition, OriginalName.length(), NewVariableName);
+      }
+    }
+    return true;
+  }
+
+  bool VisitParmVarDecl(clang::ParmVarDecl *FunctionParameter) {
+    if (FunctionParameter->getName().empty()) {
+      return true;
+    }
+
+    std::string OriginalName = FunctionParameter->getName().str();
+    std::string NewParameterName = "param_" + OriginalName;
+    RenamedVariablesMap[OriginalName] = NewParameterName;
+    RewriterTool.ReplaceText(FunctionParameter->getLocation(), OriginalName.size(), NewParameterName);
+    return true;
+  }
+
+  bool VisitDeclRefExpr(clang::DeclRefExpr *VariableReference) {
+    clang::ValueDecl *ReferencedDeclaration = VariableReference->getDecl();
+    if (!ReferencedDeclaration || ReferencedDeclaration->getName().empty()) {
+      return true;
+    }
+
+    if (llvm::isa<clang::FunctionDecl>(ReferencedDeclaration)) {
+      return true;
+    }
+
+    std::string OriginalName = ReferencedDeclaration->getName().str();
+    auto MapIterator = RenamedVariablesMap.find(OriginalName);
+    
+    if (MapIterator != RenamedVariablesMap.end()) {
+      clang::SourceLocation ReferencePosition = VariableReference->getLocation();
+      RewriterTool.ReplaceText(ReferencePosition, OriginalName.length(), MapIterator->second);
+    } else {
+      if (auto VarDecl = llvm::dyn_cast<clang::VarDecl>(ReferencedDeclaration)) {
+        VarDecl = VarDecl->getCanonicalDecl();
+        std::string NewName;
+        
+        if (VarDecl->hasGlobalStorage() && !VarDecl->isStaticLocal()) {
+          NewName = "global_" + OriginalName;
+        } else if (VarDecl->isStaticLocal()) {
+          NewName = "static_" + OriginalName;
+        } else if (llvm::isa<clang::ParmVarDecl>(VarDecl)) {
+          NewName = "param_" + OriginalName;
+        } else if (VarDecl->isLocalVarDecl()) {
+          NewName = "local_" + OriginalName;
+        }
+        
+        if (!NewName.empty()) {
+          RenamedVariablesMap[OriginalName] = NewName;
+          RewriterTool.ReplaceText(VariableReference->getLocation(), OriginalName.length(), NewName);
+        }
+      }
+    }
+    return true;
+  }
+
+private:
+  clang::Rewriter &RewriterTool;
+  std::map<std::string, std::string> RenamedVariablesMap;
+};
+
+class ASTTransformer final : public clang::ASTConsumer {
+public:
+  explicit ASTTransformer(clang::ASTContext *Context, clang::Rewriter &CodeRewriter)
+      : RewriterTool(CodeRewriter), PrefixVisitor(CodeRewriter) {}
+
+  void HandleTranslationUnit(clang::ASTContext &Context) override {
+    PrefixVisitor.TraverseDecl(Context.getTranslationUnitDecl());
+  }
+
+private:
+  clang::Rewriter &RewriterTool;
+  ScopePrefixAdder PrefixVisitor;
+};
+
+class PrefixPlugin final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &Compiler, llvm::StringRef) override {
+    SourceRewriter.setSourceMgr(Compiler.getSourceManager(), Compiler.getLangOpts());
+    return std::make_unique<ASTTransformer>(&Compiler.getASTContext(), SourceRewriter);
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &Compiler,
+                 const std::vector<std::string> &Arguments) override {
+    return true;
+  }
+
+  void EndSourceFileAction() override {
+    SourceRewriter.getEditBuffer(SourceRewriter.getSourceMgr().getMainFileID())
+        .write(llvm::outs());
+  }
+
+private:
+  clang::Rewriter SourceRewriter;
+};
+
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<PrefixPlugin>
+    PluginRegistration("clangAstPrefix_1", "Adds scope-based prefixes to variable names");

--- a/clang/compiler-course/mezhuev_m_lab1/mezhuev_m_lab1.cpp
+++ b/clang/compiler-course/mezhuev_m_lab1/mezhuev_m_lab1.cpp
@@ -35,7 +35,7 @@ public:
         std::string NewVariableName = ScopePrefix + OriginalName;
         RenamedVariablesMap[OriginalName] = NewVariableName;
         clang::SourceLocation NamePosition = VariableDeclaration->getLocation();
-        RewriterTool.ReplaceText(NamePosition, OriginalName.length(), 
+        RewriterTool.ReplaceText(NamePosition, OriginalName.length(),
                                  NewVariableName);
       }
     }
@@ -50,7 +50,7 @@ public:
     std::string OriginalName = FunctionParameter->getName().str();
     std::string NewParameterName = "param_" + OriginalName;
     RenamedVariablesMap[OriginalName] = NewParameterName;
-    RewriterTool.ReplaceText(FunctionParameter->getLocation(), 
+    RewriterTool.ReplaceText(FunctionParameter->getLocation(),
                              OriginalName.size(), NewParameterName);
     return true;
   }
@@ -74,11 +74,11 @@ public:
       RewriterTool.ReplaceText(ReferencePosition, OriginalName.length(),
                                MapIterator->second);
     } else {
-      if (auto VarDecl = 
+      if (auto VarDecl =
               llvm::dyn_cast<clang::VarDecl>(ReferencedDeclaration)) {
         VarDecl = VarDecl->getCanonicalDecl();
         std::string NewName;
-        
+
         if (VarDecl->hasGlobalStorage() && !VarDecl->isStaticLocal()) {
           NewName = "global_" + OriginalName;
         } else if (VarDecl->isStaticLocal()) {
@@ -88,7 +88,7 @@ public:
         } else if (VarDecl->isLocalVarDecl()) {
           NewName = "local_" + OriginalName;
         }
-        
+
         if (!NewName.empty()) {
           RenamedVariablesMap[OriginalName] = NewName;
           RewriterTool.ReplaceText(VariableReference->getLocation(),
@@ -106,7 +106,7 @@ private:
 
 class ASTTransformer final : public clang::ASTConsumer {
 public:
-  explicit ASTTransformer(clang::ASTContext *Context, 
+  explicit ASTTransformer(clang::ASTContext *Context,
                           clang::Rewriter &CodeRewriter)
       : RewriterTool(CodeRewriter), PrefixVisitor(CodeRewriter) {}
 
@@ -122,9 +122,9 @@ private:
 class PrefixPlugin final : public clang::PluginASTAction {
 public:
   std::unique_ptr<clang::ASTConsumer>
-  CreateASTConsumer(clang::CompilerInstance &Compiler, 
+  CreateASTConsumer(clang::CompilerInstance &Compiler,
                     llvm::StringRef) override {
-    SourceRewriter.setSourceMgr(Compiler.getSourceManager(), 
+    SourceRewriter.setSourceMgr(Compiler.getSourceManager(),
                                 Compiler.getLangOpts());
     return std::make_unique<ASTTransformer>(&Compiler.getASTContext(), 
                                             SourceRewriter);
@@ -147,5 +147,5 @@ private:
 } // namespace
 
 static clang::FrontendPluginRegistry::Add<PrefixPlugin>
-    PluginRegistration("clangAstPrefix_1", 
+    PluginRegistration("clangAstPrefix_1",
                         "Adds scope-based prefixes to variable names");

--- a/clang/compiler-course/mezhuev_m_lab1/mezhuev_m_lab1.cpp
+++ b/clang/compiler-course/mezhuev_m_lab1/mezhuev_m_lab1.cpp
@@ -8,7 +8,8 @@
 
 namespace {
 
-class ScopePrefixAdder final : public clang::RecursiveASTVisitor<ScopePrefixAdder> {
+class ScopePrefixAdder final 
+    : public clang::RecursiveASTVisitor<ScopePrefixAdder> {
 public:
   explicit ScopePrefixAdder(clang::Rewriter &CodeRewriter)
       : RewriterTool(CodeRewriter) {}
@@ -34,7 +35,8 @@ public:
         std::string NewVariableName = ScopePrefix + OriginalName;
         RenamedVariablesMap[OriginalName] = NewVariableName;
         clang::SourceLocation NamePosition = VariableDeclaration->getLocation();
-        RewriterTool.ReplaceText(NamePosition, OriginalName.length(), NewVariableName);
+        RewriterTool.ReplaceText(NamePosition, OriginalName.length(), 
+                                 NewVariableName);
       }
     }
     return true;
@@ -48,7 +50,8 @@ public:
     std::string OriginalName = FunctionParameter->getName().str();
     std::string NewParameterName = "param_" + OriginalName;
     RenamedVariablesMap[OriginalName] = NewParameterName;
-    RewriterTool.ReplaceText(FunctionParameter->getLocation(), OriginalName.size(), NewParameterName);
+    RewriterTool.ReplaceText(FunctionParameter->getLocation(), 
+                             OriginalName.size(), NewParameterName);
     return true;
   }
 
@@ -66,10 +69,13 @@ public:
     auto MapIterator = RenamedVariablesMap.find(OriginalName);
     
     if (MapIterator != RenamedVariablesMap.end()) {
-      clang::SourceLocation ReferencePosition = VariableReference->getLocation();
-      RewriterTool.ReplaceText(ReferencePosition, OriginalName.length(), MapIterator->second);
+      clang::SourceLocation ReferencePosition =
+          VariableReference->getLocation();
+      RewriterTool.ReplaceText(ReferencePosition, OriginalName.length(),
+                               MapIterator->second);
     } else {
-      if (auto VarDecl = llvm::dyn_cast<clang::VarDecl>(ReferencedDeclaration)) {
+      if (auto VarDecl = 
+              llvm::dyn_cast<clang::VarDecl>(ReferencedDeclaration)) {
         VarDecl = VarDecl->getCanonicalDecl();
         std::string NewName;
         
@@ -85,7 +91,8 @@ public:
         
         if (!NewName.empty()) {
           RenamedVariablesMap[OriginalName] = NewName;
-          RewriterTool.ReplaceText(VariableReference->getLocation(), OriginalName.length(), NewName);
+          RewriterTool.ReplaceText(VariableReference->getLocation(),
+                                   OriginalName.length(), NewName);
         }
       }
     }
@@ -99,7 +106,8 @@ private:
 
 class ASTTransformer final : public clang::ASTConsumer {
 public:
-  explicit ASTTransformer(clang::ASTContext *Context, clang::Rewriter &CodeRewriter)
+  explicit ASTTransformer(clang::ASTContext *Context, 
+                          clang::Rewriter &CodeRewriter)
       : RewriterTool(CodeRewriter), PrefixVisitor(CodeRewriter) {}
 
   void HandleTranslationUnit(clang::ASTContext &Context) override {
@@ -114,9 +122,12 @@ private:
 class PrefixPlugin final : public clang::PluginASTAction {
 public:
   std::unique_ptr<clang::ASTConsumer>
-  CreateASTConsumer(clang::CompilerInstance &Compiler, llvm::StringRef) override {
-    SourceRewriter.setSourceMgr(Compiler.getSourceManager(), Compiler.getLangOpts());
-    return std::make_unique<ASTTransformer>(&Compiler.getASTContext(), SourceRewriter);
+  CreateASTConsumer(clang::CompilerInstance &Compiler, 
+                    llvm::StringRef) override {
+    SourceRewriter.setSourceMgr(Compiler.getSourceManager(), 
+                                Compiler.getLangOpts());
+    return std::make_unique<ASTTransformer>(&Compiler.getASTContext(), 
+                                            SourceRewriter);
   }
 
   bool ParseArgs(const clang::CompilerInstance &Compiler,
@@ -136,4 +147,5 @@ private:
 } // namespace
 
 static clang::FrontendPluginRegistry::Add<PrefixPlugin>
-    PluginRegistration("clangAstPrefix_1", "Adds scope-based prefixes to variable names");
+    PluginRegistration("clangAstPrefix_1", 
+                        "Adds scope-based prefixes to variable names");

--- a/clang/compiler-course/mezhuev_m_lab1/mezhuev_m_lab1.cpp
+++ b/clang/compiler-course/mezhuev_m_lab1/mezhuev_m_lab1.cpp
@@ -148,4 +148,4 @@ private:
 
 static clang::FrontendPluginRegistry::Add<PrefixPlugin>
     PluginRegistration("clangAstPrefix_1",
-                      "Adds scope-based prefixes to variable names");
+                        "Adds scope-based prefixes to variable names");

--- a/clang/compiler-course/mezhuev_m_lab1/mezhuev_m_lab1.cpp
+++ b/clang/compiler-course/mezhuev_m_lab1/mezhuev_m_lab1.cpp
@@ -148,4 +148,4 @@ private:
 
 static clang::FrontendPluginRegistry::Add<PrefixPlugin>
     PluginRegistration("clangAstPrefix_1",
-                      "Adds scope-based prefixes to variable names");
+                       "Adds scope-based prefixes to variable names");

--- a/clang/compiler-course/mezhuev_m_lab1/mezhuev_m_lab1.cpp
+++ b/clang/compiler-course/mezhuev_m_lab1/mezhuev_m_lab1.cpp
@@ -8,7 +8,7 @@
 
 namespace {
 
-class ScopePrefixAdder final 
+class ScopePrefixAdder final
     : public clang::RecursiveASTVisitor<ScopePrefixAdder> {
 public:
   explicit ScopePrefixAdder(clang::Rewriter &CodeRewriter)
@@ -20,7 +20,7 @@ public:
     }
 
     std::string ScopePrefix;
-    
+
     if (VariableDeclaration->isStaticLocal()) {
       ScopePrefix = "static_";
     } else if (VariableDeclaration->isLocalVarDecl()) {
@@ -67,7 +67,7 @@ public:
 
     std::string OriginalName = ReferencedDeclaration->getName().str();
     auto MapIterator = RenamedVariablesMap.find(OriginalName);
-    
+
     if (MapIterator != RenamedVariablesMap.end()) {
       clang::SourceLocation ReferencePosition =
           VariableReference->getLocation();
@@ -126,7 +126,7 @@ public:
                     llvm::StringRef) override {
     SourceRewriter.setSourceMgr(Compiler.getSourceManager(),
                                 Compiler.getLangOpts());
-    return std::make_unique<ASTTransformer>(&Compiler.getASTContext(), 
+    return std::make_unique<ASTTransformer>(&Compiler.getASTContext(),
                                             SourceRewriter);
   }
 
@@ -148,4 +148,4 @@ private:
 
 static clang::FrontendPluginRegistry::Add<PrefixPlugin>
     PluginRegistration("clangAstPrefix_1",
-                        "Adds scope-based prefixes to variable names");
+                      "Adds scope-based prefixes to variable names");

--- a/clang/test/compiler-course/mezhuev_m_lab1/mezhuev_m_lab1_tests.cpp
+++ b/clang/test/compiler-course/mezhuev_m_lab1/mezhuev_m_lab1_tests.cpp
@@ -1,0 +1,29 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/clangAstPrefix_1_MezhuevM_FIIT2_ClangAST%pluginext -plugin clangAstPrefix_1 -fsyntax-only %s 2>&1 | FileCheck %s
+
+// CHECK: int static global_Var1 = 0;
+// CHECK-NEXT: extern int global_Var3;
+// CHECK-NEXT: int rA(int param_A) {
+// CHECK-NEXT:   return -param_A;
+// CHECK-NEXT: }
+// CHECK-NEXT: int static foo(int param_A, int param_B) {
+// CHECK-NEXT:   static int static_Var2 = 0;
+// CHECK-NEXT:   int local_Var3 = 123;
+// CHECK-NEXT:   int &local_rA = param_A;
+// CHECK-NEXT:   ++static_Var2;
+// CHECK-NEXT:   return local_rA + param_B + global_Var1 + static_Var2 + local_Var3;
+// CHECK-NEXT: }
+// CHECK-NEXT: int static global_X = foo(1, rA(global_Var3));
+
+int static Var1 = 0;
+extern int Var3;
+int rA(int A) {
+  return -A;
+}
+int static foo(int A, int B) {
+  static int Var2 = 0;
+  int Var3 = 123;
+  int &rA = A;
+  ++Var2;
+  return rA + B + Var1 + Var2 + Var3;
+}
+int static X = foo(1, rA(Var3));


### PR DESCRIPTION
Разработан инструмент для автоматического добавления префиксов к переменным в зависимости от их области видимости. Плагин анализирует AST исходного кода и переименовывает переменные, добавляя префиксы: static_ для статических локальных переменных, local_ для обычных локальных, global_ для глобальных и param_ для параметров функций. Код автоматически обрабатывает все объявления переменных и ссылки на них, обеспечивая корректное преобразование всего исходного кода с сохранением семантики программы.