### PR TITLE
Межуев Максим. Лабораторная работа 2. Вариант 4

### DIFF
--- a/llvm/compiler-course/llvm-ir/mezhuev_m_lab2/CMakeLists.txt
+++ b/llvm/compiler-course/llvm-ir/mezhuev_m_lab2/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(Title "IntegerDivisionOptimizer")
+set(Student "Mezhuev_Maksim")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_LLVM_IR")
+
+if (NOT WIN32 AND NOT CYGWIN)
+    file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+    add_llvm_pass_plugin(${TARGET_NAME} ${SOURCES}
+        DEPENDS
+        intrinsics_gen
+        BUILDTREE_ONLY
+    )
+    set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)
+endif()

--- a/llvm/compiler-course/llvm-ir/mezhuev_m_lab2/lab2.cpp
+++ b/llvm/compiler-course/llvm-ir/mezhuev_m_lab2/lab2.cpp
@@ -101,7 +101,7 @@ private:
 
     DivOp->replaceAllUsesWith(ShiftResult);
     DivOp->eraseFromParent();
-    
+
     return true;
   }
 };

--- a/llvm/compiler-course/llvm-ir/mezhuev_m_lab2/lab2.cpp
+++ b/llvm/compiler-course/llvm-ir/mezhuev_m_lab2/lab2.cpp
@@ -1,7 +1,7 @@
+#include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
-#include "llvm/IR/Constants.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Support/raw_ostream.h"

--- a/llvm/compiler-course/llvm-ir/mezhuev_m_lab2/lab2.cpp
+++ b/llvm/compiler-course/llvm-ir/mezhuev_m_lab2/lab2.cpp
@@ -15,9 +15,9 @@ struct IntegerDivisionOptimizer : PassInfoMixin<IntegerDivisionOptimizer> {
     bool Modified = false;
 
     for (auto &Block : F) {
-      for (auto InstIter = Block.begin(); InstIter != Block.end(); ) {
+      for (auto InstIter = Block.begin(); InstIter != Block.end();) {
         Instruction *CurrentInst = &*InstIter++;
-        
+
         if (auto *DivisionOp = dyn_cast<BinaryOperator>(CurrentInst)) {
           if (DivisionOp->getOpcode() == Instruction::SDiv) {
             Modified |= processSignedDivision(DivisionOp);
@@ -34,41 +34,41 @@ struct IntegerDivisionOptimizer : PassInfoMixin<IntegerDivisionOptimizer> {
 private:
   bool processSignedDivision(BinaryOperator *DivOp) {
     Value *DivisorValue = DivOp->getOperand(1);
-    
+
     if (auto *ConstDivisor = dyn_cast<ConstantInt>(DivisorValue)) {
       int64_t Divisor = ConstDivisor->getSExtValue();
-      
+
       if (Divisor == 1 || Divisor == -1) {
         return false;
       }
-      
+
       if (Divisor > 0 && isPowerOfTwo(Divisor)) {
         return replaceDivisionWithShift(DivOp, Divisor, true);
       }
-      
+
       if (Divisor < 0 && isPowerOfTwo(-Divisor)) {
         return replaceDivisionWithShift(DivOp, -Divisor, false);
       }
     }
-    
+
     return false;
   }
 
   bool processUnsignedDivision(BinaryOperator *DivOp) {
     Value *DivisorValue = DivOp->getOperand(1);
-    
+
     if (auto *ConstDivisor = dyn_cast<ConstantInt>(DivisorValue)) {
       uint64_t Divisor = ConstDivisor->getZExtValue();
 
       if (Divisor == 1) {
         return false;
       }
-      
+
       if (Divisor > 0 && isPowerOfTwo(Divisor)) {
         return replaceDivisionWithShift(DivOp, Divisor, true);
       }
     }
-    
+
     return false;
   }
 
@@ -76,7 +76,8 @@ private:
     return Value > 0 && (Value & (Value - 1)) == 0;
   }
 
-  bool replaceDivisionWithShift(BinaryOperator *DivOp, uint64_t PowerOfTwo, bool IsPositive) {
+  bool replaceDivisionWithShift(BinaryOperator *DivOp, uint64_t PowerOfTwo,
+                                bool IsPositive) {
     unsigned ShiftCount = 0;
     uint64_t Temp = PowerOfTwo;
     while (Temp > 1) {
@@ -86,11 +87,11 @@ private:
 
     IRBuilder<> Builder(DivOp);
     Value *Dividend = DivOp->getOperand(0);
-    
+
     Value *ShiftResult;
     if (DivOp->getOpcode() == Instruction::SDiv) {
       ShiftResult = Builder.CreateAShr(Dividend, ShiftCount, "opt_shift");
-      
+
       if (!IsPositive) {
         ShiftResult = Builder.CreateNeg(ShiftResult, "opt_neg");
       }
@@ -109,21 +110,16 @@ private:
 
 extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
 llvmGetPassPluginInfo() {
-  return {
-    LLVM_PLUGIN_API_VERSION,
-    "IntegerDivisionOptimizer",
-    "0.1",
-    [](llvm::PassBuilder &PB) {
-      PB.registerPipelineParsingCallback(
-        [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
-           llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) -> bool {
-          if (Name == "int-div-optimize") {
-            FPM.addPass(IntegerDivisionOptimizer{});
-            return true;
-          }
-          return false;
-        }
-      );
-    }
-  };
+  return {LLVM_PLUGIN_API_VERSION, "IntegerDivisionOptimizer", "0.1",
+          [](llvm::PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](llvm::StringRef name, llvm::FunctionPassManager &FPM,
+                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) -> bool {
+                  if (name == "int-div-optimize") {
+                    FPM.addPass(DivToBitwiseShiftPass{});
+                    return true;
+                  }
+                  return false;
+                });
+          }};
 }

--- a/llvm/compiler-course/llvm-ir/mezhuev_m_lab2/lab2.cpp
+++ b/llvm/compiler-course/llvm-ir/mezhuev_m_lab2/lab2.cpp
@@ -1,0 +1,129 @@
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+
+namespace {
+
+struct IntegerDivisionOptimizer : PassInfoMixin<IntegerDivisionOptimizer> {
+  PreservedAnalyses run(Function &F, FunctionAnalysisManager &) {
+    bool Modified = false;
+
+    for (auto &Block : F) {
+      for (auto InstIter = Block.begin(); InstIter != Block.end(); ) {
+        Instruction *CurrentInst = &*InstIter++;
+        
+        if (auto *DivisionOp = dyn_cast<BinaryOperator>(CurrentInst)) {
+          if (DivisionOp->getOpcode() == Instruction::SDiv) {
+            Modified |= processSignedDivision(DivisionOp);
+          } else if (DivisionOp->getOpcode() == Instruction::UDiv) {
+            Modified |= processUnsignedDivision(DivisionOp);
+          }
+        }
+      }
+    }
+
+    return Modified ? PreservedAnalyses::none() : PreservedAnalyses::all();
+  }
+
+private:
+  bool processSignedDivision(BinaryOperator *DivOp) {
+    Value *DivisorValue = DivOp->getOperand(1);
+    
+    if (auto *ConstDivisor = dyn_cast<ConstantInt>(DivisorValue)) {
+      int64_t Divisor = ConstDivisor->getSExtValue();
+      
+      if (Divisor == 1 || Divisor == -1) {
+        return false;
+      }
+      
+      if (Divisor > 0 && isPowerOfTwo(Divisor)) {
+        return replaceDivisionWithShift(DivOp, Divisor, true);
+      }
+      
+      if (Divisor < 0 && isPowerOfTwo(-Divisor)) {
+        return replaceDivisionWithShift(DivOp, -Divisor, false);
+      }
+    }
+    
+    return false;
+  }
+
+  bool processUnsignedDivision(BinaryOperator *DivOp) {
+    Value *DivisorValue = DivOp->getOperand(1);
+    
+    if (auto *ConstDivisor = dyn_cast<ConstantInt>(DivisorValue)) {
+      uint64_t Divisor = ConstDivisor->getZExtValue();
+
+      if (Divisor == 1) {
+        return false;
+      }
+      
+      if (Divisor > 0 && isPowerOfTwo(Divisor)) {
+        return replaceDivisionWithShift(DivOp, Divisor, true);
+      }
+    }
+    
+    return false;
+  }
+
+  bool isPowerOfTwo(int64_t Value) {
+    return Value > 0 && (Value & (Value - 1)) == 0;
+  }
+
+  bool replaceDivisionWithShift(BinaryOperator *DivOp, uint64_t PowerOfTwo, bool IsPositive) {
+    unsigned ShiftCount = 0;
+    uint64_t Temp = PowerOfTwo;
+    while (Temp > 1) {
+      Temp >>= 1;
+      ShiftCount++;
+    }
+
+    IRBuilder<> Builder(DivOp);
+    Value *Dividend = DivOp->getOperand(0);
+    
+    Value *ShiftResult;
+    if (DivOp->getOpcode() == Instruction::SDiv) {
+      ShiftResult = Builder.CreateAShr(Dividend, ShiftCount, "opt_shift");
+      
+      if (!IsPositive) {
+        ShiftResult = Builder.CreateNeg(ShiftResult, "opt_neg");
+      }
+    } else {
+      ShiftResult = Builder.CreateLShr(Dividend, ShiftCount, "opt_shift");
+    }
+
+    DivOp->replaceAllUsesWith(ShiftResult);
+    DivOp->eraseFromParent();
+    
+    return true;
+  }
+};
+
+} // namespace
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return {
+    LLVM_PLUGIN_API_VERSION,
+    "IntegerDivisionOptimizer",
+    "0.1",
+    [](llvm::PassBuilder &PB) {
+      PB.registerPipelineParsingCallback(
+        [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
+           llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) -> bool {
+          if (Name == "int-div-optimize") {
+            FPM.addPass(IntegerDivisionOptimizer{});
+            return true;
+          }
+          return false;
+        }
+      );
+    }
+  };
+}

--- a/llvm/compiler-course/llvm-ir/mezhuev_m_lab2/lab2.cpp
+++ b/llvm/compiler-course/llvm-ir/mezhuev_m_lab2/lab2.cpp
@@ -116,7 +116,7 @@ llvmGetPassPluginInfo() {
                 [](llvm::StringRef name, llvm::FunctionPassManager &FPM,
                    llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) -> bool {
                   if (name == "int-div-optimize") {
-                    FPM.addPass(DivToBitwiseShiftPass{});
+                    FPM.addPass(IntegerDivisionOptimizer{});
                     return true;
                   }
                   return false;

--- a/llvm/test/compiler-course/mezhuev_m_lab2/lab2_test.ll
+++ b/llvm/test/compiler-course/mezhuev_m_lab2/lab2_test.ll
@@ -1,0 +1,54 @@
+; RUN: opt -load-pass-plugin %llvmshlibdir/IntegerDivisionOptimizer_Mezhuev_Maksim_FIIT2_LLVM_IR%pluginext\
+; RUN: -passes=int-div-optimize -S %s | FileCheck %s
+
+define i32 @test_sdiv_positive(i32 %x) {
+; CHECK-LABEL: @test_sdiv_positive(
+; CHECK-NOT: sdiv
+; CHECK: ashr i32 %x, 3
+; CHECK: ret i32
+  %result = sdiv i32 %x, 8
+  ret i32 %result
+}
+
+define i32 @test_sdiv_negative(i32 %x) {
+; CHECK-LABEL: @test_sdiv_negative(
+; CHECK-NOT: sdiv
+; CHECK: ashr i32 %x, 3
+; CHECK: sub i32 0, 
+; CHECK: ret i32
+  %result = sdiv i32 %x, -8
+  ret i32 %result
+}
+
+define i32 @test_udiv(i32 %x) {
+; CHECK-LABEL: @test_udiv(
+; CHECK-NOT: udiv
+; CHECK: lshr i32 %x, 4
+; CHECK: ret i32
+  %result = udiv i32 %x, 16
+  ret i32 %result
+}
+
+define i32 @test_non_power(i32 %x) {
+; CHECK-LABEL: @test_non_power(
+; CHECK: sdiv i32 %x, 3
+; CHECK: ret i32
+  %result = sdiv i32 %x, 3
+  ret i32 %result
+}
+
+define i32 @test_variable_div(i32 %x, i32 %y) {
+; CHECK-LABEL: @test_variable_div(
+; CHECK: sdiv i32 %x, %y
+; CHECK: ret i32
+  %result = sdiv i32 %x, %y
+  ret i32 %result
+}
+
+define i32 @test_div_by_one(i32 %x) {
+; CHECK-LABEL: @test_div_by_one(
+; CHECK: sdiv i32 %x, 1
+; CHECK: ret i32
+  %result = sdiv i32 %x, 1
+  ret i32 %result
+}


### PR DESCRIPTION
Данный LLVM pass выполняет преобразование операций целочисленного деления на степени двойки в эквивалентные побитовые сдвиги. Пасс анализирует инструкции SDiv и UDiv, проверяя, является ли делитель константной степенью двойки. Для знакового деления обрабатываются как положительные, так и отрицательные делители, с последующей инверсией результата при необходимости. Деление на ±1 исключается из оптимизации. Преобразование значительно ускоряет выполнение программ, заменяя медленные операции деления быстрыми битовыми сдвигами.