### PR TITLE
Велиев Эльвин. Лабораторная работа 4: MLIR. Вариант 5.

### DIFF
--- a/mlir/compiler-course/Veliev_E_CeilPass/CMakeLists.txt
+++ b/mlir/compiler-course/Veliev_E_CeilPass/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(Title "ReplaceCeilPass")
+set(Student "VelievElvin")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_MLIR")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    MLIRBuiltinLocationAttributesIncGen
+    BUILDTREE_ONLY
+)
+
+set(MLIR_TEST_DEPENDS ${TARGET_NAME} ${MLIR_TEST_DEPENDS} PARENT_SCOPE)

--- a/mlir/compiler-course/Veliev_E_CeilPass/CeilPass.cpp
+++ b/mlir/compiler-course/Veliev_E_CeilPass/CeilPass.cpp
@@ -1,0 +1,80 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Tools/Plugins/PassPlugin.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace {
+class ReplaceCeilPass
+    : public mlir::PassWrapper<ReplaceCeilPass,
+                               mlir::OperationPass<mlir::ModuleOp>> {
+public:
+  llvm::StringRef getArgument() const final {
+    return "ReplaceCeilPass_VelievElvin_FIIT1_MLIR";
+  }
+  llvm::StringRef getDescription() const final {
+    return "Replace math.ceil with -math.floor(-x)";
+  }
+
+  void runOnOperation() override {
+    mlir::MLIRContext *ctx = &getContext();
+    mlir::RewritePatternSet patterns(ctx);
+    patterns.add<ReplaceCeilPattern>(ctx);
+    if (mlir::failed(mlir::applyPatternsAndFoldGreedily(getOperation(),
+                                                        std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+
+private:
+  struct ReplaceCeilPattern
+      : public mlir::OpRewritePattern<mlir::math::CeilOp> {
+    using mlir::OpRewritePattern<mlir::math::CeilOp>::OpRewritePattern;
+
+    template <typename NegOp, typename FloorOp>
+    static mlir::Value createNegFloorNeg(mlir::PatternRewriter &rewriter,
+                                         mlir::Location loc, mlir::Type type,
+                                         mlir::Value input) {
+      mlir::Value n1 = rewriter.create<NegOp>(loc, type, input).getResult();
+      mlir::Value f = rewriter.create<FloorOp>(loc, type, n1).getResult();
+      return rewriter.create<NegOp>(loc, type, f).getResult();
+    }
+
+    mlir::LogicalResult
+    matchAndRewrite(mlir::math::CeilOp op,
+                    mlir::PatternRewriter &rewriter) const override {
+      mlir::Location loc = op.getLoc();
+      mlir::Value input = op.getOperand();
+      mlir::Type inType = input.getType();
+
+      if (mlir::isa<mlir::IntegerType>(inType)) {
+        rewriter.replaceOp(op, input);
+        return mlir::success();
+      }
+
+      mlir::Value result =
+          createNegFloorNeg<mlir::arith::NegFOp, mlir::math::FloorOp>(
+              rewriter, loc, inType, input);
+
+      rewriter.replaceOp(op, result);
+      return mlir::success();
+    }
+  };
+};
+} // namespace
+
+MLIR_DECLARE_EXPLICIT_TYPE_ID(ReplaceCeilPass)
+MLIR_DEFINE_EXPLICIT_TYPE_ID(ReplaceCeilPass)
+
+mlir::PassPluginLibraryInfo getReplaceCeilPluginInfo() {
+  return {MLIR_PLUGIN_API_VERSION, "ReplaceCeilPass", "1.0",
+          []() { mlir::PassRegistration<ReplaceCeilPass>(); }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo
+mlirGetPassPluginInfo() {
+  return getReplaceCeilPluginInfo();
+}

--- a/mlir/test/compiler-course/Veliev_E_CeilPass/CeilPass.mlir
+++ b/mlir/test/compiler-course/Veliev_E_CeilPass/CeilPass.mlir
@@ -1,0 +1,71 @@
+// RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/ReplaceCeilPass_VelievElvin_FIIT1_MLIR%shlibext \
+// RUN: --pass-pipeline="builtin.module(ReplaceCeilPass_VelievElvin_FIIT1_MLIR)" %s | FileCheck %s
+
+module {
+  // TEST 1. Simple ceil
+  // CHECK-LABEL: func.func @simple_ceil
+  // CHECK-SAME: (%[[ARG:.*]]: f32)
+  // CHECK-NEXT: %[[NEG:.*]] = arith.negf %[[ARG]] : f32
+  // CHECK-NEXT: %[[FLOOR:.*]] = math.floor %[[NEG]] : f32
+  // CHECK-NEXT: %[[RES:.*]] = arith.negf %[[FLOOR]] : f32
+  // CHECK-NEXT: return %[[RES]] : f32
+  func.func @simple_ceil(%arg0: f32) -> f32 {
+    %0 = math.ceil %arg0 : f32
+    return %0 : f32
+  }
+
+  // TEST 2: Two ceil operations
+  // CHECK-LABEL: func.func @multiple_ceil
+  // CHECK:       %[[NEG1:.*]] = arith.negf %arg0 : f32
+  // CHECK-NEXT:  %[[FLOOR1:.*]] = math.floor %[[NEG1]] : f32
+  // CHECK-NEXT:  %[[RES1:.*]] = arith.negf %[[FLOOR1]] : f32
+  // CHECK-NEXT:  %[[NEG2:.*]] = arith.negf %arg1 : f32
+  // CHECK-NEXT:  %[[FLOOR2:.*]] = math.floor %[[NEG2]] : f32
+  // CHECK-NEXT:  %[[RES2:.*]] = arith.negf %[[FLOOR2]] : f32
+  // CHECK-NEXT:  %[[SUM:.*]] = arith.addf %[[RES1]], %[[RES2]] : f32
+  // CHECK-NEXT:  return %[[SUM]] : f32
+  func.func @multiple_ceil(%arg0: f32, %arg1: f32) -> f32 {
+    %a = math.ceil %arg0 : f32
+    %b = math.ceil %arg1 : f32
+    %c = arith.addf %a, %b : f32
+    return %c : f32
+  }
+  
+  // TEST 3. f64 ceil
+  // CHECK-LABEL: func.func @double_ceil
+  // CHECK: %[[NEG:.*]] = arith.negf %arg0 : f64
+  // CHECK-NEXT: %[[FLOOR:.*]] = math.floor %[[NEG]] : f64
+  // CHECK-NEXT: %[[RES:.*]] = arith.negf %[[FLOOR]] : f64
+  // CHECK-NEXT: return %[[RES]] : f64
+  func.func @double_ceil(%arg0: f64) -> f64 {
+    %0 = math.ceil %arg0 : f64
+    return %0 : f64
+  }
+
+  // TEST 4. Ceil inside control flow
+  // CHECK-LABEL: func.func @ceil_in_control_flow
+  // CHECK:       %[[NEG:.*]] = arith.negf %arg0 : f32
+  // CHECK-NEXT:  %[[FLOOR:.*]] = math.floor %[[NEG]] : f32
+  // CHECK-NEXT:  %[[RES:.*]] = arith.negf %[[FLOOR]] : f32
+  func.func @ceil_in_control_flow(%arg0: f32, %cond: i1) -> f32 {
+    %res = scf.if %cond -> (f32) {
+      %tmp = math.ceil %arg0 : f32
+      scf.yield %tmp : f32
+    } else {
+      scf.yield %arg0 : f32
+    }
+    return %res : f32
+  }
+  
+  // TEST 5. Ceil on vector floats
+  // CHECK-LABEL: func.func @test_vector
+  // CHECK-NEXT:   %[[NEG:.*]] = arith.negf %arg0 : vector<4xf32>
+  // CHECK-NEXT:   %[[FLOOR:.*]] = math.floor %[[NEG]] : vector<4xf32>
+  // CHECK-NEXT:   %[[RES:.*]] = arith.negf %[[FLOOR]] : vector<4xf32>
+  // CHECK-NEXT:   return %[[RES]] : vector<4xf32>
+  func.func @test_vector(%arg0: vector<4xf32>) -> vector<4xf32> {
+    %0 = math.ceil %arg0 : vector<4xf32>
+    return %0 : vector<4xf32>
+  }
+}
+


### PR DESCRIPTION
Данный пасс находит операции math.ceil и заменяет их эквивалентной -floor(-x). Если операнд целочисленного типа, то замена происходит сразу на x. Для вещественных типов создается последовательность операций neg->floor->neg