### PR TITLE
Аникин Максим. Лабораторная работа 4. Вариант 1.

### DIFF
--- a/mlir/compiler-course/anikin_m_mlir_loop/CMakeLists.txt
+++ b/mlir/compiler-course/anikin_m_mlir_loop/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(Title "mlirtraceloop")
+set(Student "Anikin_Maksim")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_MLIR")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    MLIRBuiltinLocationAttributesIncGen
+    BUILDTREE_ONLY
+)
+
+set(MLIR_TEST_DEPENDS ${TARGET_NAME} ${MLIR_TEST_DEPENDS} PARENT_SCOPE)

--- a/mlir/compiler-course/anikin_m_mlir_loop/mlirtraceloop.cpp
+++ b/mlir/compiler-course/anikin_m_mlir_loop/mlirtraceloop.cpp
@@ -7,7 +7,7 @@
 #include "mlir/Tools/Plugins/PassPlugin.h"
 #include "llvm/ADT/TypeSwitch.h"
 
-namespace mlir {
+using namespace mlir;
 
 namespace {
 class LoopTracingPass : public PassWrapper<LoopTracingPass, OperationPass<ModuleOp>> {
@@ -27,9 +27,6 @@ private:
   }
 
   void handleForLikeLoop(Operation* forOp, OpBuilder& rewriter) {
-    auto loopInterface = dyn_cast<LoopLikeOpInterface>(forOp);
-    if (!loopInterface) return;
-
     if (auto affineFor = dyn_cast<affine::AffineForOp>(forOp)) {
       instrumentLoopBody(affineFor, affineFor.getBody(), ValueRange{affineFor.getInductionVar()}, rewriter);
     } else if (auto scfFor = dyn_cast<scf::ForOp>(forOp)) {
@@ -88,21 +85,19 @@ public:
 
 } // namespace
 
-MLIR_DECLARE_EXPLICIT_TYPE_ID(LoopTracingPass)
-MLIR_DEFINE_EXPLICIT_TYPE_ID(LoopTracingPass)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::LoopTracingPass)
+MLIR_DEFINE_EXPLICIT_TYPE_ID(::LoopTracingPass)
 
-mlir::PassPluginLibraryInfo getLoopTracingPluginInfo() {
+PassPluginLibraryInfo getLoopTracingPluginInfo() {
   return {
       MLIR_PLUGIN_API_VERSION,
       "mlirtraceloop_Anikin_Maksim_FIIT2_MLIR",
       LLVM_VERSION_STRING,
-      []() { mlir::PassRegistration<LoopTracingPass>(); }
+      []() { PassRegistration<LoopTracingPass>(); }
   };
 }
 
-extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo
+extern "C" LLVM_ATTRIBUTE_WEAK PassPluginLibraryInfo
 mlirGetPassPluginInfo() {
   return getLoopTracingPluginInfo();
 }
-
-} // namespace mlir

--- a/mlir/compiler-course/anikin_m_mlir_loop/mlirtraceloop.cpp
+++ b/mlir/compiler-course/anikin_m_mlir_loop/mlirtraceloop.cpp
@@ -12,7 +12,8 @@ using namespace mlir;
 namespace {
 class LoopTracingPass : public PassWrapper<LoopTracingPass, OperationPass<ModuleOp>> {
 private:
-  void instrumentLoopBody(Operation* loopOp, Block* bodyBlock, ValueRange inductionVars, OpBuilder& rewriter) {
+  void instrumentLoopBody(Operation *loopOp, Block *bodyBlock,
+                          ValueRange inductionVars, OpBuilder &rewriter) {
     Location opLocation = loopOp->getLoc();
     size_t varCount = inductionVars.size();
 
@@ -26,18 +27,21 @@ private:
     rewriter.create<func::CallOp>(opLocation, loopEndMarker, TypeRange{}, inductionVars);
   }
 
-  void handleForLikeLoop(Operation* forOp, OpBuilder& rewriter) {
+  void handleForLikeLoop(Operation *forOp, OpBuilder &rewriter) {
     if (auto affineFor = dyn_cast<affine::AffineForOp>(forOp)) {
-      instrumentLoopBody(affineFor, affineFor.getBody(), ValueRange{affineFor.getInductionVar()}, rewriter);
+      instrumentLoopBody(affineFor, affineFor.getBody(),
+                         ValueRange{affineFor.getInductionVar()}, rewriter);
     } else if (auto scfFor = dyn_cast<scf::ForOp>(forOp)) {
-      instrumentLoopBody(scfFor, scfFor.getBody(), ValueRange{scfFor.getInductionVar()}, rewriter);
+      instrumentLoopBody(scfFor, scfFor.getBody(),
+                         ValueRange{scfFor.getInductionVar()}, rewriter);
     } else if (auto affineParallel = dyn_cast<affine::AffineParallelOp>(forOp)) {
-      instrumentLoopBody(affineParallel, affineParallel.getBody(), affineParallel.getIVs(), rewriter);
+      instrumentLoopBody(affineParallel, affineParallel.getBody(),
+                         affineParallel.getIVs(), rewriter);
     }
   }
 
-  void handleWhileLoop(scf::WhileOp whileOp, OpBuilder& rewriter) {
-    Block& afterBlock = whileOp.getAfter().front();
+  void handleWhileLoop(scf::WhileOp whileOp, OpBuilder &rewriter) {
+    Block &afterBlock = whileOp.getAfter().front();
     ValueRange beforeArgs = whileOp.getBeforeArguments();
     ValueRange afterArgs = whileOp.getAfterArguments();
 
@@ -58,7 +62,7 @@ public:
   StringRef getArgument() const final {
     return "mlirtraceloop_Anikin_Maksim_FIIT2_MLIR";
   }
-  
+
   StringRef getDescription() const final {
     return "Instruments loop operations with tracing function calls. "
            "Inserts @trace_loop_iter_begin_* at loop entry and "
@@ -70,12 +74,15 @@ public:
     ModuleOp module = getOperation();
     OpBuilder instrumentationBuilder(module);
 
-    auto loopInstrumentation = [&](Operation* op) {
-      TypeSwitch<Operation*>(op)
+    auto loopInstrumentation = [&](Operation *op) {
+      TypeSwitch<Operation *>(op)
           .Case<affine::AffineForOp, affine::AffineParallelOp, scf::ForOp>(
-              [&](auto loopOp) { handleForLikeLoop(loopOp, instrumentationBuilder); })
-          .Case<scf::WhileOp>([&](scf::WhileOp whileOp) { 
-              handleWhileLoop(whileOp, instrumentationBuilder); })
+              [&](auto loopOp) {
+                handleForLikeLoop(loopOp, instrumentationBuilder);
+              })
+          .Case<scf::WhileOp>([&](scf::WhileOp whileOp) {
+            handleWhileLoop(whileOp, instrumentationBuilder);
+          })
           .Default([](auto) {});
     };
 
@@ -97,7 +104,6 @@ PassPluginLibraryInfo getLoopTracingPluginInfo() {
   };
 }
 
-extern "C" LLVM_ATTRIBUTE_WEAK PassPluginLibraryInfo
-mlirGetPassPluginInfo() {
+extern "C" LLVM_ATTRIBUTE_WEAK PassPluginLibraryInfo mlirGetPassPluginInfo() {
   return getLoopTracingPluginInfo();
 }

--- a/mlir/compiler-course/anikin_m_mlir_loop/mlirtraceloop.cpp
+++ b/mlir/compiler-course/anikin_m_mlir_loop/mlirtraceloop.cpp
@@ -1,30 +1,35 @@
-#include "mlir/Pass/Pass.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/Pass/Pass.h"
 #include "mlir/Tools/Plugins/PassPlugin.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 using namespace mlir;
 
 namespace {
-class LoopTracingPass : public PassWrapper<LoopTracingPass, OperationPass<ModuleOp>> {
+class LoopTracingPass
+    : public PassWrapper<LoopTracingPass, OperationPass<ModuleOp>> {
 private:
   void instrumentLoopBody(Operation *loopOp, Block *bodyBlock,
                           ValueRange inductionVars, OpBuilder &rewriter) {
     Location opLocation = loopOp->getLoc();
     size_t varCount = inductionVars.size();
 
-    std::string loopStartMarker = "trace_loop_iter_begin_" + std::to_string(varCount);
-    std::string loopEndMarker = "trace_loop_iter_end_" + std::to_string(varCount);
+    std::string loopStartMarker =
+        "trace_loop_iter_begin_" + std::to_string(varCount);
+    std::string loopEndMarker =
+        "trace_loop_iter_end_" + std::to_string(varCount);
 
     rewriter.setInsertionPointToStart(bodyBlock);
-    rewriter.create<func::CallOp>(opLocation, loopStartMarker, TypeRange{}, inductionVars);
+    rewriter.create<func::CallOp>(opLocation, loopStartMarker, TypeRange{},
+                                  inductionVars);
 
     rewriter.setInsertionPoint(bodyBlock->getTerminator());
-    rewriter.create<func::CallOp>(opLocation, loopEndMarker, TypeRange{}, inductionVars);
+    rewriter.create<func::CallOp>(opLocation, loopEndMarker, TypeRange{},
+                                  inductionVars);
   }
 
   void handleForLikeLoop(Operation *forOp, OpBuilder &rewriter) {
@@ -34,7 +39,8 @@ private:
     } else if (auto scfFor = dyn_cast<scf::ForOp>(forOp)) {
       instrumentLoopBody(scfFor, scfFor.getBody(),
                          ValueRange{scfFor.getInductionVar()}, rewriter);
-    } else if (auto affineParallel = dyn_cast<affine::AffineParallelOp>(forOp)) {
+    } else if (auto affineParallel =
+                   dyn_cast<affine::AffineParallelOp>(forOp)) {
       instrumentLoopBody(affineParallel, affineParallel.getBody(),
                          affineParallel.getIVs(), rewriter);
     }
@@ -48,14 +54,18 @@ private:
     Location opLocation = whileOp.getLoc();
     size_t argCount = beforeArgs.size();
 
-    std::string whileStartMarker = "trace_loop_iter_begin_" + std::to_string(argCount);
-    std::string whileEndMarker = "trace_loop_iter_end_" + std::to_string(argCount);
+    std::string whileStartMarker =
+        "trace_loop_iter_begin_" + std::to_string(argCount);
+    std::string whileEndMarker =
+        "trace_loop_iter_end_" + std::to_string(argCount);
 
     rewriter.setInsertionPointToStart(&afterBlock);
-    rewriter.create<func::CallOp>(opLocation, whileStartMarker, TypeRange{}, afterArgs);
+    rewriter.create<func::CallOp>(opLocation, whileStartMarker, TypeRange{},
+                                  afterArgs);
 
     rewriter.setInsertionPoint(afterBlock.getTerminator());
-    rewriter.create<func::CallOp>(opLocation, whileEndMarker, TypeRange{}, afterArgs);
+    rewriter.create<func::CallOp>(opLocation, whileEndMarker, TypeRange{},
+                                  afterArgs);
   }
 
 public:
@@ -96,12 +106,8 @@ MLIR_DECLARE_EXPLICIT_TYPE_ID(::LoopTracingPass)
 MLIR_DEFINE_EXPLICIT_TYPE_ID(::LoopTracingPass)
 
 PassPluginLibraryInfo getLoopTracingPluginInfo() {
-  return {
-      MLIR_PLUGIN_API_VERSION,
-      "mlirtraceloop_Anikin_Maksim_FIIT2_MLIR",
-      LLVM_VERSION_STRING,
-      []() { PassRegistration<LoopTracingPass>(); }
-  };
+  return {MLIR_PLUGIN_API_VERSION, "mlirtraceloop_Anikin_Maksim_FIIT2_MLIR",
+          LLVM_VERSION_STRING, []() { PassRegistration<LoopTracingPass>(); }};
 }
 
 extern "C" LLVM_ATTRIBUTE_WEAK PassPluginLibraryInfo mlirGetPassPluginInfo() {

--- a/mlir/compiler-course/anikin_m_mlir_loop/mlirtraceloop.cpp
+++ b/mlir/compiler-course/anikin_m_mlir_loop/mlirtraceloop.cpp
@@ -1,0 +1,108 @@
+#include "mlir/Pass/Pass.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Tools/Plugins/PassPlugin.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+namespace mlir {
+
+namespace {
+class LoopTracingPass : public PassWrapper<LoopTracingPass, OperationPass<ModuleOp>> {
+private:
+  void instrumentLoopBody(Operation* loopOp, Block* bodyBlock, ValueRange inductionVars, OpBuilder& rewriter) {
+    Location opLocation = loopOp->getLoc();
+    size_t varCount = inductionVars.size();
+
+    std::string loopStartMarker = "trace_loop_iter_begin_" + std::to_string(varCount);
+    std::string loopEndMarker = "trace_loop_iter_end_" + std::to_string(varCount);
+
+    rewriter.setInsertionPointToStart(bodyBlock);
+    rewriter.create<func::CallOp>(opLocation, loopStartMarker, TypeRange{}, inductionVars);
+
+    rewriter.setInsertionPoint(bodyBlock->getTerminator());
+    rewriter.create<func::CallOp>(opLocation, loopEndMarker, TypeRange{}, inductionVars);
+  }
+
+  void handleForLikeLoop(Operation* forOp, OpBuilder& rewriter) {
+    auto loopInterface = dyn_cast<LoopLikeOpInterface>(forOp);
+    if (!loopInterface) return;
+
+    if (auto affineFor = dyn_cast<affine::AffineForOp>(forOp)) {
+      instrumentLoopBody(affineFor, affineFor.getBody(), ValueRange{affineFor.getInductionVar()}, rewriter);
+    } else if (auto scfFor = dyn_cast<scf::ForOp>(forOp)) {
+      instrumentLoopBody(scfFor, scfFor.getBody(), ValueRange{scfFor.getInductionVar()}, rewriter);
+    } else if (auto affineParallel = dyn_cast<affine::AffineParallelOp>(forOp)) {
+      instrumentLoopBody(affineParallel, affineParallel.getBody(), affineParallel.getIVs(), rewriter);
+    }
+  }
+
+  void handleWhileLoop(scf::WhileOp whileOp, OpBuilder& rewriter) {
+    Block& afterBlock = whileOp.getAfter().front();
+    ValueRange beforeArgs = whileOp.getBeforeArguments();
+    ValueRange afterArgs = whileOp.getAfterArguments();
+
+    Location opLocation = whileOp.getLoc();
+    size_t argCount = beforeArgs.size();
+
+    std::string whileStartMarker = "trace_loop_iter_begin_" + std::to_string(argCount);
+    std::string whileEndMarker = "trace_loop_iter_end_" + std::to_string(argCount);
+
+    rewriter.setInsertionPointToStart(&afterBlock);
+    rewriter.create<func::CallOp>(opLocation, whileStartMarker, TypeRange{}, afterArgs);
+
+    rewriter.setInsertionPoint(afterBlock.getTerminator());
+    rewriter.create<func::CallOp>(opLocation, whileEndMarker, TypeRange{}, afterArgs);
+  }
+
+public:
+  StringRef getArgument() const final {
+    return "mlirtraceloop_Anikin_Maksim_FIIT2_MLIR";
+  }
+  
+  StringRef getDescription() const final {
+    return "Instruments loop operations with tracing function calls. "
+           "Inserts @trace_loop_iter_begin_* at loop entry and "
+           "@trace_loop_iter_end_* before loop termination. "
+           "The suffix indicates the number of induction variables.";
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    OpBuilder instrumentationBuilder(module);
+
+    auto loopInstrumentation = [&](Operation* op) {
+      TypeSwitch<Operation*>(op)
+          .Case<affine::AffineForOp, affine::AffineParallelOp, scf::ForOp>(
+              [&](auto loopOp) { handleForLikeLoop(loopOp, instrumentationBuilder); })
+          .Case<scf::WhileOp>([&](scf::WhileOp whileOp) { 
+              handleWhileLoop(whileOp, instrumentationBuilder); })
+          .Default([](auto) {});
+    };
+
+    module.walk(loopInstrumentation);
+  }
+};
+
+} // namespace
+
+MLIR_DECLARE_EXPLICIT_TYPE_ID(LoopTracingPass)
+MLIR_DEFINE_EXPLICIT_TYPE_ID(LoopTracingPass)
+
+mlir::PassPluginLibraryInfo getLoopTracingPluginInfo() {
+  return {
+      MLIR_PLUGIN_API_VERSION,
+      "mlirtraceloop_Anikin_Maksim_FIIT2_MLIR",
+      LLVM_VERSION_STRING,
+      []() { mlir::PassRegistration<LoopTracingPass>(); }
+  };
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo
+mlirGetPassPluginInfo() {
+  return getLoopTracingPluginInfo();
+}
+
+} // namespace mlir

--- a/mlir/test/compiler-course/anikin_m_mlir_loop/tracelooptest.mlir
+++ b/mlir/test/compiler-course/anikin_m_mlir_loop/tracelooptest.mlir
@@ -1,0 +1,89 @@
+// RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/mlirtraceloop_Anikin_Maksim_FIIT2_MLIR%shlibext \
+// RUN: --pass-pipeline="builtin.module(mlirtraceloop_Anikin_Maksim_FIIT2_MLIR)" %s | FileCheck %s
+
+// Affine For Loop Instrumentation Tests
+module {
+  func.func private @trace_loop_iter_begin_1(index) -> ()
+  func.func private @trace_loop_iter_end_1(index) -> ()
+
+  // CHECK-LABEL: func.func @affine_loop_tracing
+  func.func @affine_loop_tracing() {
+    %initial = arith.constant 0 : index
+    %limit = arith.constant 10 : index
+
+    affine.for %counter = %initial to %limit {
+      // VERIFY: func.call @trace_loop_iter_begin_1(%arg0) : (index) -> ()
+      // VERIFY-NEXT: "test.operation"
+      // VERIFY-NEXT: func.call @trace_loop_iter_end_1(%arg0) : (index) -> ()
+      "test.operation"() : () -> ()
+    }
+    func.return
+  }
+}
+
+// SCF For Loop Verification
+module {
+  func.func private @trace_loop_iter_begin_1(index) -> ()
+  func.func private @trace_loop_iter_end_1(index) -> ()
+
+  // CHECK-LABEL: func.func @scf_for_loop_instrumentation
+  func.func @scf_for_loop_instrumentation() {
+    %start_val = arith.constant 0 : index
+    %end_val = arith.constant 10 : index
+    %increment = arith.constant 1 : index
+
+    scf.for %index = %start_val to %end_val step %increment {
+      // CHECK: func.call @trace_loop_iter_begin_1(%arg0) : (index) -> ()
+      // CHECK-NEXT: "test.operation"
+      // CHECK-NEXT: func.call @trace_loop_iter_end_1(%arg0) : (index) -> ()
+      "test.operation"() : () -> ()
+    }
+    func.return
+  }
+}
+
+// SCF While Loop Testing
+module {
+  func.func private @trace_loop_iter_begin_2(i32, i32) -> ()
+  func.func private @trace_loop_iter_end_2(i32, i32) -> ()
+
+  // CHECK-LABEL: func.func @while_loop_tracing
+  func.func @while_loop_tracing() -> i32 {
+    %initial_sum = arith.constant 0 : i32
+    %initial_index = arith.constant 0 : i32
+    %max_value = arith.constant 10 : i32
+
+    %final_values:2 = scf.while (%accumulator = %initial_sum, %current = %initial_index) : (i32, i32) -> (i32, i32) {
+      %condition = arith.cmpi slt, %current, %max_value : i32
+      scf.condition(%condition) %accumulator, %current : i32, i32
+    } do {
+    ^bb0(%sum_arg: i32, %idx_arg: i32):
+      // CHECK: func.call @trace_loop_iter_begin_2
+      // CHECK-NEXT: arith.addi
+      // CHECK: func.call @trace_loop_iter_end_2
+      %updated_sum = arith.addi %sum_arg, %idx_arg : i32
+      %unit = arith.constant 1 : i32
+      %next_index = arith.addi %idx_arg, %unit : i32
+      scf.yield %updated_sum, %next_index : i32, i32
+    }
+
+    func.return %final_values#0 : i32
+  }
+}
+
+// Affine Parallel Loop Verification
+module {
+  func.func private @trace_loop_iter_begin_2(index, index) -> ()
+  func.func private @trace_loop_iter_end_2(index, index) -> ()
+
+  // CHECK-LABEL: func.func @parallel_loop_instrumentation
+  func.func @parallel_loop_instrumentation() {
+    affine.parallel (%dim1, %dim2) = (0, 0) to (10, 10) step (2, 2) {
+      // CHECK: func.call @trace_loop_iter_begin_2(%arg0, %arg1) : (index, index) -> ()
+      // CHECK-NEXT: "test.operation"() : () -> ()
+      // CHECK-NEXT: func.call @trace_loop_iter_end_2(%arg0, %arg1) : (index, index) -> ()
+      "test.operation"() : () -> ()
+    }
+    func.return
+  }
+}


### PR DESCRIPTION
Проход для MLIR, который автоматически добавляет в код вызовы функций трассировки. Эти вызовы обрамляют каждую итерацию циклов affine.for, scf.for и scf.while, позволяя в реальном времени отслеживать их выполнение для целей отладки и анализа производительности.