### PR TITLE
Сдобнов Владимир. Лабораторная работа 2. Вариант 4

### DIFF
--- a/llvm/compiler-course/llvm-ir/sdobnov_v_lab2/CMakeLists.txt
+++ b/llvm/compiler-course/llvm-ir/sdobnov_v_lab2/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(Title "DivisionOptimizer")
+set(Student "SdobnovV")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_LLVM_IR")
+
+if (NOT WIN32 AND NOT CYGWIN)
+    file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+    add_llvm_pass_plugin(${TARGET_NAME} ${SOURCES}
+        DEPENDS
+        intrinsics_gen
+        BUILDTREE_ONLY
+    )
+    set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)
+endif()

--- a/llvm/compiler-course/llvm-ir/sdobnov_v_lab2/sdobnov_v_lab2.cpp
+++ b/llvm/compiler-course/llvm-ir/sdobnov_v_lab2/sdobnov_v_lab2.cpp
@@ -1,0 +1,121 @@
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+
+namespace {
+
+class DivisionOptimizer : public PassInfoMixin<DivisionOptimizer> {
+private:
+  bool processDivisionInstruction(BinaryOperator *DivisionOp) {
+    auto *DivisorConstant = dyn_cast<ConstantInt>(DivisionOp->getOperand(1));
+    if (!DivisorConstant)
+      return false;
+
+    if (DivisionOp->getOpcode() == Instruction::SDiv) {
+      return optimizeSignedDivision(DivisionOp, DivisorConstant);
+    } else if (DivisionOp->getOpcode() == Instruction::UDiv) {
+      return optimizeUnsignedDivision(DivisionOp, DivisorConstant);
+    }
+    return false;
+  }
+
+  bool optimizeSignedDivision(BinaryOperator *SignedDiv, ConstantInt *Divisor) {
+    int64_t divisorValue = Divisor->getSExtValue();
+    uint64_t absoluteDivisor = std::abs(divisorValue);
+
+    if (absoluteDivisor == 0 || !isPowerOf2_64(absoluteDivisor)) {
+      return false;
+    }
+
+    unsigned shiftAmount = Log2_64(absoluteDivisor);
+    return replaceDivisionWithShift(SignedDiv, shiftAmount, divisorValue < 0);
+  }
+
+  bool optimizeUnsignedDivision(BinaryOperator *UnsignedDiv,
+                                ConstantInt *Divisor) {
+    uint64_t divisorValue = Divisor->getZExtValue();
+
+    if (divisorValue == 0 || !isPowerOf2_64(divisorValue)) {
+      return false;
+    }
+
+    unsigned shiftAmount = Log2_64(divisorValue);
+    return replaceDivisionWithShift(UnsignedDiv, shiftAmount, false);
+  }
+
+  bool replaceDivisionWithShift(BinaryOperator *DivisionOp, unsigned shiftBits,
+                                bool needsNegation) {
+    IRBuilder<> builder(DivisionOp);
+    Value *dividend = DivisionOp->getOperand(0);
+    Value *shiftValue = ConstantInt::get(dividend->getType(), shiftBits);
+
+    Value *optimizedResult = createShiftOperation(builder, dividend, shiftValue,
+                                                  DivisionOp->getOpcode());
+
+    if (needsNegation) {
+      optimizedResult = builder.CreateNeg(optimizedResult, "negated_shift");
+    }
+
+    DivisionOp->replaceAllUsesWith(optimizedResult);
+    DivisionOp->eraseFromParent();
+    return true;
+  }
+
+  Value *createShiftOperation(IRBuilder<> &builder, Value *value, Value *shift,
+                              Instruction::BinaryOps originalOp) {
+    if (originalOp == Instruction::SDiv) {
+      return builder.CreateAShr(value, shift, "signed_shift_div");
+    } else {
+      return builder.CreateLShr(value, shift, "unsigned_shift_div");
+    }
+  }
+
+public:
+  PreservedAnalyses run(Function &func, FunctionAnalysisManager &) {
+    bool modificationsMade = false;
+
+    for (auto &basicBlock : func) {
+      for (auto instructionIter = basicBlock.begin();
+           instructionIter != basicBlock.end();) {
+        Instruction *currentInst = &*instructionIter++;
+
+        if (auto *binaryOp = dyn_cast<BinaryOperator>(currentInst)) {
+          if (binaryOp->getOpcode() == Instruction::SDiv ||
+              binaryOp->getOpcode() == Instruction::UDiv) {
+            modificationsMade |= processDivisionInstruction(binaryOp);
+          }
+        }
+      }
+    }
+
+    return modificationsMade ? PreservedAnalyses::none()
+                             : PreservedAnalyses::all();
+  }
+
+  static bool isRequired() { return true; }
+};
+
+} // namespace
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "DivisionOptimizer", "1.0",
+          [](llvm::PassBuilder &passBuilder) {
+            passBuilder.registerPipelineParsingCallback(
+                [](llvm::StringRef passName,
+                   llvm::FunctionPassManager &functionPM,
+                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) -> bool {
+                  if (passName == "optimize-divisions") {
+                    functionPM.addPass(DivisionOptimizer{});
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}

--- a/llvm/test/compiler-course/sdobnov_v_lab2/sdobnov_v_test_test_lab2.ll
+++ b/llvm/test/compiler-course/sdobnov_v_lab2/sdobnov_v_test_test_lab2.ll
@@ -1,0 +1,182 @@
+; RUN: opt -load-pass-plugin %llvmshlibdir/DivisionOptimizer_SdobnovV_FIIT2_LLVM_IR%pluginext \
+; RUN: -passes=optimize-divisions -S %s | FileCheck %s
+
+; Тест оптимизации знакового деления на степень двойки
+; Исходная операция: value / 8
+; Ожидаемая оптимизация: value >> 3
+; CHECK-LABEL: @test_signed_division_power_of_two
+; CHECK-NOT: sdiv i32
+; CHECK: ashr i32 %input_value, 3
+; CHECK: ret i32
+
+define i32 @test_signed_division_power_of_two(i32 %input_value) {
+entry:
+  %division_result = sdiv i32 %input_value, 8
+  ret i32 %division_result
+}
+
+; Тест сохранения деления на не-степень двойки
+; Исходная операция: value / 5
+; Ожидается: сохранение операции деления
+; CHECK-LABEL: @test_division_non_power_of_two
+; CHECK: sdiv i32 %input_value, 5
+; CHECK: ret i32
+
+define i32 @test_division_non_power_of_two(i32 %input_value) {
+entry:
+  %division_result = sdiv i32 %input_value, 5
+  ret i32 %division_result
+}
+
+; Тест оптимизации беззнакового деления
+; Исходная операция: value / 16 (беззнаковое)
+; Ожидаемая оптимизация: value >>> 4
+; CHECK-LABEL: @test_unsigned_division_optimization
+; CHECK-NOT: udiv i32
+; CHECK: lshr i32 %input_value, 4
+; CHECK: ret i32
+
+define i32 @test_unsigned_division_optimization(i32 %input_value) {
+entry:
+  %division_result = udiv i32 %input_value, 16
+  ret i32 %division_result
+}
+
+; Тест игнорирования других арифметических операций
+; Исходная операция: value * 2
+; Ожидается: сохранение умножения
+; CHECK-LABEL: @test_multiplication_untouched
+; CHECK: mul i32 %input_value, 2
+; CHECK: ret i32
+
+define i32 @test_multiplication_untouched(i32 %input_value) {
+entry:
+  %multiplication_result = mul i32 %input_value, 2
+  ret i32 %multiplication_result
+}
+
+; Тест деления на простое число
+; Исходная операция: value / 17
+; Ожидается: сохранение деления
+; CHECK-LABEL: @test_prime_number_division
+; CHECK: sdiv i32 %input_value, 17
+; CHECK: ret i32
+
+define i32 @test_prime_number_division(i32 %input_value) {
+entry:
+  %division_result = sdiv i32 %input_value, 17
+  ret i32 %division_result
+}
+
+; Тест минимальной степени двойки
+; Исходная операция: value / 2
+; Ожидаемая оптимизация: value >> 1
+; CHECK-LABEL: @test_minimal_power_of_two
+; CHECK-NOT: sdiv i32
+; CHECK: ashr i32 %input_value, 1
+; CHECK: ret i32
+
+define i32 @test_minimal_power_of_two(i32 %input_value) {
+entry:
+  %division_result = sdiv i32 %input_value, 2
+  ret i32 %division_result
+}
+
+; Тест обработки деления на ноль
+; Исходная операция: value / 0
+; Ожидается: сохранение (undefined behavior)
+; CHECK-LABEL: @test_division_by_zero
+; CHECK: sdiv i32 %input_value, 0
+; CHECK: ret i32
+
+define i32 @test_division_by_zero(i32 %input_value) {
+entry:
+  %division_result = sdiv i32 %input_value, 0
+  ret i32 %division_result
+}
+
+; Тест деления на переменную величину
+; Исходная операция: value / divisor
+; Ожидается: сохранение динамического деления
+; CHECK-LABEL: @test_dynamic_division
+; CHECK: sdiv i32 %input_value, %divisor_value
+; CHECK: ret i32
+
+define i32 @test_dynamic_division(i32 %input_value, i32 %divisor_value) {
+entry:
+  %division_result = sdiv i32 %input_value, %divisor_value
+  ret i32 %division_result
+}
+
+; Тест оптимизации отрицательного делителя (степень двойки)
+; Исходная операция: value / -4
+; Ожидаемая оптимизация: -(value >> 2)
+; CHECK-LABEL: @test_negative_power_of_two
+; CHECK-NOT: sdiv i32
+; CHECK: %signed_shift_div = ashr i32 %input_value, 2
+; CHECK: %negated_shift = sub i32 0, %signed_shift_div
+; CHECK: ret i32 %negated_shift
+
+define i32 @test_negative_power_of_two(i32 %input_value) {
+entry:
+  %division_result = sdiv i32 %input_value, -4
+  ret i32 %division_result
+}
+
+; Тест отрицательного не-степени двойки
+; Исходная операция: value / -11
+; Ожидается: сохранение деления
+; CHECK-LABEL: @test_negative_non_power
+; CHECK: sdiv i32 %input_value, -11
+; CHECK: ret i32
+
+define i32 @test_negative_non_power(i32 %input_value) {
+entry:
+  %division_result = sdiv i32 %input_value, -11
+  ret i32 %division_result
+}
+
+; Тест большой степени двойки
+; Исходная операция: value / 1024
+; Ожидаемая оптимизация: value >> 10
+; CHECK-LABEL: @test_large_power_of_two
+; CHECK-NOT: sdiv i32
+; CHECK: ashr i32 %input_value, 10
+; CHECK: ret i32
+
+define i32 @test_large_power_of_two(i32 %input_value) {
+entry:
+  %division_result = sdiv i32 %input_value, 1024
+  ret i32 %division_result
+}
+
+; Тест граничного случая (деление на 1)
+; Исходная операция: value / 1
+; Ожидаемая оптимизация: value >> 0 (или value)
+; CHECK-LABEL: @test_division_by_one
+; CHECK-NOT: sdiv i32
+; CHECK: ashr i32 %input_value, 0
+; CHECK: ret i32
+
+define i32 @test_division_by_one(i32 %input_value) {
+entry:
+  %division_result = sdiv i32 %input_value, 1
+  ret i32 %division_result
+}
+
+; Тест смешанных операций в функции
+; Проверка, что пасс корректно работает в контексте других инструкций
+; CHECK-LABEL: @test_mixed_operations
+; CHECK: mul i32 %input_value, 3
+; CHECK-NOT: sdiv i32 {{.*}}, 4
+; CHECK: ashr i32 {{.*}}, 2
+; CHECK: add i32 {{.*}}, 10
+; CHECK: ret i32
+
+define i32 @test_mixed_operations(i32 %input_value) {
+entry:
+  %mul_result = mul i32 %input_value, 3
+  %div_result = sdiv i32 %mul_result, 4
+  %final_result = add i32 %div_result, 10
+  ret i32 %final_result
+}


### PR DESCRIPTION
LLVM-пасс, оптимизирующий целочисленное деление заменой операций на побитовые сдвиги для степеней двойки. Он обрабатывает как знаковое (SDiv), так и беззнаковое (UDiv) деление, автоматически учитывая отрицательные делители. Пасс интегрируется в пайплайн оптимизаций LLVM и проверяет делитель на ноль и соответствие степени двойки. В результате дорогостоящие операции деления заменяются эффективными битовыми сдвигами, ускоряя выполнение кода.