### PR TITLE
Шишкарев Андрей. Лабораторная работа 3: Backend. Вариант 3.

### DIFF
--- a/llvm/compiler-course/backend/shishkarev_a_backend/CMakeLists.txt
+++ b/llvm/compiler-course/backend/shishkarev_a_backend/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(Title "FMADecomposePass")
+set(Student "Shishkarev_Andrey")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_BACKEND")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY
+)
+
+target_include_directories(${TARGET_NAME} PUBLIC ${PATH_TO_X86})
+set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/compiler-course/backend/shishkarev_a_backend/FMADecomposePass.cpp
+++ b/llvm/compiler-course/backend/shishkarev_a_backend/FMADecomposePass.cpp
@@ -1,0 +1,108 @@
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/CodeGen/TargetOpcodes.h"
+#include "llvm/Passes/PassBuilder.h"
+
+#define DEBUG_TYPE "fma-decompose"
+
+namespace {
+
+class FMADecomposePass : public llvm::MachineFunctionPass {
+public:
+  static char ID;
+  FMADecomposePass() : llvm::MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(llvm::MachineFunction &MF) override {
+    const llvm::X86Subtarget &ST = MF.getSubtarget<llvm::X86Subtarget>();
+    // skip if fma not supported
+    if (!ST.hasFMA())
+      return false;
+    const llvm::X86InstrInfo *TII = ST.getInstrInfo();
+    llvm::MachineRegisterInfo &MRI = MF.getRegInfo();
+    bool Changed = false;
+
+    for (auto &MBB : MF) {
+      llvm::SmallVector<llvm::MachineInstr *, 8> ToErase;
+      // first pass: insert mul+add and mark original fma for erasure
+      for (auto &MI : MBB) {
+        unsigned Opc = MI.getOpcode();
+        unsigned MulOpc = 0, AddOpc = 0;
+
+        // skip non-fma instructions
+        switch (Opc) {
+        // packed single-precision fma
+        case llvm::X86::VFMADD132PSr:
+        case llvm::X86::VFMADD213PSr:
+        case llvm::X86::VFMADD231PSr:
+          MulOpc = llvm::X86::MULPSrr;
+          AddOpc = llvm::X86::ADDPSrr;
+          break;
+        // packed double-precision fma
+        case llvm::X86::VFMADD132PDr:
+        case llvm::X86::VFMADD213PDr:
+        case llvm::X86::VFMADD231PDr:
+          MulOpc = llvm::X86::MULPDrr;
+          AddOpc = llvm::X86::ADDPDrr;
+          break;
+        // scalar single-precision fma
+        case llvm::X86::VFMADD132SSr:
+        case llvm::X86::VFMADD213SSr:
+        case llvm::X86::VFMADD231SSr:
+          MulOpc = llvm::X86::MULSSrr;
+          AddOpc = llvm::X86::ADDSSrr;
+          break;
+        // scalar double-precision fma
+        case llvm::X86::VFMADD132SDr:
+        case llvm::X86::VFMADD213SDr:
+        case llvm::X86::VFMADD231SDr:
+          MulOpc = llvm::X86::MULSDrr;
+          AddOpc = llvm::X86::ADDSDrr;
+          break;
+        default:
+          continue;
+        }
+
+        // operands: dst, src1, src2, src3
+        llvm::DebugLoc DL = MI.getDebugLoc();
+        llvm::Register Dst = MI.getOperand(0).getReg();
+        llvm::Register A = MI.getOperand(1).getReg();
+        llvm::Register B = MI.getOperand(2).getReg();
+        llvm::Register C = MI.getOperand(3).getReg();
+
+        // create a tmp vreg of the same class as A
+        const llvm::TargetRegisterClass *RC = MRI.getRegClass(A);
+        llvm::Register Tmp = MRI.createVirtualRegister(RC);
+
+        // insert mul before this fma
+        llvm::BuildMI(MBB, MI, DL, TII->get(MulOpc), Tmp).addReg(A).addReg(B);
+
+        // insert add before this fma
+        llvm::BuildMI(MBB, MI, DL, TII->get(AddOpc), Dst).addReg(C).addReg(Tmp);
+
+        // mark original fma for erasure
+        ToErase.push_back(&MI);
+        Changed = true;
+      }
+
+      // second pass: actually remove all marked FMAs
+      for (auto *MI : ToErase)
+        MI->eraseFromParent();
+    }
+
+    return Changed;
+  }
+};
+
+char FMADecomposePass::ID = 0;
+
+} // end anonymous namespace
+
+static llvm::RegisterPass<FMADecomposePass>
+    X("fma-decompose-x86",
+      "Decomposes single FMA instructions into MUL and ADD ones", false, false);

--- a/llvm/test/compiler-course/shishkarev_a_backend/FMADecompose.mir
+++ b/llvm/test/compiler-course/shishkarev_a_backend/FMADecompose.mir
@@ -1,0 +1,407 @@
+#  RUN: llc -mtriple=x86_64-unknown-linux-gnu -mattr=+avx \
+#  RUN:     --load=%llvmshlibdir/FMADecomposePass_Shishkarev_Andrey_FIIT2_BACKEND%shlibext \
+#  RUN:     -run-pass=fma-decompose-x86 %s -o - | FileCheck %s
+
+# test-fma.cpp
+#
+# #include <immintrin.h>
+# 
+# // packed single-precision fma
+# __m128 test_packed_single(__m128 a, __m128 b, __m128 c) {
+#     // should lower to vfmadd132ps
+#     return _mm_fmadd_ps(a, b, c);
+# }
+# 
+# // packed double-precision fma
+# __m128d test_packed_double(__m128d a, __m128d b, __m128d c) {
+#     // should lower to vfmadd132pd
+#     return _mm_fmadd_pd(a, b, c);
+# }
+# 
+# // scalar single-precision fma
+# float test_scalar_single(float a, float b, float c) {
+#     // builtin_fmaf maps to fma scalar single
+#     return __builtin_fmaf(a, b, c);
+# }
+# 
+# // scalar double-precision fma
+# double test_scalar_double(double a, double b, double c) {
+#     // builtin_fma maps to fma scalar double
+#     return __builtin_fma(a, b, c);
+# }
+
+--- |
+  ; ModuleID = 'fma.ll'
+  source_filename = "test-fma.cpp"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-pc-linux-gnu"
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <4 x float> @_Z18test_packed_singleDv4_fS_S_(<4 x float> noundef %0, <4 x float> noundef %1, <4 x float> noundef %2) local_unnamed_addr #0 {
+    %4 = tail call noundef <4 x float> @llvm.fma.v4f32(<4 x float> %0, <4 x float> %1, <4 x float> %2)
+    ret <4 x float> %4
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <2 x double> @_Z18test_packed_doubleDv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
+    %4 = tail call noundef <2 x double> @llvm.fma.v2f64(<2 x double> %0, <2 x double> %1, <2 x double> %2)
+    ret <2 x double> %4
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef float @_Z18test_scalar_singlefff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
+    %4 = tail call float @llvm.fma.f32(float %0, float %1, float %2)
+    ret float %4
+  }
+  
+  ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+  declare float @llvm.fma.f32(float, float, float) #2
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef double @_Z18test_scalar_doubleddd(double noundef %0, double noundef %1, double noundef %2) local_unnamed_addr #1 {
+    %4 = tail call double @llvm.fma.f64(double %0, double %1, double %2)
+    ret double %4
+  }
+  
+  ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+  declare double @llvm.fma.f64(double, double, double) #2
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef i32 @main() local_unnamed_addr #0 {
+    ret i32 0
+  }
+  
+  ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+  declare <4 x float> @llvm.fma.v4f32(<4 x float>, <4 x float>, <4 x float>) #2
+  
+  ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+  declare <2 x double> @llvm.fma.v2f64(<2 x double>, <2 x double>, <2 x double>) #2
+  
+  attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable "min-legal-vector-width"="128" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+avx,+cmov,+crc32,+cx8,+fma,+fxsr,+mmx,+popcnt,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3,+x87,+xsave" "tune-cpu"="generic" }
+  attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+avx,+cmov,+crc32,+cx8,+fma,+fxsr,+mmx,+popcnt,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3,+x87,+xsave" "tune-cpu"="generic" }
+  attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) "target-cpu"="haswell" }
+  
+  !llvm.module.flags = !{!0, !1, !2, !3}
+  !llvm.ident = !{!4}
+  
+  !0 = !{i32 1, !"wchar_size", i32 4}
+  !1 = !{i32 8, !"PIC Level", i32 2}
+  !2 = !{i32 7, !"PIE Level", i32 2}
+  !3 = !{i32 7, !"uwtable", i32 2}
+  !4 = !{!"Ubuntu clang version 18.1.3 (1ubuntu1)"}
+
+...
+---
+# CHECK-LABEL: name:            _Z18test_packed_singleDv4_fS_S_
+name:            _Z18test_packed_singleDv4_fS_S_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128, preferred-register: '' }
+  - { id: 1, class: vr128, preferred-register: '' }
+  - { id: 2, class: vr128, preferred-register: '' }
+  - { id: 3, class: vr128, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $xmm0, $xmm1, $xmm2
+
+    ; CHECK: %2:vr128 = COPY $xmm2
+    ; CHECK-NEXT: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %4:vr128 = MULPSrr %1, %0, implicit $mxcsr
+    ; CHECK-NEXT: %3:vr128 = ADDPSrr %2, %4, implicit $mxcsr
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+  
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept VFMADD213PSr %1, %0, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+# CHECK-LABEL: name:            _Z18test_packed_doubleDv2_dS_S_
+name:            _Z18test_packed_doubleDv2_dS_S_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128, preferred-register: '' }
+  - { id: 1, class: vr128, preferred-register: '' }
+  - { id: 2, class: vr128, preferred-register: '' }
+  - { id: 3, class: vr128, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $xmm0, $xmm1, $xmm2
+
+    ; CHECK: %2:vr128 = COPY $xmm2
+    ; CHECK-NEXT: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %4:vr128 = MULPDrr %1, %0, implicit $mxcsr
+    ; CHECK-NEXT: %3:vr128 = ADDPDrr %2, %4, implicit $mxcsr
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+  
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept VFMADD213PDr %1, %0, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+# CHECK-LABEL: name:            _Z18test_scalar_singlefff
+name:            _Z18test_scalar_singlefff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $xmm0, $xmm1, $xmm2
+
+    ; CHECK: %2:fr32 = COPY $xmm2
+    ; CHECK-NEXT: %1:fr32 = COPY $xmm1
+    ; CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ; CHECK-NEXT: %4:fr32 = MULSSrr %1, %0, implicit $mxcsr
+    ; CHECK-NEXT: %3:fr32 = ADDSSrr %2, %4, implicit $mxcsr
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+  
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VFMADD213SSr %1, %0, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+# CHECK-LABEL: name:            _Z18test_scalar_doubleddd
+name:            _Z18test_scalar_doubleddd
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr64, preferred-register: '' }
+  - { id: 1, class: fr64, preferred-register: '' }
+  - { id: 2, class: fr64, preferred-register: '' }
+  - { id: 3, class: fr64, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $xmm0, $xmm1, $xmm2
+
+    ; CHECK: %2:fr64 = COPY $xmm2
+    ; CHECK-NEXT: %1:fr64 = COPY $xmm1
+    ; CHECK-NEXT: %0:fr64 = COPY $xmm0
+    ; CHECK-NEXT: %4:fr64 = MULSDrr %1, %0, implicit $mxcsr
+    ; CHECK-NEXT: %3:fr64 = ADDSDrr %2, %4, implicit $mxcsr
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+  
+    %2:fr64 = COPY $xmm2
+    %1:fr64 = COPY $xmm1
+    %0:fr64 = COPY $xmm0
+    %3:fr64 = nofpexcept VFMADD213SDr %1, %0, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0


### PR DESCRIPTION
Этот MachineFunctionPass для архитектуры X86 выполняет разложение FMA-инструкций на отдельные операции умножения (MUL) и сложения (ADD). Пасс работает с упакованными и скалярными FMA-операциями одинарной и двойной точности.

Пасс проверяет, поддерживает ли целевая платформа FMA. Если нет, он завершает работу без изменений.

Работа состоит из двух этапов:
1. Для каждой FMA-инструкции создаются соответствующие инструкции MUL и ADD
2. Все оригинальные FMA-инструкции удаляются

Временные регистры сохраняют те же классы, что и исходные операнды FMA. Пасс регистрируется через legacy-менеджер для совместимости с утилитой llc.