### PR TITLE
Шишкарев Андрей. Лабораторная работа 4: MLIR. Вариант 1.

### DIFF
--- a/mlir/compiler-course/shishkarev_a_mlir/CMakeLists.txt
+++ b/mlir/compiler-course/shishkarev_a_mlir/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(Title "TraceLoopPass")
+set(Student "Shishkarev_Andrey")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_MLIR")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    MLIRBuiltinLocationAttributesIncGen
+    BUILDTREE_ONLY
+)
+
+set(MLIR_TEST_DEPENDS ${TARGET_NAME} ${MLIR_TEST_DEPENDS} PARENT_SCOPE)

--- a/mlir/compiler-course/shishkarev_a_mlir/traceLoopIterPass.cpp
+++ b/mlir/compiler-course/shishkarev_a_mlir/traceLoopIterPass.cpp
@@ -25,26 +25,26 @@ struct TraceLoopPass
   }
 
 private:
-  void createTraceFunction(ModuleOp module, OpBuilder &builder, 
-                          StringRef functionName) {
+  void createTraceFunction(ModuleOp module, OpBuilder &builder,
+                           StringRef functionName) {
     if (!module.lookupSymbol<func::FuncOp>(functionName)) {
       Location loc = module.getLoc();
       builder.setInsertionPointToStart(module.getBody());
-      auto func = builder.create<func::FuncOp>(
-          loc, functionName, builder.getFunctionType({}, {}));
+      auto func = builder.create<func::FuncOp>(loc, functionName,
+                                               builder.getFunctionType({}, {}));
       func.setSymVisibility("private");
     }
   }
 
   void instrumentLoopBody(OpBuilder &builder, Block &body, Location loopLoc) {
     builder.setInsertionPointToStart(&body);
-    builder.create<func::CallOp>(loopLoc, "trace_loop_iter_begin",
-                                 TypeRange{}, ValueRange{});
-    
+    builder.create<func::CallOp>(loopLoc, "trace_loop_iter_begin", TypeRange{},
+                                 ValueRange{});
+
     Operation *term = body.getTerminator();
     builder.setInsertionPoint(term);
-    builder.create<func::CallOp>(loopLoc, "trace_loop_iter_end",
-                                 TypeRange{}, ValueRange{});
+    builder.create<func::CallOp>(loopLoc, "trace_loop_iter_end", TypeRange{},
+                                 ValueRange{});
   }
 
 public:
@@ -57,7 +57,7 @@ public:
 
     module.walk([&](Operation *op) {
       OpBuilder::InsertionGuard guard(builder);
-      
+
       if (auto forOp = dyn_cast<affine::AffineForOp>(op)) {
         instrumentLoopBody(builder, *forOp.getBody(), op->getLoc());
       } else if (auto scfFor = dyn_cast<scf::ForOp>(op)) {

--- a/mlir/compiler-course/shishkarev_a_mlir/traceLoopIterPass.cpp
+++ b/mlir/compiler-course/shishkarev_a_mlir/traceLoopIterPass.cpp
@@ -1,0 +1,97 @@
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Tools/Plugins/PassPlugin.h"
+
+using namespace mlir;
+
+namespace {
+struct TraceLoopPass
+    : public PassWrapper<TraceLoopPass, OperationPass<ModuleOp>> {
+  StringRef getArgument() const final {
+    return "TraceLoopPass_KudryashovaIrina_FIIT3_MLIR";
+  }
+  StringRef getDescription() const final {
+    return "Insert @trace_loop_iter_begin and @trace_loop_iter_end calls at "
+           "loop iteration boundaries";
+  }
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry
+        .insert<affine::AffineDialect, scf::SCFDialect, func::FuncDialect>();
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    OpBuilder builder(module.getContext());
+    Location loc = module.getLoc();
+
+    if (!module.lookupSymbol<func::FuncOp>("trace_loop_iter_begin")) {
+      builder.setInsertionPointToStart(module.getBody());
+      auto begin = builder.create<func::FuncOp>(
+          loc, "trace_loop_iter_begin", builder.getFunctionType({}, {}));
+      begin.setSymVisibility("private");
+    }
+    if (!module.lookupSymbol<func::FuncOp>("trace_loop_iter_end")) {
+      builder.setInsertionPointToStart(module.getBody());
+      auto end = builder.create<func::FuncOp>(loc, "trace_loop_iter_end",
+                                              builder.getFunctionType({}, {}));
+      end.setSymVisibility("private");
+    }
+
+    module.walk([&](Operation *op) {
+      Location loopLoc = op->getLoc();
+      OpBuilder::InsertionGuard guard(builder);
+
+      if (auto forOp = dyn_cast<affine::AffineForOp>(op)) {
+        Block &body = *forOp.getBody();
+        builder.setInsertionPointToStart(&body);
+        builder.create<func::CallOp>(loopLoc, "trace_loop_iter_begin",
+                                     TypeRange{}, ValueRange{});
+        Operation *term = body.getTerminator();
+        builder.setInsertionPoint(term);
+        builder.create<func::CallOp>(loopLoc, "trace_loop_iter_end",
+                                     TypeRange{}, ValueRange{});
+      }
+
+      else if (auto scfFor = dyn_cast<scf::ForOp>(op)) {
+        Block &body = *scfFor.getBody();
+        builder.setInsertionPointToStart(&body);
+        builder.create<func::CallOp>(loopLoc, "trace_loop_iter_begin",
+                                     TypeRange{}, ValueRange{});
+        Operation *term = body.getTerminator();
+        builder.setInsertionPoint(term);
+        builder.create<func::CallOp>(loopLoc, "trace_loop_iter_end",
+                                     TypeRange{}, ValueRange{});
+      }
+
+      else if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+        Block &body = whileOp.getAfter().front();
+        builder.setInsertionPointToStart(&body);
+        builder.create<func::CallOp>(loopLoc, "trace_loop_iter_begin",
+                                     TypeRange{}, ValueRange{});
+        Operation *term = body.getTerminator();
+        builder.setInsertionPoint(term);
+        builder.create<func::CallOp>(loopLoc, "trace_loop_iter_end",
+                                     TypeRange{}, ValueRange{});
+      }
+    });
+  }
+};
+} // namespace
+
+MLIR_DECLARE_EXPLICIT_TYPE_ID(TraceLoopPass)
+MLIR_DEFINE_EXPLICIT_TYPE_ID(TraceLoopPass)
+
+mlir::PassPluginLibraryInfo getTraceLoopPassPluginInfo() {
+  return {MLIR_PLUGIN_API_VERSION, "TraceLoopPass", "1.0",
+          []() { mlir::PassRegistration<TraceLoopPass>(); }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo
+mlirGetPassPluginInfo() {
+  return getTraceLoopPassPluginInfo();
+}

--- a/mlir/compiler-course/shishkarev_a_mlir/traceLoopIterPass.cpp
+++ b/mlir/compiler-course/shishkarev_a_mlir/traceLoopIterPass.cpp
@@ -24,59 +24,46 @@ struct TraceLoopPass
         .insert<affine::AffineDialect, scf::SCFDialect, func::FuncDialect>();
   }
 
+private:
+  void createTraceFunction(ModuleOp module, OpBuilder &builder, 
+                          StringRef functionName) {
+    if (!module.lookupSymbol<func::FuncOp>(functionName)) {
+      Location loc = module.getLoc();
+      builder.setInsertionPointToStart(module.getBody());
+      auto func = builder.create<func::FuncOp>(
+          loc, functionName, builder.getFunctionType({}, {}));
+      func.setSymVisibility("private");
+    }
+  }
+
+  void instrumentLoopBody(OpBuilder &builder, Block &body, Location loopLoc) {
+    builder.setInsertionPointToStart(&body);
+    builder.create<func::CallOp>(loopLoc, "trace_loop_iter_begin",
+                                 TypeRange{}, ValueRange{});
+    
+    Operation *term = body.getTerminator();
+    builder.setInsertionPoint(term);
+    builder.create<func::CallOp>(loopLoc, "trace_loop_iter_end",
+                                 TypeRange{}, ValueRange{});
+  }
+
+public:
   void runOnOperation() override {
     ModuleOp module = getOperation();
     OpBuilder builder(module.getContext());
-    Location loc = module.getLoc();
 
-    if (!module.lookupSymbol<func::FuncOp>("trace_loop_iter_begin")) {
-      builder.setInsertionPointToStart(module.getBody());
-      auto begin = builder.create<func::FuncOp>(
-          loc, "trace_loop_iter_begin", builder.getFunctionType({}, {}));
-      begin.setSymVisibility("private");
-    }
-    if (!module.lookupSymbol<func::FuncOp>("trace_loop_iter_end")) {
-      builder.setInsertionPointToStart(module.getBody());
-      auto end = builder.create<func::FuncOp>(loc, "trace_loop_iter_end",
-                                              builder.getFunctionType({}, {}));
-      end.setSymVisibility("private");
-    }
+    createTraceFunction(module, builder, "trace_loop_iter_begin");
+    createTraceFunction(module, builder, "trace_loop_iter_end");
 
     module.walk([&](Operation *op) {
-      Location loopLoc = op->getLoc();
       OpBuilder::InsertionGuard guard(builder);
-
+      
       if (auto forOp = dyn_cast<affine::AffineForOp>(op)) {
-        Block &body = *forOp.getBody();
-        builder.setInsertionPointToStart(&body);
-        builder.create<func::CallOp>(loopLoc, "trace_loop_iter_begin",
-                                     TypeRange{}, ValueRange{});
-        Operation *term = body.getTerminator();
-        builder.setInsertionPoint(term);
-        builder.create<func::CallOp>(loopLoc, "trace_loop_iter_end",
-                                     TypeRange{}, ValueRange{});
-      }
-
-      else if (auto scfFor = dyn_cast<scf::ForOp>(op)) {
-        Block &body = *scfFor.getBody();
-        builder.setInsertionPointToStart(&body);
-        builder.create<func::CallOp>(loopLoc, "trace_loop_iter_begin",
-                                     TypeRange{}, ValueRange{});
-        Operation *term = body.getTerminator();
-        builder.setInsertionPoint(term);
-        builder.create<func::CallOp>(loopLoc, "trace_loop_iter_end",
-                                     TypeRange{}, ValueRange{});
-      }
-
-      else if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
-        Block &body = whileOp.getAfter().front();
-        builder.setInsertionPointToStart(&body);
-        builder.create<func::CallOp>(loopLoc, "trace_loop_iter_begin",
-                                     TypeRange{}, ValueRange{});
-        Operation *term = body.getTerminator();
-        builder.setInsertionPoint(term);
-        builder.create<func::CallOp>(loopLoc, "trace_loop_iter_end",
-                                     TypeRange{}, ValueRange{});
+        instrumentLoopBody(builder, *forOp.getBody(), op->getLoc());
+      } else if (auto scfFor = dyn_cast<scf::ForOp>(op)) {
+        instrumentLoopBody(builder, *scfFor.getBody(), op->getLoc());
+      } else if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+        instrumentLoopBody(builder, whileOp.getAfter().front(), op->getLoc());
       }
     });
   }

--- a/mlir/test/compiler-course/shishakrev_a_mlir/test.mlir
+++ b/mlir/test/compiler-course/shishakrev_a_mlir/test.mlir
@@ -1,0 +1,67 @@
+// RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/TraceLoopPass_Shishkarev_Andrey_FIIT2_MLIR%shlibext \
+// RUN: --pass-pipeline="builtin.module(TraceLoopPass_KudryashovaIrina_FIIT3_MLIR)" %s | FileCheck %s
+
+module {
+  // CHECK: func.func private @trace_loop_iter_end()
+  // CHECK-NEXT: func.func private @trace_loop_iter_begin()
+  // CHECK-LABEL: func.func @kern()
+  func.func @kern() {
+    // CHECK: affine.for %arg0 = 0 to 4 {
+    // CHECK-NEXT:   func.call @trace_loop_iter_begin() : () -> ()
+    // CHECK-DAG:   %cst = arith.constant 0.000000e+00 : f32
+    // CHECK-DAG:   %cst_0 = arith.constant 1.000000e+00 : f32
+    // CHECK-NEXT:   %0 = arith.addf %cst, %cst_0 : f32
+    // CHECK-NEXT:   func.call @trace_loop_iter_end() : () -> ()
+    affine.for %i = 0 to 4 {
+      %c0 = arith.constant 0.0 : f32
+      %c1 = arith.constant 1.0 : f32
+      %add = arith.addf %c0, %c1 : f32
+      affine.yield
+    }
+    return
+  }
+  // CHECK-LABEL: func.func @work()
+  func.func @work() {
+    // CHECK-DAG: %c0_i32 = arith.constant 0 : i32
+    // CHECK-DAG: %c0 = arith.constant 0 : index
+    // CHECK-NEXT: scf.for %arg0 = %c0 to %c0 step %c0 {
+    // CHECK-NEXT:   func.call @trace_loop_iter_begin() : () -> ()
+    // CHECK-DAG:   %c1_i32 = arith.constant 1 : i32
+    // CHECK-NEXT:   func.call @trace_loop_iter_end() : () -> ()
+    %0 = arith.constant 0 : i32
+    %c0 = arith.constant 0 : index
+    scf.for %i = %c0 to %c0 step %c0 {
+      %one = arith.constant 1 : i32
+      scf.yield
+    }
+    return
+  }
+  // CHECK-LABEL: func.func @while_example(%arg0: index)
+  func.func @while_example(%arg0: index) {
+    // CHECK-DAG: %c1 = arith.constant 1 : index
+    // CHECK-NEXT: %0 = scf.while (%arg1 = %arg0) : (index) -> index {
+    // CHECK-DAG:   %c4 = arith.constant 4 : index
+    // CHECK-NEXT:   %1 = arith.cmpi slt, %arg1, %c4 : index
+    // CHECK-NEXT:   scf.condition(%1) %arg1 : index
+    // CHECK-NEXT: } do {
+    // CHECK-NEXT: ^bb0(%arg1: index):
+    // CHECK-NEXT:   func.call @trace_loop_iter_begin() : () -> ()
+    // CHECK-DAG:   %c7_i32 = arith.constant 7 : i32
+    // CHECK-NEXT:   %1 = arith.addi %arg1, %c1 : index
+    // CHECK-NEXT:   func.call @trace_loop_iter_end() : () -> ()
+    // CHECK-NEXT:   scf.yield %1 : index
+    // CHECK-NEXT: }
+    %one   = arith.constant 1 : index
+    %res = scf.while (%i = %arg0) : (index) -> (index) {
+      %limit = arith.constant 4 : index
+      %cond  = arith.cmpi slt, %i, %limit : index
+      scf.condition(%cond) %i : index
+    } do {
+      ^bb0(%i_curr: index):
+        %v   = arith.constant 7 : i32 
+        %inc = arith.addi %i_curr, %one : index
+        scf.yield %inc : index 
+    }
+    return
+  }
+}


### PR DESCRIPTION
Этот MLIR-пасс вставляет вызовы функций `@trace_loop_iter_begin` и `@trace_loop_iter_end` в начало и конец циклов. Пасс поддерживает циклы `affine.for`, `scf.for` и `scf.while`. Если функции трассировки не объявлены в коде, пасс автоматически создаст их.