### PR TITLE
 Будажапова Екатерина. Лабораторная работа номер 1. Clang AST. Вариант 2

### DIFF
--- a/clang/compiler-course/budazhapova_e_unused_var_par/CMakeLists.txt
+++ b/clang/compiler-course/budazhapova_e_unused_var_par/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "UnusedVP")
+set(Student "Budazhapova_Ekaterina")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/budazhapova_e_unused_var_par/budazhapova_lab1.cpp
+++ b/clang/compiler-course/budazhapova_e_unused_var_par/budazhapova_lab1.cpp
@@ -9,77 +9,80 @@
 using namespace clang;
 
 namespace {
-    class UnusedVarVisitor : public RecursiveASTVisitor<UnusedVarVisitor> {
-    public:
-        explicit UnusedVarVisitor(Rewriter& rw) : rewriter(rw) {}
+class UnusedVarVisitor : public RecursiveASTVisitor<UnusedVarVisitor> {
+public:
+  explicit UnusedVarVisitor(Rewriter &rw) : rewriter(rw) {}
 
-        bool VisitVarDecl(VarDecl* vd) {
-            if (isa<ParmVarDecl>(vd)) {
-                return true;
-            }
-            if (!vd->isUsed()) {
-                rewriter.InsertText(vd->getBeginLoc(), "[[maybe_unused]] ", true, true);
-            }
-            return true;
-        }
+  bool VisitVarDecl(VarDecl *vd) {
+    if (isa<ParmVarDecl>(vd)) {
+      return true;
+    }
+    if (!vd->isUsed()) {
+      rewriter.InsertText(vd->getBeginLoc(), "[[maybe_unused]] ", true, true);
+    }
+    return true;
+  }
 
-        bool VisitParmVarDecl(ParmVarDecl* pvd) {
-            if (!pvd->isUsed()) {
-                rewriter.InsertText(pvd->getBeginLoc(), "[[maybe_unused]] ", true, true);
-            }
-            return true;
-        }
+  bool VisitParmVarDecl(ParmVarDecl *pvd) {
+    if (!pvd->isUsed()) {
+      rewriter.InsertText(pvd->getBeginLoc(), "[[maybe_unused]] ", true, true);
+    }
+    return true;
+  }
 
-    private:
-        Rewriter& rewriter;
-    };
+private:
+  Rewriter &rewriter;
+};
 
-    class UnusedVPConsumer : public ASTConsumer {
-    public:
-        explicit UnusedVPConsumer(Rewriter& rw) : visitor(rw) {}
+class UnusedVPConsumer : public ASTConsumer {
+public:
+  explicit UnusedVPConsumer(Rewriter &rw) : visitor(rw) {}
 
-        void HandleTranslationUnit(ASTContext& ctx) override {
-            visitor.TraverseDecl(ctx.getTranslationUnitDecl());
-        }
+  void HandleTranslationUnit(ASTContext &ctx) override {
+    visitor.TraverseDecl(ctx.getTranslationUnitDecl());
+  }
 
-    private:
-        UnusedVarVisitor visitor;
-    };
+private:
+  UnusedVarVisitor visitor;
+};
 
-    class UnusedVarPlugin : public PluginASTAction {
-    public:
-        std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance& ci,
-            llvm::StringRef) override {
-            rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
-            return std::make_unique<UnusedVPConsumer>(rewriter);
-        }
+class UnusedVarPlugin : public PluginASTAction {
+public:
+  std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &ci,
+                                                 llvm::StringRef) override {
+    rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
+    return std::make_unique<UnusedVPConsumer>(rewriter);
+  }
 
-        bool ParseArgs(const CompilerInstance&, const std::vector<std::string>&) override {
-            return true;
-        }
+  bool ParseArgs(const CompilerInstance &,
+                 const std::vector<std::string> &) override {
+    return true;
+  }
 
-        void EndSourceFileAction() override {
-            auto& buffer = rewriter.getEditBuffer(rewriter.getSourceMgr().getMainFileID());
-            std::string code;
-            llvm::raw_string_ostream stream(code);
-            buffer.write(stream);
+  void EndSourceFileAction() override {
+    auto &buffer =
+        rewriter.getEditBuffer(rewriter.getSourceMgr().getMainFileID());
+    std::string code;
+    llvm::raw_string_ostream stream(code);
+    buffer.write(stream);
 
-            std::stringstream ss(code);
-            std::string line;
-            std::string result;
-            while (std::getline(ss, line)) {
-                if (line.find("// RUN:") == 0 || line.find("// CHECK:") == 0) {
-                    continue;
-                }
-                result += line + "\n";
-            }
-            llvm::outs() << result;
-        }
+    std::stringstream ss(code);
+    std::string line;
+    std::string result;
+    while (std::getline(ss, line)) {
+      if (line.find("// RUN:") == 0 || line.find("// CHECK:") == 0) {
+        continue;
+      }
+      result += line + "\n";
+    }
+    llvm::outs() << result;
+  }
 
-    private:
-        Rewriter rewriter;
-    };
+private:
+  Rewriter rewriter;
+};
 } // namespace
 
 static FrontendPluginRegistry::Add<UnusedVarPlugin>
-X("unused_var_plugin", "Add [[maybe_unused]] to unused variables and parameters");
+    X("unused_var_plugin",
+      "Add [[maybe_unused]] to unused variables and parameters");

--- a/clang/compiler-course/budazhapova_e_unused_var_par/budazhapova_lab1.cpp
+++ b/clang/compiler-course/budazhapova_e_unused_var_par/budazhapova_lab1.cpp
@@ -1,0 +1,85 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "llvm/Support/raw_ostream.h"
+#include <sstream>
+
+using namespace clang;
+
+namespace {
+    class UnusedVarVisitor : public RecursiveASTVisitor<UnusedVarVisitor> {
+    public:
+        explicit UnusedVarVisitor(Rewriter& rw) : rewriter(rw) {}
+
+        bool VisitVarDecl(VarDecl* vd) {
+            if (isa<ParmVarDecl>(vd)) {
+                return true;
+            }
+            if (!vd->isUsed()) {
+                rewriter.InsertText(vd->getBeginLoc(), "[[maybe_unused]] ", true, true);
+            }
+            return true;
+        }
+
+        bool VisitParmVarDecl(ParmVarDecl* pvd) {
+            if (!pvd->isUsed()) {
+                rewriter.InsertText(pvd->getBeginLoc(), "[[maybe_unused]] ", true, true);
+            }
+            return true;
+        }
+
+    private:
+        Rewriter& rewriter;
+    };
+
+    class UnusedVPConsumer : public ASTConsumer {
+    public:
+        explicit UnusedVPConsumer(Rewriter& rw) : visitor(rw) {}
+
+        void HandleTranslationUnit(ASTContext& ctx) override {
+            visitor.TraverseDecl(ctx.getTranslationUnitDecl());
+        }
+
+    private:
+        UnusedVarVisitor visitor;
+    };
+
+    class UnusedVarPlugin : public PluginASTAction {
+    public:
+        std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance& ci,
+            llvm::StringRef) override {
+            rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
+            return std::make_unique<UnusedVPConsumer>(rewriter);
+        }
+
+        bool ParseArgs(const CompilerInstance&, const std::vector<std::string>&) override {
+            return true;
+        }
+
+        void EndSourceFileAction() override {
+            auto& buffer = rewriter.getEditBuffer(rewriter.getSourceMgr().getMainFileID());
+            std::string code;
+            llvm::raw_string_ostream stream(code);
+            buffer.write(stream);
+
+            std::stringstream ss(code);
+            std::string line;
+            std::string result;
+            while (std::getline(ss, line)) {
+                if (line.find("// RUN:") == 0 || line.find("// CHECK:") == 0) {
+                    continue;
+                }
+                result += line + "\n";
+            }
+            llvm::outs() << result;
+        }
+
+    private:
+        Rewriter rewriter;
+    };
+} // namespace
+
+static FrontendPluginRegistry::Add<UnusedVarPlugin>
+X("unused_var_plugin", "Add [[maybe_unused]] to unused variables and parameters");

--- a/clang/test/compiler-course/budazhapova_e_unused_var_par_test/budazhapova_lab1_tests.cpp
+++ b/clang/test/compiler-course/budazhapova_e_unused_var_par_test/budazhapova_lab1_tests.cpp
@@ -1,0 +1,52 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/UnusedVP_Budazhapova_Ekaterina_FIIT3_ClangAST%pluginext -plugin unused_var_plugin -fsyntax-only %s 2>&1 | FileCheck %s
+
+// CHECK: int x = 10;
+// CHECK-NEXT: {{\[\[maybe_unused\]\]}} int y = 20;
+int x = 10;
+int y = 20;
+
+// CHECK: int sum(int a, int b, {{\[\[maybe_unused\]\]}} int c) {
+// CHECK-NEXT: int result = a + b;
+// CHECK-NEXT: {{\[\[maybe_unused\]\]}} int temp = a * b;
+// CHECK-NEXT: return result;
+int sum(int a, int b, int c) {
+    int result = a + b;
+    int temp = a * b;
+    return result;
+}
+
+// CHECK: int mul(int p, int q) {
+// CHECK-NEXT: return p * q;
+int mul(int p, int q) {
+    return p * q;
+}
+
+// CHECK: void init() {
+// CHECK-NEXT: {{\[\[maybe_unused\]\]}} int count = 0;
+// CHECK-NEXT: {{\[\[maybe_unused\]\]}} float pi = 3.14;
+void init() {
+    int count = 0;
+    float pi = 3.14;
+}
+
+// CHECK: double calc({{\[\[maybe_unused\]\]}} char ch, double d) {
+// CHECK-NEXT: {{\[\[maybe_unused\]\]}} int unused = 5;
+// CHECK-NEXT: return d * x;
+double calc(char ch, double d) {
+    int unused = 5;
+    return d * x;
+}
+
+// CHECK: int main() {
+// CHECK-NEXT: sum(1, 2, 3);
+// CHECK-NEXT: mul(4, 5);
+// CHECK-NEXT: init();
+// CHECK-NEXT: calc('A', 2.5);
+// CHECK-NEXT: return x;
+int main() {
+    sum(1, 2, 3);
+    mul(4, 5);
+    init();
+    calc('A', 2.5);
+    return x;
+}


### PR DESCRIPTION
Этот плагин находит неиспользуемые переменные в коде и добавляет к ним [[maybe_unused]]
Описание работы плагина:
1. Обход AST - Рекурсивно проходит по всему дереву разбора кода, посещая каждое объявление переменной
2. Проверка использования - Для каждой найденной переменной проверяет, используется ли она где-то в коде
3. Добавление атрибута - Если переменная не используется, вставляет перед ней [[maybe_unused]]
4. Фильтрация вывода - В конце убирает служебные комментарии тестов и выдает чистый исправленный код