### PR TITLE
Поляков Алексей. Лабораторная работа 4. MLIR. Вариант 5. 

### DIFF
--- a/mlir/compiler-course/polyakov_a_lab4/CMakeLists.txt
+++ b/mlir/compiler-course/polyakov_a_lab4/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(Title "ReplaceMathCeil")
+set(Student "Polyakov_Alexey")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_MLIR")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    MLIRBuiltinLocationAttributesIncGen
+    BUILDTREE_ONLY
+)
+
+set(MLIR_TEST_DEPENDS ${TARGET_NAME} ${MLIR_TEST_DEPENDS} PARENT_SCOPE)

--- a/mlir/compiler-course/polyakov_a_lab4/polyakov_a_lab4.cpp
+++ b/mlir/compiler-course/polyakov_a_lab4/polyakov_a_lab4.cpp
@@ -26,15 +26,14 @@ struct CeilToNegFloorPattern : public OpRewritePattern<math::CeilOp> {
   }
 };
 
-class ReplaceMathCeil : public PassWrapper<ReplaceMathCeil, OperationPass<ModuleOp>> {
+class ReplaceMathCeil
+    : public PassWrapper<ReplaceMathCeil, OperationPass<ModuleOp>> {
 public:
   StringRef getArgument() const final {
     return "ReplaceMathCeil_Polyakov_Alexey_FIIT2_MLIR";
   }
 
-  StringRef getDescription() const final {
-    return "Replace math.ceil";
-  }
+  StringRef getDescription() const final { return "Replace math.ceil"; }
 
   void runOnOperation() override {
     ModuleOp module = getOperation();

--- a/mlir/compiler-course/polyakov_a_lab4/polyakov_a_lab4.cpp
+++ b/mlir/compiler-course/polyakov_a_lab4/polyakov_a_lab4.cpp
@@ -1,0 +1,64 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Tools/Plugins/PassPlugin.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir;
+
+namespace {
+struct CeilToNegFloorPattern : public OpRewritePattern<math::CeilOp> {
+  using OpRewritePattern<math::CeilOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(math::CeilOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Value input = op.getOperand();
+
+    Value neg = rewriter.create<arith::NegFOp>(loc, input);
+    Value floor = rewriter.create<math::FloorOp>(loc, neg);
+    Value result = rewriter.create<arith::NegFOp>(loc, floor);
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+class ReplaceMathCeil : public PassWrapper<ReplaceMathCeil, OperationPass<ModuleOp>> {
+public:
+  StringRef getArgument() const final {
+    return "ReplaceMathCeil_Polyakov_Alexey_FIIT2_MLIR";
+  }
+
+  StringRef getDescription() const final {
+    return "Replace math.ceil";
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    MLIRContext *ctx = module.getContext();
+
+    RewritePatternSet patterns(ctx);
+    patterns.add<CeilToNegFloorPattern>(ctx);
+    if (failed(applyPatternsAndFoldGreedily(module, std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+MLIR_DECLARE_EXPLICIT_TYPE_ID(ReplaceMathCeil)
+MLIR_DEFINE_EXPLICIT_TYPE_ID(ReplaceMathCeil)
+
+mlir::PassPluginLibraryInfo getReplaceMathCeilPluginInfo() {
+  return {MLIR_PLUGIN_API_VERSION, "ReplaceMathCeil", "1.0",
+          []() { PassRegistration<ReplaceMathCeil>(); }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo
+mlirGetPassPluginInfo() {
+  return getReplaceMathCeilPluginInfo();
+}

--- a/mlir/test/compiler-course/polyakov_a_lab4/polyakov_a_lab4_test.mlir
+++ b/mlir/test/compiler-course/polyakov_a_lab4/polyakov_a_lab4_test.mlir
@@ -1,0 +1,69 @@
+// RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/ReplaceMathCeil_Polyakov_Alexey_FIIT2_MLIR%shlibext \
+// RUN: --pass-pipeline="builtin.module(ReplaceMathCeil_Polyakov_Alexey_FIIT2_MLIR)" %s | FileCheck %s
+
+module {
+  // Test 1: Ceil on a single f32 scalar
+  // CHECK-LABEL: func.func @ceil_scalar_f32
+  // CHECK-NEXT:   %[[NEG:.*]] = arith.negf %arg0 : f32
+  // CHECK-NEXT:   %[[FLOOR:.*]] = math.floor %[[NEG]] : f32
+  // CHECK-NEXT:   %[[RES:.*]] = arith.negf %[[FLOOR]] : f32
+  // CHECK-NEXT:   return %[[RES]] : f32
+  func.func @ceil_scalar_f32(%arg0: f32) -> f32 {
+    %0 = math.ceil %arg0 : f32
+    return %0 : f32
+  }
+
+  // Test 2: Two independent ceil operations on f32 scalars
+  // CHECK-LABEL: func.func @ceil_multiple_scalars
+  // CHECK:       %[[NEG1:.*]] = arith.negf %arg0 : f32
+  // CHECK-NEXT:  %[[FLOOR1:.*]] = math.floor %[[NEG1]] : f32
+  // CHECK-NEXT:  %[[RES1:.*]] = arith.negf %[[FLOOR1]] : f32
+  // CHECK-NEXT:  %[[NEG2:.*]] = arith.negf %arg1 : f32
+  // CHECK-NEXT:  %[[FLOOR2:.*]] = math.floor %[[NEG2]] : f32
+  // CHECK-NEXT:  %[[RES2:.*]] = arith.negf %[[FLOOR2]] : f32
+  // CHECK-NEXT:  %[[SUM:.*]] = arith.addf %[[RES1]], %[[RES2]] : f32
+  // CHECK-NEXT:  return %[[SUM]] : f32
+  func.func @ceil_multiple_scalars(%arg0: f32, %arg1: f32) -> f32 {
+    %a = math.ceil %arg0 : f32
+    %b = math.ceil %arg1 : f32
+    %c = arith.addf %a, %b : f32
+    return %c : f32
+  }
+
+  // Test 3: Ceil inside an scf.if region
+  // CHECK-LABEL: func.func @ceil_in_scf_if
+  // CHECK:       %[[NEG:.*]] = arith.negf %arg0 : f32
+  // CHECK-NEXT:  %[[FLOOR:.*]] = math.floor %[[NEG]] : f32
+  // CHECK-NEXT:  %[[RES:.*]] = arith.negf %[[FLOOR]] : f32
+  func.func @ceil_in_scf_if(%arg0: f32, %cond: i1) -> f32 {
+    %res = scf.if %cond -> (f32) {
+      %tmp = math.ceil %arg0 : f32
+      scf.yield %tmp : f32
+    } else {
+      scf.yield %arg0 : f32
+    }
+    return %res : f32
+  }
+
+  // Test 4: Ceil on a 4-element f32 vector
+  // CHECK-LABEL: func.func @ceil_vector_4xf32
+  // CHECK-NEXT:   %[[NEG:.*]] = arith.negf %arg0 : vector<4xf32>
+  // CHECK-NEXT:   %[[FLOOR:.*]] = math.floor %[[NEG]] : vector<4xf32>
+  // CHECK-NEXT:   %[[RES:.*]] = arith.negf %[[FLOOR]] : vector<4xf32>
+  // CHECK-NEXT:   return %[[RES]] : vector<4xf32>
+  func.func @ceil_vector_4xf32(%arg0: vector<4xf32>) -> vector<4xf32> {
+    %0 = math.ceil %arg0 : vector<4xf32>
+    return %0 : vector<4xf32>
+  }
+
+  // Test 5: Ceil on an f64 scalar
+  // CHECK-LABEL: func.func @ceil_scalar_f64
+  // CHECK-NEXT:   %[[NEG:.*]] = arith.negf %arg0 : f64
+  // CHECK-NEXT:   %[[FLOOR:.*]] = math.floor %[[NEG]] : f64
+  // CHECK-NEXT:   %[[RES:.*]] = arith.negf %[[FLOOR]] : f64
+  // CHECK-NEXT:   return %[[RES]] : f64
+  func.func @ceil_scalar_f64(%arg0: f64) -> f64 {
+    %0 = math.ceil %arg0 : f64
+    return %0 : f64
+  }
+}


### PR DESCRIPTION
Пасс, который заменяет операцию math.ceil в соответствии с этой формулой: ceil(x) = -floor(-x).